### PR TITLE
[image] Change apt-get to yum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' cmd/
 
 # Final container
 FROM debian:stretch-slim
-RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN yum update && yum install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/manifests manifests


### PR DESCRIPTION
The CI complains about it:

```
  | 2018/08/24 16:08:08 Resolved source https://github.com/openshift/machine-api-operator to master@5f0a0197, merging: #28 890dc508 @ingvagabund
-- | --
  | 2018/08/24 16:08:08 Resolving inputs for the test
  | 2018/08/24 16:08:08 Resolved openshift/release:golang-1.10 to sha256:23c49017c40e1b7c910e3fcf6370ffb31faf5c376402681cbe7379ec949cd5be
  | 2018/08/24 16:08:08 Resolved openshift/origin-v3.11:base to sha256:55347ca0fd3cc0fda323e083c24dba7fa55558ca29a68bd3dc5b49b4dda617c1
  | 2018/08/24 16:08:08 Resolved inputs, targetting namespace ci-op-mgn0nsh3
  | 2018/08/24 16:08:08 Running [input:root], [input:base], [release-inputs], src, machine-api-operator, [output:stable:machine-api-operator], [images], unit
  | 2018/08/24 16:08:08 Creating namespace ci-op-mgn0nsh3
  | 2018/08/24 16:08:09 Setting a soft TTL of 1h0m0s for the namespace
  | 2018/08/24 16:08:09 Setting a hard TTL of 12h0m0s for the namespace
  | 2018/08/24 16:08:09 Setting up pipeline imagestream for the test
  | 2018/08/24 16:08:09 Populating secrets for test
  | 2018/08/24 16:08:09 Tagging openshift/release:golang-1.10 into pipeline:root
  | 2018/08/24 16:08:09 Tagging openshift/origin-v3.11:base into pipeline:base
  | 2018/08/24 16:08:09 Tagged release images from openshift/origin-v3.11:${component}, images will be pullable from registry.svc.ci.openshift.org/ci-op-mgn0nsh3/stable:${component}
  | 2018/08/24 16:08:10 Building src
  | 2018/08/24 16:08:32 Build src succeeded after 21s
  | 2018/08/24 16:08:32 Executing test unit
  | 2018/08/24 16:08:32 Building machine-api-operator
  | 2018/08/24 16:10:04 Build machine-api-operator failed, printing logs:
  | Pulling image "docker-registry.default.svc:5000/ci-op-mgn0nsh3/pipeline@sha256:bfbf1128b31276baacfba4dfcae46536c0c141b189adbb0d4df080906ea792a2" ...
  |  
  | Pulling image docker-registry.default.svc:5000/ci-op-mgn0nsh3/pipeline@sha256:55347ca0fd3cc0fda323e083c24dba7fa55558ca29a68bd3dc5b49b4dda617c1 ...
  |  
  | Pulling image golang:1.10.0 ...
  | Pulled 1/7 layers, 19% complete
  | Pulled 2/7 layers, 29% complete
  | Pulled 3/7 layers, 47% complete
  | Pulled 4/7 layers, 65% complete
  | Pulled 5/7 layers, 74% complete
  | Pulled 6/7 layers, 88% complete
  | Pulled 7/7 layers, 100% complete
  | Extracting
  | --> FROM golang:1.10.0 as builder
  | --> WORKDIR /go/src/github.com/openshift/machine-api-operator
  | --> COPY . .
  | --> RUN CGO_ENABLED=0 GOOS=linux go install -a -ldflags '-extldflags "-static"' cmd/
  | --> FROM docker-registry.default.svc:5000/ci-op-mgn0nsh3/pipeline@sha256:55347ca0fd3cc0fda323e083c24dba7fa55558ca29a68bd3dc5b49b4dda617c1 as 1
  | --> RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
  | /bin/sh: apt-get: command not found
  | error: build error: running 'apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*' failed with exit code 127
  | 2018/08/24 16:11:24 Container test in pod unit completed successfully
  | 2018/08/24 16:11:24 Pod unit succeeded after 2m51s
  | 2018/08/24 16:11:24 Ran for 3m16s
  | error: could not run steps: could not wait for build: the build machine-api-operator failed after 1m35s with reason DockerBuildFailed: Docker build strategy has failed.
  |  
```

And the CI has higher priority!!!