### PR TITLE
Use libvirt actuator image from CoreOS Quay org

### DIFF
--- a/manifests/clusterapi-controller.yaml
+++ b/manifests/clusterapi-controller.yaml
@@ -52,7 +52,7 @@ spec:
         image: openshift/origin-machine-controller:v4.0.0
       {{- else if .Libvirt}}
       - name: libvirt-machine-controller
-        image: quay.io/alberto_lamela/libvirt-machine-controller:0.0.1-dev # TODO: move this to openshift org
+        image: quay.io/coreos/cluster-api-provider-libvirt:cd386e4 # TODO: move this to openshift org
       {{- end}}
         env:
           - name: NODE_NAME

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -276,7 +276,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: libvirt-machine-controller
-        image: quay.io/alberto_lamela/libvirt-machine-controller:0.0.1-dev # TODO: move this to openshift org
+        image: quay.io/coreos/cluster-api-provider-libvirt:cd386e4 # TODO: move this to openshift org
         env:
           - name: NODE_NAME
             valueFrom:


### PR DESCRIPTION
This is a temporary home for this image until we have it under the OpenShift org. This is better than our personal namespaces, and is required to merge the PR integrating with the installer.