### PR TITLE
remove harcoded ssh key

### DIFF
--- a/machines/aws/machine-set.yaml
+++ b/machines/aws/machine-set.yaml
@@ -40,7 +40,6 @@ spec:
           publicIp: true
           iamInstanceProfile:
             id: {{.AWS.ClusterName}}-master-profile
-          keyName: tectonic
           tags:
             - name: tectonicClusterID
               value: {{.AWS.ClusterID}}

--- a/machines/libvirt/machine-set.yaml
+++ b/machines/libvirt/machine-set.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         sigs.k8s.io/cluster-api-machineset: worker
         sigs.k8s.io/cluster-api-cluster: {{.Libvirt.ClusterName}}
-        sigs.k8s.io/cluster-api-machine-role: infra
+        sigs.k8s.io/cluster-api-machine-role: worker
         sigs.k8s.io/cluster-api-machine-type: worker
     spec:
       providerConfig:

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -121,7 +121,6 @@ spec:
           publicIp: true
           iamInstanceProfile:
             id: TestClusterManifest-ClusterName-master-profile
-          keyName: tectonic
           tags:
             - name: tectonicClusterID
               value: TestClusterManifest-ClusterID


### PR DESCRIPTION
Removed carried over harcoded key.This is making the installer PR tests fail https://gcsweb-ci.svc.ci.openshift.org/gcs/origin-ci-test/pr-logs/pull/openshift_installer/119/pull-ci-origin-installer-e2e-aws/786/artifacts/e2e-aws/pods/