### PR TITLE
rolebinding namespace kube-system -> default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+bin

--- a/manifests/clusterapi-apiserver-role-binding.yaml
+++ b/manifests/clusterapi-apiserver-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clusterapi
-  namespace: kube-system
+  namespace: default
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
this commit changes the role-binding namespace to default until a suitable namespace is decided upon.

+ fix .gitignore