### PR TITLE
Integrate node role labeling into the nodelink controller

### DIFF
--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -64,8 +64,8 @@ const (
 	controllerName = "nodelink"
 
 	// machineAnnotationKey is the annotation storing a link between a node and it's machine. Should match upstream cluster-api machine controller. (node.go)
-	machineAnnotationKey = "machine"
-	kubeClusterNamespace = "kube-cluster"
+	machineAnnotationKey  = "machine"
+	nodeRoleAnnotationKey = "sigs.k8s.io/cluster-api-node-role"
 )
 
 // NewController returns a new *Controller.
@@ -400,6 +400,23 @@ func (c *Controller) processNode(node *corev1.Node) error {
 	if modNode.Labels == nil {
 		modNode.Labels = map[string]string{}
 	}
+
+	nodeRole, exists := matchingMachine.Annotations[nodeRoleAnnotationKey]
+	if !exists {
+		nodeLog.WithField("machine", fmt.Sprintf("%v/%v", matchingMachine.Namespace, matchingMachine.Name)).Warnf("Unable to find machine's %q annotation", nodeRoleAnnotationKey)
+	} else {
+		switch nodeRole {
+		case "master":
+			modNode.Labels["node-role.kubernetes.io/master"] = ""
+		case "infra":
+			modNode.Labels["node-role.kubernetes.io/infra"] = ""
+		case "compute":
+			modNode.Labels["node-role.kubernetes.io/compute"] = ""
+		default:
+			nodeLog.Infof("machine %q's annotation %q can contain only 'master', 'infra' or 'compute' value, %v given\n", machineKey, nodeRoleAnnotationKey, nodeRole)
+		}
+	}
+
 	for k, v := range matchingMachine.Spec.Labels {
 		nodeLog.Debugf("copying label %s = %s", k, v)
 		modNode.Labels[k] = v


### PR DESCRIPTION
Perform both node-machine matching and node role labelling inside the same controller.

Any machine (or machineset) is expected to set `sigs.k8s.io/cluster-api-node-role` annotation to `master`, `infra` or `compute`. Once done and a node joins the cluster it gets the role assigned.