### PR TITLE
Fix machineset apiversion in tests from aws.cluster.k8s.io/v1alpha1 to awsproviderconfig.k8s.io/v1alpha1

### DIFF
--- a/test/integration/manifests/machineset.yaml
+++ b/test/integration/manifests/machineset.yaml
@@ -27,7 +27,7 @@ spec:
             name: aws-credentials-secret
           ami:
             id: ami-05c79276d240b93bc
-          apiVersion: aws.cluster.k8s.io/v1alpha1
+          apiVersion: awsproviderconfig.k8s.io/v1alpha1
           iamInstanceProfile:
             id: {{ .ClusterID }}-worker-profile
           instanceType: t2.medium


### PR DESCRIPTION
Due to substitution of `yaml.Unmarshal` for `codec.DecodeProviderConfig` in [1], `aws.cluster.k8s.io/v1alpha1` is no longer supported.

[1] https://github.com/openshift/cluster-api-provider-aws/pull/114/files#diff-ff59ea1505d1c2206134802c4f0f8ff2R167