### PR TITLE
wrap binary building in a bash script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-operator
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/machine-api-operator -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/machine-api-operator
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/nodelink-controller -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/nodelink-controller
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/machine-healthcheck -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/machine-healthcheck
+RUN NO_DOCKER=1 make build
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/owned-manifests owned-manifests

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,9 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-operator
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/machine-api-operator -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/machine-api-operator
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/nodelink-controller -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/nodelink-controller
-RUN CGO_ENABLED=0 GOOS=linux go build -o bin/machine-healthcheck -a -ldflags '-extldflags "-static"' github.com/openshift/machine-api-operator/cmd/machine-healthcheck
+RUN NO_DOCKER=1 make build
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/owned-manifests owned-manifests

--- a/Makefile
+++ b/Makefile
@@ -21,23 +21,22 @@ else
 endif
 
 .PHONY: check
-check: lint fmt vet test
+check: lint fmt vet test ## Run code validations
 
 .PHONY: build
-build: ## Build binary
-	@echo -e "\033[32mBuilding package...\033[0m"
-	mkdir -p bin
-	$(DOCKER_CMD) go build $(GOGCFLAGS) -ldflags "-X github.com/openshift/machine-api-operator/pkg/version.Raw=$(VERSION)" -o bin/machine-api-operator github.com/openshift/machine-api-operator/cmd/machine-api-operator
+build: machine-api-operator nodelink-controller machine-healthcheck ## Build binaries
+
+.PHONY: machine-api-operator
+machine-api-operator:
+	$(DOCKER_CMD) ./hack/go-build.sh machine-api-operator
 
 .PHONY: nodelink-controller
 nodelink-controller:
-	@echo -e "\033[32mBuilding node link controller binary...\033[0m"
-	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/nodelink-controller github.com/openshift/machine-api-operator/cmd/nodelink-controller
+	$(DOCKER_CMD) ./hack/go-build.sh nodelink-controller
 
 .PHONY: machine-healthcheck
 machine-healthcheck:
-	@echo -e "\033[32mBuilding machine healthcheck binary...\033[0m"
-	$(DOCKER_CMD) go build $(GOGCFLAGS) -o bin/machine-healthcheck github.com/openshift/machine-api-operator/cmd/machine-healthcheck
+	$(DOCKER_CMD) ./hack/go-build.sh machine-healthcheck 
 
 .PHONY: build-integration
 build-integration: ## Build integration test binary

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -9,8 +9,8 @@ GLDFLAGS=${GLDFLAGS:-}
 
 eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
 
-GOOS=${GOOS:-${GOHOSTOS}}
-GOARCH=${GOACH:-${GOHOSTARCH}}
+: "${GOOS:=${GOHOSTOS}}"
+: "${GOARCH:=${GOHOSTARCH}}"
 
 # Go to the root of the repo
 cd "$(git rev-parse --show-cdup)"
@@ -23,8 +23,6 @@ fi
 GLDFLAGS+="-extldflags '-static' -X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
 
 eval $(go env)
-
-mkdir -p bin
 
 echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
 CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${WHAT} ${REPO}/cmd/${WHAT}

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eu
+
+REPO=github.com/openshift/machine-api-operator
+WHAT=${1:-machine-api-operator}
+GOFLAGS=${GOFLAGS:-}
+GLDFLAGS=${GLDFLAGS:-}
+
+eval $(go env | grep -e "GOHOSTOS" -e "GOHOSTARCH")
+
+GOOS=${GOOS:-${GOHOSTOS}}
+GOARCH=${GOACH:-${GOHOSTARCH}}
+
+# Go to the root of the repo
+cd "$(git rev-parse --show-cdup)"
+
+if [ -z ${VERSION_OVERRIDE+a} ]; then
+	echo "Using version from git..."
+	VERSION_OVERRIDE=$(git describe --abbrev=8 --dirty --always)
+fi
+
+GLDFLAGS+="-extldflags '-static' -X ${REPO}/pkg/version.Raw=${VERSION_OVERRIDE}"
+
+eval $(go env)
+
+mkdir -p bin
+
+echo "Building ${REPO}/cmd/${WHAT} (${VERSION_OVERRIDE})"
+CGO_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build ${GOFLAGS} -ldflags "${GLDFLAGS}" -o bin/${WHAT} ${REPO}/cmd/${WHAT}


### PR DESCRIPTION
Unify a way to build binaries. Previously binaries for containers were build in a different way than those for development which posed a problem (for example lack of mao version number when run from a container image). This bash wrapper solves those issues.

Wrapper is a slightly modified version of: https://github.com/openshift/machine-config-operator/blob/master/hack/build-go.sh