### PR TITLE
ease disabling docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ IMAGE        = $(REGISTRY)machine-api-operator
 .PHONY: all
 all: check build test
 
-ifndef NO_DOCKER
+NO_DOCKER ?= 0
+ifeq ($(NO_DOCKER), 1)
+  DOCKER_CMD =
+else
   DOCKER_CMD := docker run --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-operator:Z -w /go/src/github.com/openshift/machine-api-operator golang:1.10
 endif
 


### PR DESCRIPTION
This allows to easily disable dockerized build env by setting `NO_DOCKER` env variable to anything.

This is also needed for CI system.

Example run:
```sh
make build              # build in docker container (golang:1.10)
NO_DOCKER=1 make build  # build using host env
```