### PR TITLE
Makefile: fix call to go fmt check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ lint: ## Go lint your code
 
 .PHONY: fmt
 fmt: ## Go fmt your code
-	hack/verify-gofmt.sh
+	hack/go-fmt.sh
 
 .PHONY: vet
 vet: ## Apply go vet to all go files


### PR DESCRIPTION
This (presumably) should be hack/go-fmt.sh, not hack/verify-gofmt.sh
because the latter doesn't exist in the repo.