### PR TITLE
add support for openshift actuator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -131,14 +131,14 @@ func deployMachineSet() {
 
 	for {
 		glog.Info("Trying to deploy Cluster object")
-		if _, err := v1alphaClient.Clusters("test").Create(cluster); err != nil {
+		if _, err := v1alphaClient.Clusters("default").Create(cluster); err != nil {
 			glog.Infof("Cannot create cluster, retrying in 5 secs: %v", err)
 		} else {
 			glog.Info("Created Cluster object")
 		}
 
 		glog.Info("Trying to deploy MachineSet object")
-		_, err = v1alphaClient.MachineSets("test").Create(machineSet)
+		_, err = v1alphaClient.MachineSets("default").Create(machineSet)
 		if err != nil {
 			glog.Infof("Cannot create MachineSet, retrying in 5 secs: %v", err)
 		} else {

--- a/machines/cluster.yaml
+++ b/machines/cluster.yaml
@@ -1,39 +1,15 @@
+---
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
 metadata:
-  name: test
-  namespace: test
+  name: {{.ClusterName}}
+  namespace: default
 spec:
   clusterNetwork:
     services:
       cidrBlocks:
-        - "10.0.0.1/24"
+      - "10.0.0.1/24"
     pods:
       cidrBlocks:
-        - "10.0.0.2/24"
-    serviceDomain: example.com
-  providerConfig:
-    value:
-      apiVersion: awsproviderconfig/v1alpha1
-      kind: AWSClusterProviderConfig
-      clusterId: {{.VpcName}}
-      clusterVersionRef:
-        namespace: test
-        name: test
-      hardware:
-        aws:
-          region: {{.Region}}
-          keyPairName: {{.SshKey}}
-      defaultHardwareSpec:
-        aws:
-          instanceType: m4.large
-      machineSets:
-      - nodeType: Master
-        size: 1
-      - shortName: infra
-        nodeType: Compute
-        infra: true
-        size: 1
-      - shortName: compute
-        nodeType: Compute
-        size: 1
+      - "10.0.0.2/24"
+    serviceDomain: unused

--- a/machines/machine-set.yaml
+++ b/machines/machine-set.yaml
@@ -1,40 +1,56 @@
+---
 apiVersion: cluster.k8s.io/v1alpha1
 kind: MachineSet
 metadata:
   name: worker
-  namespace: test
+  namespace: default
   labels:
-    machineapioperator.openshift.io/cluster: test
+    sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
+    sigs.k8s.io/cluster-api-machine-role: worker
+    sigs.k8s.io/cluster-api-machine-type: worker
 spec:
-  replicas: 3
+  replicas: {{.Replicas}}
   selector:
     matchLabels:
-      machineapioperator.openshift.io/machineset: worker
-      machineapioperator.openshift.io/cluster: test
+      sigs.k8s.io/cluster-api-machineset: worker
+      sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
   template:
     metadata:
       labels:
-        machineapioperator.openshift.io/machineset: worker
-        machineapioperator.openshift.io/cluster: test
+        sigs.k8s.io/cluster-api-machineset: worker
+        sigs.k8s.io/cluster-api-cluster: {{.ClusterName}}
+        sigs.k8s.io/cluster-api-machine-role: worker
+        sigs.k8s.io/cluster-api-machine-type: worker
     spec:
       providerConfig:
         value:
-          apiVersion: awsproviderconfig/v1alpha1
+          apiVersion: aws.cluster.k8s.io/v1alpha1
           kind: AWSMachineProviderConfig
-          clusterId: {{.VpcName}}
-          clusterHardware:
-            aws:
-              keyPairName: {{.SshKey}}
-              region: {{.Region}}
-          hardware:
-            aws:
-              instanceType: m4.large
-          infra: false
-          vmImage:
-            awsImage: {{.Image}}
+          ami:
+            id: {{.Image}}
+          instanceType: m4.large
+          placement:
+            region: {{.Region}}
+            availabilityZone: {{.AvailabilityZone}}
+          subnet:
+            filters:
+            - name: "tag:Name"
+              values:
+              - {{.ClusterName}}-worker-{{.AvailabilityZone}}
+          publicIp: true
+          iamInstanceProfile:
+            id: {{.ClusterName}}-master-profile
+          keyName: tectonic
+          tags:
+            - name: tectonicClusterID
+              value: {{.ClusterID}}
+          securityGroups:
+            - filters:
+              - name: "tag:Name"
+                values:
+                - {{.ClusterName}}_worker_sg
+          userDataSecret:
+            name: ignition-worker
       versions:
-        kubelet: 0.0.0
-        controlPlane: 0.0.0
-      roles:
-      - Master
-
+        kubelet: ""
+        controlPlane: ""

--- a/manifests/clusterapi-controller.yaml
+++ b/manifests/clusterapi-controller.yaml
@@ -45,14 +45,14 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: aws-machine-controller
-        image: quay.io/alberto_lamela/aws-machine-controller:mvp # TODO: move this to openshift org
+        image: quay.io/alberto_lamela/aws-machine-controller:dev # TODO: move this to openshift org
         env:
           - name: NODE_NAME
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
         command:
-          - /opt/services/aws-machine-controller
+          - /machine-controller
         args:
           - --log-level=debug
         resources:

--- a/pkg/render/config.go
+++ b/pkg/render/config.go
@@ -11,11 +11,11 @@ const (
 
 // OperatorConfig contains configuration for KAO managed add-ons
 type OperatorConfig struct {
-	metav1.TypeMeta `json:",inline"`
-	VpcName         string `json:"vpcName"`
-	SshKey          string `json:"sshKey"`
-	ClusterName     string `json:"clusterName"`
-	ClusterDomain   string `json:"clusterDomain"`
-	Region          string `json:"region"`
-	Image           string `json:"image"`
+	metav1.TypeMeta  `json:",inline"`
+	ClusterName      string `json:"clusterName"`
+	ClusterID        string `json:"clusterID"`
+	Region           string `json:"region"`
+	AvailabilityZone string `json:"availabilityZone"`
+	Image            string `json:"image"`
+	Replicas         string `json:"replicas"`
 }

--- a/pkg/render/machine-api-operator-config.yaml
+++ b/pkg/render/machine-api-operator-config.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: machineAPIOperatorConfig
-vpcName: "test"
-sshKey: "test"
-clusterName: "test"
-clusterDomain: "test"
+clusterName: meh
+clusterID: b302cf66-f5ff-4d5d-1cc1-0ab2755d2065
+image: ami-0e502f54daeb8686e
+region: eu-west-1
+availabilityZone: eu-west-1a
+replicas: 1


### PR DESCRIPTION
This allows to integrate the openshift actuator with mao and the installer:
- https://github.com/enxebre/installer/blob/mao/modules/bootkube/resources/manifests/mao-config.yaml#L3
- https://github.com/openshift/cluster-api-provider-aws/pull/35