### PR TITLE
Remove unused clients and informers

### DIFF
--- a/cmd/common/client_builder.go
+++ b/cmd/common/client_builder.go
@@ -7,24 +7,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	apiregistrationclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
-	clusterapiclientset "sigs.k8s.io/cluster-api/pkg/client/clientset_generated/clientset"
 )
 
 // ClientBuilder can create a variety of kubernetes client interface
 // with its embeded rest.Config.
 type ClientBuilder struct {
 	config *rest.Config
-}
-
-// ClusterAPIClientOrDie returns the kubernetes client interface for machine config.
-func (cb *ClientBuilder) ClusterAPIClientOrDie(name string) clusterapiclientset.Interface {
-	return clusterapiclientset.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
-}
-
-// APIRegistrationClientOrDie returns the kubernetes client interface for machine config.
-func (cb *ClientBuilder) APIRegistrationClientOrDie(name string) apiregistrationclientset.Interface {
-	return apiregistrationclientset.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
 }
 
 // KubeClientOrDie returns the kubernetes client interface for general kubernetes objects.
@@ -38,7 +26,7 @@ func (cb *ClientBuilder) APIExtClientOrDie(name string) apiext.Interface {
 }
 
 // ClusterversionClientOrDie returns the kubernetes client interface for cluster version objects.
-// TODO(yifan): Just return the client for the Operator Status objects.
+// TODO(alberto): Return the client for the Cluster Operator Status objects under config.io.
 func (cb *ClientBuilder) ClusterversionClientOrDie(name string) cvoclientset.Interface {
 	return cvoclientset.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
 }

--- a/cmd/common/controller_context.go
+++ b/cmd/common/controller_context.go
@@ -12,7 +12,6 @@ import (
 type ControllerContext struct {
 	ClientBuilder *ClientBuilder
 
-	KubeInformerFactory           informers.SharedInformerFactory
 	KubeNamespacedInformerFactory informers.SharedInformerFactory
 	APIExtInformerFactory         apiextinformers.SharedInformerFactory
 
@@ -22,8 +21,6 @@ type ControllerContext struct {
 
 	InformersStarted chan struct{}
 
-	KubeInformersStarted chan struct{}
-
 	ResyncPeriod func() time.Duration
 }
 
@@ -32,18 +29,15 @@ func CreateControllerContext(cb *ClientBuilder, stop <-chan struct{}, targetName
 	kubeClient := cb.KubeClientOrDie("kube-shared-informer")
 	apiExtClient := cb.APIExtClientOrDie("apiext-shared-informer")
 
-	kubeSharedInformer := informers.NewSharedInformerFactory(kubeClient, resyncPeriod()())
 	kubeNamespacedSharedInformer := informers.NewFilteredSharedInformerFactory(kubeClient, resyncPeriod()(), targetNamespace, nil)
 	apiExtSharedInformer := apiextinformers.NewSharedInformerFactory(apiExtClient, resyncPeriod()())
 
 	return &ControllerContext{
 		ClientBuilder:                 cb,
-		KubeInformerFactory:           kubeSharedInformer,
 		KubeNamespacedInformerFactory: kubeNamespacedSharedInformer,
 		APIExtInformerFactory:         apiExtSharedInformer,
-		Stop:                 stop,
-		InformersStarted:     make(chan struct{}),
-		KubeInformersStarted: make(chan struct{}),
-		ResyncPeriod:         resyncPeriod(),
+		Stop:             stop,
+		InformersStarted: make(chan struct{}),
+		ResyncPeriod:     resyncPeriod(),
 	}
 }

--- a/cmd/common/helpers.go
+++ b/cmd/common/helpers.go
@@ -22,7 +22,7 @@ const (
 	// RetryPeriod is the default duration for the leader electrion retrial.
 	RetryPeriod = 30 * time.Second
 
-	minResyncPeriod = 10 * time.Second
+	minResyncPeriod = 10 * time.Minute
 )
 
 func resyncPeriod() func() time.Duration {

--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -54,10 +54,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			glog.Fatalf("error starting controllers: %v", err)
 		}
 
-		ctx.KubeInformerFactory.Start(ctx.Stop)
 		ctx.KubeNamespacedInformerFactory.Start(ctx.Stop)
 		ctx.APIExtInformerFactory.Start(ctx.Stop)
-		close(ctx.KubeInformersStarted)
+		close(ctx.InformersStarted)
 
 		select {}
 	}
@@ -83,7 +82,6 @@ func startControllers(ctx *common.ControllerContext) error {
 		startOpts.imagesFile,
 
 		config,
-		ctx.KubeInformerFactory.Core().V1().ConfigMaps(),
 		ctx.KubeNamespacedInformerFactory.Core().V1().ServiceAccounts(),
 		ctx.APIExtInformerFactory.Apiextensions().V1beta1().CustomResourceDefinitions(),
 		ctx.KubeNamespacedInformerFactory.Apps().V1().Deployments(),

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	// maxRetries is the number of times a machineconfig pool will be retried before it is dropped out of the queue.
+	// maxRetries is the number of times a key will be retried before it is dropped out of the queue.
 	// With the current rate-limiter in use (5ms*2^(maxRetries-1)) the following numbers represent the times
 	// a machineconfig pool is going to be requeued:
 	//
@@ -36,7 +36,7 @@ const (
 	ownedManifestsDir = "owned-manifests"
 )
 
-// Operator defines machince config operator.
+// Operator defines machine api operator.
 type Operator struct {
 	namespace, name string
 
@@ -67,7 +67,6 @@ func New(
 
 	config string,
 
-	configMapInformer coreinformersv1.ConfigMapInformer,
 	serviceAccountInfomer coreinformersv1.ServiceAccountInformer,
 	crdInformer apiextinformersv1beta1.CustomResourceDefinitionInformer,
 	deployInformer appsinformersv1.DeploymentInformer,
@@ -93,7 +92,6 @@ func New(
 		queue:         workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineapioperator"),
 	}
 
-	configMapInformer.Informer().AddEventHandler(optr.eventHandler())
 	serviceAccountInfomer.Informer().AddEventHandler(optr.eventHandler())
 	crdInformer.Informer().AddEventHandler(optr.eventHandler())
 	deployInformer.Informer().AddEventHandler(optr.eventHandler())


### PR DESCRIPTION
Remove unused clients and informers:
- No need for ctx.KubeInformerFactory.Core().V1().ConfigMaps() since only config is the one time provider got from installer config
- Remove old apiregistrationclientset and clusterapiclientset

Increase minResyncPeriod