### PR TITLE
Support both .providerConfig and .providerSpec fields

### DIFF
--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -22,40 +22,75 @@ spec:
         metadata:
           type: object
         spec:
-          properties:
-            configSource:
-              type: object
-            metadata:
-              type: object
-            providerConfig:
-              properties:
-                value:
-                  type: object
-                valueFrom:
-                  properties:
-                    machineClass:
-                      properties:
-                        provider:
-                          type: string
-                      type: object
-                  type: object
-              type: object
-            taints:
-              items:
+          oneOf:
+          - properties:
+              configSource:
                 type: object
-              type: array
-            versions:
-              properties:
-                controlPlane:
-                  type: string
-                kubelet:
-                  type: string
-              required:
-              - kubelet
-              type: object
-          required:
-          - providerConfig
-          type: object
+              metadata:
+                type: object
+              providerConfig:
+                properties:
+                  value:
+                    type: object
+                  valueFrom:
+                    properties:
+                      machineClass:
+                        properties:
+                          provider:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              taints:
+                items:
+                  type: object
+                type: array
+              versions:
+                properties:
+                  controlPlane:
+                    type: string
+                  kubelet:
+                    type: string
+                required:
+                - kubelet
+                type: object
+            required:
+            - providerConfig
+            type: object
+          - properties:
+              configSource:
+                type: object
+              metadata:
+                type: object
+              providerSpec:
+                properties:
+                  value:
+                    type: object
+                  valueFrom:
+                    properties:
+                      machineClass:
+                        properties:
+                          provider:
+                            type: string
+                        type: object
+                    type: object
+                type: object
+              taints:
+                items:
+                  type: object
+                type: array
+              versions:
+                properties:
+                  controlPlane:
+                    type: string
+                  kubelet:
+                    type: string
+                required:
+                - kubelet
+                type: object
+            required:
+            - providerSpec
+            type: object
         status:
           properties:
             addresses:

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -40,40 +40,75 @@ spec:
                 metadata:
                   type: object
                 spec:
-                  properties:
-                    configSource:
-                      type: object
-                    metadata:
-                      type: object
-                    providerConfig:
-                      properties:
-                        value:
-                          type: object
-                        valueFrom:
-                          properties:
-                            machineClass:
-                              properties:
-                                provider:
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      items:
+                  oneOf:
+                  - properties:
+                      configSource:
                         type: object
-                      type: array
-                    versions:
-                      properties:
-                        controlPlane:
-                          type: string
-                        kubelet:
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerConfig
-                  type: object
+                      metadata:
+                        type: object
+                      providerConfig:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerConfig
+                    type: object
+                  - properties:
+                      configSource:
+                        type: object
+                      metadata:
+                        type: object
+                      providerSpec:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerSpec
+                    type: object
               type: object
           required:
           - selector

--- a/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
+++ b/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
@@ -58,40 +58,75 @@ spec:
                 metadata:
                   type: object
                 spec:
-                  properties:
-                    configSource:
-                      type: object
-                    metadata:
-                      type: object
-                    providerConfig:
-                      properties:
-                        value:
-                          type: object
-                        valueFrom:
-                          properties:
-                            machineClass:
-                              properties:
-                                provider:
-                                  type: string
-                              type: object
-                          type: object
-                      type: object
-                    taints:
-                      items:
+                  oneOf:
+                  - properties:
+                      configSource:
                         type: object
-                      type: array
-                    versions:
-                      properties:
-                        controlPlane:
-                          type: string
-                        kubelet:
-                          type: string
-                      required:
-                      - kubelet
-                      type: object
-                  required:
-                  - providerConfig
-                  type: object
+                      metadata:
+                        type: object
+                      providerConfig:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerConfig
+                    type: object
+                  - properties:
+                      configSource:
+                        type: object
+                      metadata:
+                        type: object
+                      providerSpec:
+                        properties:
+                          value:
+                            type: object
+                          valueFrom:
+                            properties:
+                              machineClass:
+                                properties:
+                                  provider:
+                                    type: string
+                                type: object
+                            type: object
+                        type: object
+                      taints:
+                        items:
+                          type: object
+                        type: array
+                      versions:
+                        properties:
+                          controlPlane:
+                            type: string
+                          kubelet:
+                            type: string
+                        required:
+                        - kubelet
+                        type: object
+                    required:
+                    - providerSpec
+                    type: object
               type: object
           required:
           - selector


### PR DESCRIPTION
Due to recent renaming of providerConfig into providerSpec field
of machine CRD, we need to temporarily support both until the installer
migrates all its generated manifest to specify providerSpec instead
of providerConfig.

Everytime I specify both fields I get this error: `must validate one and only one schema (oneOf)`
At most one of `.providerConfig` and `.providerSpec` fields is allowed to be specified.

Tested the updated CRDS in the following scenarios (see https://gist.github.com/ingvagabund/193f868c858792067b90fbae3790a712):
- machine with providerConfig (succesfully created)
- machine with providerSpec (succesfully created)
- machine with both providerConfig and providerSpec (validation error)
- machineset with providerConfig (succesfully created)
- machineset with providerSpec (succesfully created)
- machineset with both providerConfig and providerSpec (validation error)
- machinedeployment with providerConfig (succesfully created)
- machinedeployment with providerSpec (succesfully created)
- machinedeployment with both providerConfig and providerSpec (validation error)

Both aws and libvirt actuator accept both fields:
- libvirt actuator PR: https://github.com/openshift/cluster-api-provider-libvirt/pull/104
- aws actuator PR: https://github.com/openshift/cluster-api-provider-aws/pull/127