### PR TITLE
Run MAO in its own namespace

### DIFF
--- a/cmd/machine-api-operator/main.go
+++ b/cmd/machine-api-operator/main.go
@@ -22,7 +22,6 @@ var (
 )
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&config, "config", "/etc/mao-config/config", "path to the mao config")
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 }
 

--- a/cmd/machine-api-operator/main.go
+++ b/cmd/machine-api-operator/main.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	componentName      = "machine-api-operator"
-	componentNamespace = "kube-system"
+	componentNamespace = "openshift-machine-api-operator"
 )
 
 var (

--- a/install/machineapioperator_01_images.configmap.yaml
+++ b/install/machineapioperator_01_images.configmap.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: machine-api-operator-images
-  namespace: kube-system
+  namespace: openshift-machine-api-operator
 data:
   images.json: '{"clusterAPIControllerAWS": "openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerManagerAWS": "openshift/origin-aws-machine-controllers:v4.0.0" , "clusterAPIControllerManagerLibvirt": "gcr.io/k8s-cluster-api/controller-manager:0.0.7", "clusterAPIControllerLibvirt": "quay.io/coreos/cluster-api-provider-libvirt:cd386e4", "clusterAPIServer": "gcr.io/k8s-cluster-api/cluster-apiserver:0.0.6", "Etcd": "quay.io/coreos/etcd:latest"}'

--- a/install/machineapioperator_02_deployment.yaml
+++ b/install/machineapioperator_02_deployment.yaml
@@ -33,8 +33,6 @@ spec:
             cpu: 20m
             memory: 50Mi
         volumeMounts:
-        - name: cluster-config
-          mountPath: /etc/mao-config
         - name: images
           mountPath: /etc/mao-config/images
       imagePullSecrets:
@@ -50,12 +48,6 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       volumes:
-      - name: cluster-config
-        configMap:
-          name: cluster-config-v1
-          items:
-          - key: mao-config
-            path: config
       - name: images
         configMap:
                 name: machine-api-operator-images

--- a/install/machineapioperator_02_rbac.yaml
+++ b/install/machineapioperator_02_rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-openshift-machine-api-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-machine-api-operator
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/install/machineapioperator_03_deployment.yaml
+++ b/install/machineapioperator_03_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: machine-api-operator
-  namespace: kube-system
+  namespace: openshift-machine-api-operator
   labels:
     k8s-app: machine-api-operator
     managed-by-channel-operator: "true"

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	cvoclientset "github.com/openshift/cluster-version-operator/pkg/generated/clientset/versioned"
 
@@ -13,6 +14,7 @@ import (
 	apiextclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextinformersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions/v1beta1"
 	apiextlistersv1beta1 "k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
@@ -44,6 +46,9 @@ const (
 	providerAWS       = "aws"
 	providerLibvirt   = "libvirt"
 	ownedManifestsDir = "owned-manifests"
+	// DefaultNamespace is the default namespace for components to be
+	// installed in.
+	DefaultNamespace = "openshift-cluster-api"
 )
 
 // Operator defines machince config operator.
@@ -151,7 +156,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 	go func() {
 		err := wait.Poll(machineRolloutPollInterval, machineRolloutTimeout, func() (bool, error) {
 			//TODO(vikasc) move operatorconfig rendering logic to main() to fail fast
-			operatorConfig, err := render.Config(optr.config)
+			operatorConfig, err := optr.getOperatorConfig()
 			if err != nil {
 				return false, fmt.Errorf("error decoding operator config: %v", err)
 			}
@@ -252,7 +257,6 @@ func (optr *Operator) updateImageDetails(config *render.OperatorConfig) error {
 		return err
 	}
 	(*config).Images = &imgs
-	glog.Infof("images %+v", config)
 	return nil
 }
 
@@ -268,8 +272,8 @@ func (optr *Operator) sync(key string) error {
 	}
 
 	// TODO(alberto) operatorConfig as CRD?
-	operatorConfig, err := render.Config(optr.config)
-
+	glog.Infof("Getting operator config using kubeclient")
+	operatorConfig, err := optr.getOperatorConfig()
 	if err != nil {
 		glog.Fatalf("Error decoding operator config: %v", err)
 		return err
@@ -293,4 +297,35 @@ func (optr *Operator) sync(key string) error {
 	}
 	glog.Info("Synched up cluster api controller")
 	return optr.syncAll(*operatorConfig)
+}
+
+func (optr *Operator) getOperatorConfig() (*render.OperatorConfig, error) {
+	var (
+		clusterConfigNamespace = "kube-system"
+		clusterConfigName      = "cluster-config-v1"
+	)
+	clusterConfig, err := optr.kubeClient.CoreV1().ConfigMaps(clusterConfigNamespace).Get(clusterConfigName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("could not find cluster-config-v1 namespace: %v", err)
+	}
+	return mcFromClusterConfig(clusterConfig)
+}
+
+func mcFromClusterConfig(cm *v1.ConfigMap) (*render.OperatorConfig, error) {
+	var (
+		mcKey = "mao-config"
+	)
+	var operatorConfig render.OperatorConfig
+	mcData, ok := cm.Data[mcKey]
+	if !ok {
+		return nil, fmt.Errorf("%s doesn't exist", mcKey)
+	}
+
+	if err := yaml.Unmarshal([]byte(mcData), &operatorConfig); err != nil {
+		return nil, fmt.Errorf("failed unmarshalling config file: %v", err)
+	}
+	if operatorConfig.TargetNamespace == "" {
+		operatorConfig.TargetNamespace = DefaultNamespace
+	}
+	return &operatorConfig, nil
 }

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"text/template"
 
-	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 )
 
@@ -15,10 +14,6 @@ const (
 	providerAWS     = "aws"
 	providerLibvirt = "libvirt"
 )
-
-// DefaultNamespace is the default namespace for components to be
-// installed in.
-const DefaultNamespace = "openshift-cluster-api"
 
 // Manifests takes the config object that contains the templated value,
 // and uses that to render the templated manifest.
@@ -50,26 +45,6 @@ func Manifests(config *OperatorConfig, data []byte) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
-}
-
-// Config reads the local config file.
-func Config(configFile string) (*OperatorConfig, error) {
-	config, err := ioutil.ReadFile(configFile)
-	if err != nil {
-		return nil, fmt.Errorf("read config file %q: %v", configFile, err)
-	}
-
-	// Marshal into machineAPI config object
-	var operatorConfig OperatorConfig
-	if err := yaml.Unmarshal(config, &operatorConfig); err != nil {
-		return nil, fmt.Errorf("unmarshal config file: %v", err)
-	}
-
-	if operatorConfig.TargetNamespace == "" {
-		operatorConfig.TargetNamespace = DefaultNamespace
-	}
-
-	return &operatorConfig, nil
 }
 
 // PopulateTemplate takes the config object, and uses that to render the templated manifest

--- a/tests/e2e/manifests/images.configmap.yaml
+++ b/tests/e2e/manifests/images.configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: machine-api-operator-images
-  namespace: kube-system
+  namespace: openshift-machine-api-operator
 data:
   images.json: '{
 	"clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",

--- a/tests/e2e/manifests/operator-deployment.yaml
+++ b/tests/e2e/manifests/operator-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: machine-api-operator
-  namespace: kube-system
+  namespace: openshift-machine-api-operator
   labels:
     k8s-app: machine-api-operator
     managed-by-channel-operator: "true"
@@ -33,8 +33,6 @@ spec:
             cpu: 20m
             memory: 50Mi
         volumeMounts:
-        - name: cluster-config
-          mountPath: /etc/mao-config
         - name: images
           mountPath: /etc/mao-config/images
       imagePullSecrets:
@@ -50,12 +48,6 @@ spec:
         operator: "Exists"
         effect: "NoSchedule"
       volumes:
-      - name: cluster-config
-        configMap:
-          name: cluster-config-v1
-          items:
-          - key: mao-config
-            path: config
       - name: images
         configMap:
                 name: machine-api-operator-images

--- a/tests/e2e/manifests/rbac.yaml
+++ b/tests/e2e/manifests/rbac.yaml
@@ -1,0 +1,13 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: default-account-openshift-machine-api-operator
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: openshift-machine-api-operator
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
This is being done so that MAO can be run in its own namespace instead kube-system