### PR TITLE
replace tectonicClusterID tag with openshiftClusterID

### DIFF
--- a/test/integration/aws.go
+++ b/test/integration/aws.go
@@ -66,7 +66,7 @@ type AWSClient struct {
 func (client *AWSClient) getInstances(instanceStateFilter []*string, clusterID string) ([]*ec2.Instance, error) {
 	requestFilters := []*ec2.Filter{
 		{
-			Name:   aws.String("tag:tectonicClusterID"),
+			Name:   aws.String("tag:openshiftClusterID"),
 			Values: []*string{aws.String(clusterID)},
 		},
 	}

--- a/test/integration/manifests/machineset.yaml
+++ b/test/integration/manifests/machineset.yaml
@@ -45,7 +45,7 @@ spec:
               values:
               - {{ .ClusterID }}-worker-*
           tags:
-          - name: tectonicClusterID
+          - name: openshiftClusterID
             value: {{ .ClusterID }}
           userDataSecret:
             name: ignition-worker


### PR DESCRIPTION
The tectonicClusterID tag is being replaced with openshiftClusterID in the installer. This change will use the new tag name.

/hold on https://github.com/openshift/installer/pull/817