### PR TITLE
machineset: add additional printer columns to CRD

### DIFF
--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -94,6 +94,22 @@ spec:
           - replicas
           type: object
   version: v1alpha1
+  additionalPrinterColumns:
+  - JSONPath: .spec.replicas
+    description: Desired Replicas
+    name: Desired
+    type: integer
+  - JSONPath: .status.replicas
+    description: Current Replicas
+    name: Current
+    type: integer
+  - JSONPath: .status.readyReplicas
+    description: Ready Replicas
+    name: Ready
+    type: integer
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
 status:
   acceptedNames:
     kind: ""

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -151,11 +151,11 @@ func getMachineHealthCheckListOptions() *client.ListOptions {
 func remediate(r *ReconcileMachineHealthCheck, machine *capiv1.Machine) (reconcile.Result, error) {
 	glog.Infof("Initialising remediation logic for machine %s", machine.Name)
 	if isMaster(*machine, r.client) {
-		glog.Info("The machine %s is a master node, skipping remediation", machine.Name)
+		glog.Infof("The machine %s is a master node, skipping remediation", machine.Name)
 		return reconcile.Result{}, nil
 	}
 	if !hasMachineSetOwner(*machine) {
-		glog.Info("Machine %s has no machineSet controller owner, skipping remediation", machine.Name)
+		glog.Infof("Machine %s has no machineSet controller owner, skipping remediation", machine.Name)
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
Additionally print:

- Desired Replicas
- Current Replicas
- Ready Replicas

which is similar to the replicaset output.

If you're going to watch output then be wary of:

https://github.com/kubernetes/kubernetes/issues/66538