### PR TITLE
Fix namespace when creating Cluster and MachineSet

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -184,14 +184,14 @@ func deployMachineSet() {
 
 	for {
 		glog.Info("Trying to deploy Cluster object")
-		if _, err := v1alphaClient.Clusters("default").Create(cluster); err != nil {
+		if _, err := v1alphaClient.Clusters(operatorConfig.TargetNamespace).Create(cluster); err != nil {
 			glog.Infof("Cannot create cluster, retrying in 5 secs: %v", err)
 		} else {
 			glog.Info("Created Cluster object")
 		}
 
 		glog.Info("Trying to deploy MachineSet object")
-		_, err = v1alphaClient.MachineSets("default").Create(machineSet)
+		_, err = v1alphaClient.MachineSets(operatorConfig.TargetNamespace).Create(machineSet)
 		if err != nil {
 			glog.Infof("Cannot create MachineSet, retrying in 5 secs: %v", err)
 		} else {

--- a/examples/clusterapi-apiserver-certs.yaml
+++ b/examples/clusterapi-apiserver-certs.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
 metadata:
-  name: cluster-apiserver-secrets
+  name: cluster-apiserver-certs
   namespace: default
   labels:
     api: clusterapi

--- a/manifests/clusterapi-apiserver.yaml
+++ b/manifests/clusterapi-apiserver.yaml
@@ -110,5 +110,5 @@ spec:
         emptyDir: {}
       - name: cluster-apiserver-certs
         secret:
-          secretName: cluster-apiserver-secrets
+          secretName: cluster-apiserver-certs
 # TODO: add readiness and liveness probe


### PR DESCRIPTION
This fixes the namespace on the request when creating the Cluster and
MachineSet objects to match the target namespace.  It also changes the
name of secret containing the TLS assets to match what the installer
is using.