### PR TITLE
improve UX by running build stage before image one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,8 @@ test: ## Run tests
 	@echo -e "\033[32mTesting...\033[0m"
 	$(DOCKER_CMD) go test ./...
 
-.PHONY: images
-image: ## Build docker image
+.PHONY: image
+image: build ## Build docker image
 	@echo -e "\033[32mBuilding image $(IMAGE):$(VERSION)...\033[0m"
 	docker build -t "$(IMAGE):$(VERSION)" -f ./cmd/Dockerfile ./
 	@echo -e "\033[32mTagging image as $(IMAGE):$(MUTABLE_TAG)...\033[0m"


### PR DESCRIPTION
Minor Makefile improvement.

To push images to some repository (example assuems usage of quay) is is needed to run:
```
export REGISTRY=quay.io/openshift/
make image
make push
```

Before it was needed to run additional stage of `make build`

CC: @trawler 