### PR TITLE
Add manifests folder to docker image

### DIFF
--- a/cmd/Dockerfile
+++ b/cmd/Dockerfile
@@ -13,3 +13,4 @@ FROM debian:stretch-slim
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/manifests manifests

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,9 +45,5 @@ func main() {
 // rendererFromFile reads the config object on demand from the path and then passes it to the
 // renderer.
 func rendererFromFile() []xotypes.UpgradeSpec {
-	config, err := render.Config(configPath)
-	if err != nil {
-		glog.Exitf("Error reading machine-api config: %v", err)
-	}
-	return render.MakeRenderer(config, manifestDir)()
+  return render.MakeRenderer(&render.OperatorConfig{}, manifestDir)()
 }


### PR DESCRIPTION
this commit also removes cluster-config from the binary
since it's not required at the moment.