### PR TITLE
machines/aws/worker.machineset: Drop pubicIp

### DIFF
--- a/machines/aws/worker.machineset.yaml
+++ b/machines/aws/worker.machineset.yaml
@@ -54,7 +54,6 @@ spec:
             - name: "tag:Name"
               values:
               - "{{.AWS.ClusterName}}-worker-*"
-          publicIp: true
           iamInstanceProfile:
             id: "{{.AWS.ClusterName}}-worker-profile"
           tags:

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -135,7 +135,6 @@ spec:
             - name: "tag:Name"
               values:
               - "TestClusterManifest-ClusterName-worker-*"
-          publicIp: true
           iamInstanceProfile:
             id: "TestClusterManifest-ClusterName-worker-profile"
           tags:


### PR DESCRIPTION
We've had this since 04253cb9 (#34), but we don't need direct access to the workers.  Folks who do need to SSH into them, or whatever, should be able to access them via the masters.

Or maybe I'm just missing something, and this is actually important?