### PR TITLE
fix rolebinding namespace

### DIFF
--- a/owned-manifests/clusterapi-apiserver-role-binding.yaml
+++ b/owned-manifests/clusterapi-apiserver-role-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: clusterapi
-  namespace: {{ .TargetNamespace }}
+  namespace: kube-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
The `extension-apiserver-authentication-reader` must always be in the `kube-system` namespace because that is where the role is and that is where  the resources it wants access to are located.

I'm not sure if there's a bindata I need to update somewhere.

/assign @enxebre 