### PR TITLE
Bake nodelink-controller into the mao docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /go/src/github.com/openshift/machine-api-operator
 COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o bin/machine-api-operator -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/machine-api-operator
+RUN CGO_ENABLED=0 GOOS=linux go build -o bin/nodelink-controller -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/nodelink-controller
 
 # Final container
 FROM openshift/origin-base
@@ -14,3 +15,4 @@ FROM openshift/origin-base
 COPY --from=build /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=build /go/src/github.com/openshift/machine-api-operator/manifests manifests
 COPY --from=build /go/src/github.com/openshift/machine-api-operator/machines machines
+COPY --from=build /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .


### PR DESCRIPTION
@enxebre as discussed let's put the `nodelink-controller` binary in the mao image so we can deploy it with the actuators.