### PR TITLE
Add logtostderr flag for controller-manager

### DIFF
--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -40,6 +40,9 @@ spec:
         image: {{ .Controllers.Provider }}
         command:
         - "./manager"
+        args:
+          - --logtostderr=true
+          - --v=3
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
Let's enable this for the sake of better visibility, specially since we are introducing support for machine deployments