### PR TITLE
Rename of providerConfig to providerSpec under CRD's

### DIFF
--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -22,40 +22,75 @@ spec:
         metadata:
           type: object
         spec:
-          properties:
-            configSource:
-              type: object
-            metadata:
-              type: object
-            providerConfig:
-              properties:
-                value:
-                  type: object
-                valueFrom:
-                  properties:
-                    machineClass:
-                      properties:
-                        provider:
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            taints:
-              items:
+          anyOf:
+          - type: object
+            properties:
+              configSource:
                 type: object
-              type: array
-            versions:
-              properties:
-                controlPlane:
-                  type: string
-                kubelet:
-                  type: string
-              required:
-              - kubelet
-              type: object
-          required:
-          - providerConfig
-          type: object
+              metadata:
+                type: object
+              providerSpec:
+                properties:
+                  value:
+                    type: object
+                  valueFrom:
+                    properties:
+                      machineClass:
+                        properties:
+                          provider:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              taints:
+                items:
+                  type: object
+                type: array
+              versions:
+                properties:
+                  controlPlane:
+                    type: string
+                  kubelet:
+                    type: string
+                required:
+                - kubelet
+                type: object
+            required:
+            - providerSpec
+          - type: object
+            properties:
+              configSource:
+                type: object
+              metadata:
+                type: object
+              providerConfig:
+                properties:
+                  value:
+                    type: object
+                  valueFrom:
+                    properties:
+                      machineClass:
+                        properties:
+                          provider:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              taints:
+                items:
+                  type: object
+                type: array
+              versions:
+                properties:
+                  controlPlane:
+                    type: string
+                  kubelet:
+                    type: string
+                required:
+                - kubelet
+                type: object
+            required:
+            - providerConfig
         status:
           properties:
             addresses:

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -26,6 +26,7 @@ spec:
         metadata:
           type: object
         spec:
+          type: object
           properties:
             minReadySeconds:
               format: int32
@@ -36,48 +37,82 @@ spec:
             selector:
               type: object
             template:
+              type: object
               properties:
                 metadata:
                   type: object
                 spec:
-                  properties:
-                    configSource:
-                      type: object
-                    metadata:
-                      type: object
-                    providerConfig:
-                      properties:
-                        value:
-                          type: object
-                        valueFrom:
-                          properties:
-                            machineClass:
-                              properties:
-                                provider:
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      items:
+                  anyOf:
+                  - type: object
+                    properties:
+                      configSource:
                         type: object
-                      type: array
-                    versions:
-                      properties:
-                        controlPlane:
-                          type: string
-                        kubelet:
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerConfig
-                  type: object
-              type: object
+                      metadata:
+                        type: object
+                      providerSpec:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerSpec
+                  - type: object
+                    properties:
+                      configSource:
+                        type: object
+                      metadata:
+                        type: object
+                      providerConfig:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerConfig
           required:
           - selector
-          type: object
         status:
           properties:
             availableReplicas:

--- a/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
+++ b/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
@@ -26,6 +26,7 @@ spec:
         metadata:
           type: object
         spec:
+          type: object
           properties:
             minReadySeconds:
               format: int32
@@ -54,49 +55,83 @@ spec:
                   type: string
               type: object
             template:
+              type: object
               properties:
                 metadata:
                   type: object
                 spec:
-                  properties:
-                    configSource:
-                      type: object
-                    metadata:
-                      type: object
-                    providerConfig:
-                      properties:
-                        value:
-                          type: object
-                        valueFrom:
-                          properties:
-                            machineClass:
-                              properties:
-                                provider:
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      items:
+                  anyOf:
+                  - type: object
+                    properties:
+                      configSource:
                         type: object
-                      type: array
-                    versions:
-                      properties:
-                        controlPlane:
-                          type: string
-                        kubelet:
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerConfig
-                  type: object
-              type: object
+                      metadata:
+                        type: object
+                      providerSpec:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerSpec
+                  - type: object
+                    properties:
+                      configSource:
+                        type: object
+                      metadata:
+                        type: object
+                      providerConfig:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerConfig
           required:
           - selector
           - template
-          type: object
         status:
           properties:
             availableReplicas:

--- a/install/0000_50_machine-api-operator_06_machineclass.crd.yaml
+++ b/install/0000_50_machine-api-operator_06_machineclass.crd.yaml
@@ -12,17 +12,29 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        providerConfig:
-          type: object
-      required:
-      - providerConfig
+      anyOf:
+      - properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          providerSpec:
+            type: object
+        required:
+        - providerSpec
+      - properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          providerConfig:
+            type: object
+        required:
+        - providerConfig
   version: v1alpha1
 status:
   acceptedNames:


### PR DESCRIPTION
cluster-api master has renamed `providerConfig` to `providerSpec`,
we must allign to this changes

**TODO**
- [x] libvirt actuator change: https://github.com/openshift/cluster-api-provider-libvirt/pull/104
- [x] aws actuator change: https://github.com/openshift/cluster-api-provider-aws/pull/127