### PR TITLE
Fix typo in libvirt cluster template

### DIFF
--- a/machines/libvirt/cluster.yaml
+++ b/machines/libvirt/cluster.yaml
@@ -2,8 +2,8 @@
 apiVersion: "cluster.k8s.io/v1alpha1"
 kind: Cluster
 metadata:
-  name: {{.Libvirt.ClusterName}}
-  namespace: {{ . TargetNamespace }}
+  name: {{ .Libvirt.ClusterName }}
+  namespace: {{ .TargetNamespace }}
 spec:
   clusterNetwork:
     services:


### PR DESCRIPTION
This was breaking libvirt installs.