### PR TITLE
Add possibility to specify baremetal actuator under the install config

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -28,6 +28,8 @@ const (
 	LibvirtProvider = Provider("libvirt")
 	// OpenStackPlatformType is used to install on OpenStack
 	OpenStackProvider = Provider("openstack")
+	// BareMetalProvider is used to fence bare metal nodes
+	BareMetalProvider = Provider("baremetal")
 )
 
 type Provider string
@@ -50,6 +52,7 @@ type Images struct {
 	ClusterAPIControllerAWS       string `json:"clusterAPIControllerAWS"`
 	ClusterAPIControllerOpenStack string `json:"clusterAPIControllerOpenStack"`
 	ClusterAPIControllerLibvirt   string `json:"clusterAPIControllerLibvirt"`
+	ClusterAPIControllerBareMetal string `json:"clusterAPIControllerBareMetal"`
 }
 
 // InstallConfig contains the mao relevant config coming from the install config, i.e provider
@@ -68,6 +71,9 @@ type InstallPlatform struct {
 
 	// OpenStack is the configuration used when running on OpenStack
 	OpenStack interface{} `json:"openstack,omitempty"`
+
+	// BareMetal is the configuration used when running on bare metal nodes
+	BareMetal interface{} `json:"baremetal,omitempty"`
 }
 
 func getInstallConfig(client kubernetes.Interface) (*InstallConfig, error) {
@@ -114,6 +120,9 @@ func getProviderFromInstallConfig(installConfig *InstallConfig) (Provider, error
 	if installConfig.OpenStack != nil {
 		return OpenStackProvider, nil
 	}
+	if installConfig.BareMetal != nil {
+		return BareMetalProvider, nil
+	}
 	return "", fmt.Errorf("no platform provider found on install config")
 }
 
@@ -138,6 +147,8 @@ func getProviderControllerFromImages(provider Provider, images Images) (string, 
 		return images.ClusterAPIControllerLibvirt, nil
 	case OpenStackProvider:
 		return images.ClusterAPIControllerOpenStack, nil
+	case BareMetalProvider:
+		return images.ClusterAPIControllerBareMetal, nil
 	}
 	return "", fmt.Errorf("not known platform provider given %s", provider)
 }

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -2,5 +2,6 @@
   "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
   "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0",
   "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
+  "clusterAPIControllerBareMetal": "docker.io/alukiano/origin-baremetal-machine-controllers:v4.0.0",
   "machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0"
 }


### PR DESCRIPTION
Adding bare-metal actuator, currently, bare-metal actuator only gives the possibility to fence bare metal nodes via IPMI interface(uses fence-agents), we still do not support provisioning of the bare-metal hosts.

TODO:
- [x] add unit tests

I can see that libvirt provider does not have e2e tests under the repository, I believe it due to the fact that current `installer` supports only `aws` deployment, I prefer to leave integration tests until we will baremetal support under the installer

KubeVirt project needs this PR to provide fencing logic on top of the OpenShift