### PR TITLE
Nodelink controller

### DIFF
--- a/install/0000_50_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_50_machine-api-operator_01_images.configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: machine-api-operator-images
   namespace: openshift-cluster-api
 data:
-  images.json: '{"clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0", "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"}'
+  images.json: '{"machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0", "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0", "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"}'

--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -37,7 +37,7 @@ spec:
         operator: Exists
       containers:
       - name: controller-manager
-        image: {{ .Controller }}
+        image: {{ .Controllers.Provider }}
         command:
         - "./manager"
         resources:
@@ -48,7 +48,7 @@ spec:
             cpu: 100m
             memory: 30Mi
       - name: machine-controller
-        image: {{ .Controller }}
+        image: {{ .Controllers.Provider }}
         env:
           - name: NODE_NAME
             valueFrom:
@@ -60,7 +60,7 @@ spec:
           - --logtostderr=true
           - --v=3
       - name: nodelink-controller
-        image: {{ .Controller }}
+        image: {{ .Controllers.NodeLink }}
         command:
           - /nodelink-controller
         args:

--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -59,6 +59,13 @@ spec:
         args:
           - --logtostderr=true
           - --v=3
+      - name: nodelink-controller
+        image: {{ .Controller }}
+        command:
+          - /nodelink-controller
+        args:
+          - --logtostderr=true
+          - --v=3
         resources:
           requests:
             cpu: 100m

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -35,11 +35,17 @@ type Provider string
 // OperatorConfig contains configuration for MAO
 type OperatorConfig struct {
 	TargetNamespace string `json:"targetNamespace"`
-	Controller      string `json:"images"`
+	Controllers     Controllers
+}
+
+type Controllers struct {
+	Provider string
+	NodeLink string
 }
 
 // Images allows build systems to inject images for MAO components
 type Images struct {
+	MachineAPIOperator            string `json:"machineAPIOperator"`
 	ClusterAPIControllerAWS       string `json:"clusterAPIControllerAWS"`
 	ClusterAPIControllerOpenStack string `json:"clusterAPIControllerOpenStack"`
 	ClusterAPIControllerLibvirt   string `json:"clusterAPIControllerLibvirt"`
@@ -133,6 +139,13 @@ func getProviderControllerFromImages(provider Provider, images Images) (string, 
 		return images.ClusterAPIControllerOpenStack, nil
 	}
 	return "", fmt.Errorf("not known platform provider given %s", provider)
+}
+
+func getMachineAPIOperatorFromImages(images Images) (string, error) {
+	if images.MachineAPIOperator == "" {
+		return "", fmt.Errorf("failed gettingMachineAPIOperator image. It is empty")
+	}
+	return images.MachineAPIOperator, nil
 }
 
 // PopulateTemplate receives a template file path and renders its content populated with the config

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 var (
-	imagesJSONFile         = "fixtures/images.json"
-	expectedAWSImage       = "docker.io/openshift/origin-aws-machine-controllers:v4.0.0"
-	expectedLibvirtImage   = "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
-	expectedOpenstackImage = "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0"
+	imagesJSONFile                  = "fixtures/images.json"
+	expectedAWSImage                = "docker.io/openshift/origin-aws-machine-controllers:v4.0.0"
+	expectedLibvirtImage            = "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
+	expectedOpenstackImage          = "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0"
+	expectedMachineAPIOperatorImage = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
 )
 
 func TestInstallConfigFromClusterConfig(t *testing.T) {
@@ -166,5 +167,21 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 		if test.expectedImage != res {
 			t.Errorf("failed getProviderControllerFromImages. Expected: %q, got: %q", test.expectedImage, res)
 		}
+	}
+}
+
+func TestGetMachineAPIOperatorFromImages(t *testing.T) {
+	imagesJSONFile := "fixtures/images.json"
+	img, err := getImagesFromJSONFile(imagesJSONFile)
+	if err != nil {
+		t.Errorf("failed getImagesFromJSONFile, %v", err)
+	}
+
+	res, err := getMachineAPIOperatorFromImages(*img)
+	if err != nil {
+		t.Errorf("failed getMachineAPIOperatorFromImages : %v", err)
+	}
+	if res != expectedMachineAPIOperatorImage {
+		t.Errorf("failed getMachineAPIOperatorFromImages. Expected: %s, got: %s", expectedMachineAPIOperatorImage, res)
 	}
 }

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -1,5 +1,6 @@
 {
   "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
   "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0",
-  "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
+  "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
+  "machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0"
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -240,13 +240,17 @@ func (optr *Operator) maoConfigFromInstallConfig() (*OperatorConfig, error) {
 		return nil, err
 	}
 
-	controllerImage, err := getProviderControllerFromImages(provider, *images)
+	providerControllerImage, err := getProviderControllerFromImages(provider, *images)
+	machineAPIOperatorImage, err := getMachineAPIOperatorFromImages(*images)
 	if err != nil {
 		return nil, err
 	}
 
 	return &OperatorConfig{
 		optr.namespace,
-		controllerImage,
+		Controllers{
+			providerControllerImage,
+			machineAPIOperatorImage,
+		},
 	}, nil
 }

--- a/tests/e2e/manifests/images.configmap.yaml
+++ b/tests/e2e/manifests/images.configmap.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: openshift-cluster-api
 data:
   images.json: '{
-	"clusterAPIControllerAWS": "registry.svc.ci.openshift.org/openshift/aws-machine-controllers:crd",
-	"clusterAPIControllerManagerAWS": "registry.svc.ci.openshift.org/openshift/aws-machine-controllers:crd",
-	"clusterAPIControllerManagerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
-	"clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
+	"clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
+	"clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
+	"machineAPIOperator": "{{ .Image }}"
 }'

--- a/tests/e2e/util.go
+++ b/tests/e2e/util.go
@@ -8,32 +8,23 @@ import (
 	"github.com/golang/glog"
 )
 
-func renderTemplate(tmplData interface{}, data []byte) ([]byte, error) {
-	buf := new(bytes.Buffer)
+// PopulateTemplate receives a template file path and renders its content populated with the config
+func PopulateTemplate(config interface{}, path string) ([]byte, error) {
 
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		glog.Fatalf("failed reading file, %v", err)
+	}
+
+	buf := &bytes.Buffer{}
 	tmpl, err := template.New("").Option("missingkey=error").Parse(string(data))
 	if err != nil {
 		return nil, err
 	}
 
-	if err := tmpl.Execute(buf, tmplData); err != nil {
+	if err := tmpl.Execute(buf, config); err != nil {
 		return nil, err
 	}
 
 	return buf.Bytes(), nil
-}
-
-// RenderTemplateFromFile takes the config object, and uses that to render the templated manifest
-func RenderTemplateFromFile(config interface{}, path string) ([]byte, error) {
-
-	data, err := ioutil.ReadFile(path)
-	if err != nil {
-		glog.Fatalf("Error reading %#v", err)
-	}
-
-	populatedData, err := renderTemplate(config, data)
-	if err != nil {
-		glog.Fatalf("Unable to render manifests %q: %v", data, err)
-	}
-	return populatedData, nil
 }


### PR DESCRIPTION
Includes the nodelink controller in the controllers manifests
Move the nodelink controller to glog: `--log-level is gone` and `--logtostderror=true` is used instead.