### PR TITLE
remove unused code

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -92,9 +92,7 @@ func startControllers(ctx *common.ControllerContext) error {
 
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.APIExtClientOrDie(componentName),
-		ctx.ClientBuilder.APIRegistrationClientOrDie(componentName),
 		ctx.ClientBuilder.ClusterversionClientOrDie(componentName),
-		ctx.ClientBuilder.ClusterAPIClientOrDie(componentName),
 	).Run(2, ctx.Stop)
 
 	return nil

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,8 +1,0 @@
-package types
-
-const (
-	// MachineAPIOperatorName name of the add on operator
-	MachineAPIOperatorName = "machine-api-operator"
-	// MachineAPIVersionName appversion name of add on operator
-	MachineAPIVersionName = "machine-api"
-)


### PR DESCRIPTION
remove unused code:
- APIRegistration was needed for aggregated api server, we use CRDs now
- ClusterAPIClient was need for deploying owned machineSets. That’s instantiated by installer now