### PR TITLE
Remove deprecated machine annotation

### DIFF
--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -62,8 +62,6 @@ const (
 
 	// machineAnnotationKey is the annotation storing a link between a node and it's machine. Should match upstream cluster-api machine controller. (node.go)
 	machineAnnotationKey = "cluster.k8s.io/machine"
-	// oldMachineAnnotationKey for backward compatibility only
-	oldMachineAnnotationKey = "machine"
 )
 
 // NewController returns a new *Controller.
@@ -332,14 +330,6 @@ func (c *Controller) syncNode(key string) error {
 }
 func (c *Controller) processNode(node *corev1.Node) error {
 	machineKey, ok := node.Annotations[machineAnnotationKey]
-	// In case the old annotation is still used instead of the new one
-	// make sure we check it as well.
-	// TODO(jchaloup): Remove the check once all actuator repos updated
-	// the cluster-api deps to the new annotation key.
-	if !ok {
-		machineKey, ok = node.Annotations[oldMachineAnnotationKey]
-	}
-
 	// No machine annotation, this is likely the first time we've seen the node,
 	// need to load all machines and search for one with matching IP.
 	var matchingMachine *capiv1.Machine
@@ -391,9 +381,7 @@ func (c *Controller) processNode(node *corev1.Node) error {
 	}
 
 	modNode := node.DeepCopy()
-
 	modNode.Annotations[machineAnnotationKey] = fmt.Sprintf("%s/%s", matchingMachine.Namespace, matchingMachine.Name)
-	modNode.Annotations[oldMachineAnnotationKey] = fmt.Sprintf("%s/%s", matchingMachine.Namespace, matchingMachine.Name)
 
 	if modNode.Labels == nil {
 		modNode.Labels = map[string]string{}

--- a/test/e2e/operator_expectations.go
+++ b/test/e2e/operator_expectations.go
@@ -88,7 +88,7 @@ func (tc *testConfig) ExpectClusterOperatorStatusAvailable() error {
 }
 
 func (tc *testConfig) ExpectAllMachinesLinkedToANode() error {
-	machineAnnotationKey := "machine"
+	machineAnnotationKey := "cluster.k8s.io/machine"
 	listOptions := client.ListOptions{
 		Namespace: namespace,
 	}


### PR DESCRIPTION
Since we merge this upstream https://github.com/kubernetes-sigs/cluster-api/pull/593/files we needed to support both annotations for backwards compatibility. After aws/libvirt actuators including latest cluster-api, the old annotation can be removed. See https://github.com/openshift/cluster-api-provider-aws/pull/127 and https://github.com/openshift/cluster-api-provider-libvirt/pull/104