### PR TITLE
Revert "Support both providerConfig and providerSpec under machine CRD's"

### DIFF
--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -22,75 +22,40 @@ spec:
         metadata:
           type: object
         spec:
-          anyOf:
-          - type: object
-            properties:
-              configSource:
-                type: object
-              metadata:
-                type: object
-              providerSpec:
-                properties:
-                  value:
-                    type: object
-                  valueFrom:
-                    properties:
-                      machineClass:
-                        properties:
-                          provider:
-                            type: string
-                        type: object
-                    type: object
-                type: object
-              taints:
-                items:
+          properties:
+            configSource:
+              type: object
+            metadata:
+              type: object
+            providerConfig:
+              properties:
+                value:
                   type: object
-                type: array
-              versions:
-                properties:
-                  controlPlane:
-                    type: string
-                  kubelet:
-                    type: string
-                required:
-                - kubelet
-                type: object
-            required:
-            - providerSpec
-          - type: object
-            properties:
-              configSource:
-                type: object
-              metadata:
-                type: object
-              providerConfig:
-                properties:
-                  value:
-                    type: object
-                  valueFrom:
-                    properties:
-                      machineClass:
-                        properties:
-                          provider:
-                            type: string
-                        type: object
-                    type: object
-                type: object
-              taints:
-                items:
+                valueFrom:
+                  properties:
+                    machineClass:
+                      properties:
+                        provider:
+                          type: string
+                      type: object
                   type: object
-                type: array
-              versions:
-                properties:
-                  controlPlane:
-                    type: string
-                  kubelet:
-                    type: string
-                required:
-                - kubelet
+              type: object
+            taints:
+              items:
                 type: object
-            required:
-            - providerConfig
+              type: array
+            versions:
+              properties:
+                controlPlane:
+                  type: string
+                kubelet:
+                  type: string
+              required:
+              - kubelet
+              type: object
+          required:
+          - providerConfig
+          type: object
         status:
           properties:
             addresses:

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -26,7 +26,6 @@ spec:
         metadata:
           type: object
         spec:
-          type: object
           properties:
             minReadySeconds:
               format: int32
@@ -37,82 +36,48 @@ spec:
             selector:
               type: object
             template:
-              type: object
               properties:
                 metadata:
                   type: object
                 spec:
-                  anyOf:
-                  - type: object
-                    properties:
-                      configSource:
-                        type: object
-                      metadata:
-                        type: object
-                      providerSpec:
-                        properties:
-                          value:
-                            type: object
-                          valueFrom:
-                            properties:
-                              machineClass:
-                                properties:
-                                  provider:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      taints:
-                        items:
+                  properties:
+                    configSource:
+                      type: object
+                    metadata:
+                      type: object
+                    providerConfig:
+                      properties:
+                        value:
                           type: object
-                        type: array
-                      versions:
-                        properties:
-                          controlPlane:
-                            type: string
-                          kubelet:
-                            type: string
-                        required:
-                        - kubelet
-                        type: object
-                    required:
-                    - providerSpec
-                  - type: object
-                    properties:
-                      configSource:
-                        type: object
-                      metadata:
-                        type: object
-                      providerConfig:
-                        properties:
-                          value:
-                            type: object
-                          valueFrom:
-                            properties:
-                              machineClass:
-                                properties:
-                                  provider:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      taints:
-                        items:
+                        valueFrom:
+                          properties:
+                            machineClass:
+                              properties:
+                                provider:
+                                  type: string
+                              type: object
                           type: object
-                        type: array
-                      versions:
-                        properties:
-                          controlPlane:
-                            type: string
-                          kubelet:
-                            type: string
-                        required:
-                        - kubelet
+                      type: object
+                    taints:
+                      items:
                         type: object
-                    required:
-                    - providerConfig
+                      type: array
+                    versions:
+                      properties:
+                        controlPlane:
+                          type: string
+                        kubelet:
+                          type: string
+                      required:
+                      - kubelet
+                      type: object
+                  required:
+                  - providerConfig
+                  type: object
+              type: object
           required:
           - selector
+          type: object
         status:
           properties:
             availableReplicas:

--- a/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
+++ b/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
@@ -26,7 +26,6 @@ spec:
         metadata:
           type: object
         spec:
-          type: object
           properties:
             minReadySeconds:
               format: int32
@@ -55,83 +54,49 @@ spec:
                   type: string
               type: object
             template:
-              type: object
               properties:
                 metadata:
                   type: object
                 spec:
-                  anyOf:
-                  - type: object
-                    properties:
-                      configSource:
-                        type: object
-                      metadata:
-                        type: object
-                      providerSpec:
-                        properties:
-                          value:
-                            type: object
-                          valueFrom:
-                            properties:
-                              machineClass:
-                                properties:
-                                  provider:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      taints:
-                        items:
+                  properties:
+                    configSource:
+                      type: object
+                    metadata:
+                      type: object
+                    providerConfig:
+                      properties:
+                        value:
                           type: object
-                        type: array
-                      versions:
-                        properties:
-                          controlPlane:
-                            type: string
-                          kubelet:
-                            type: string
-                        required:
-                        - kubelet
-                        type: object
-                    required:
-                    - providerSpec
-                  - type: object
-                    properties:
-                      configSource:
-                        type: object
-                      metadata:
-                        type: object
-                      providerConfig:
-                        properties:
-                          value:
-                            type: object
-                          valueFrom:
-                            properties:
-                              machineClass:
-                                properties:
-                                  provider:
-                                    type: string
-                                type: object
-                            type: object
-                        type: object
-                      taints:
-                        items:
+                        valueFrom:
+                          properties:
+                            machineClass:
+                              properties:
+                                provider:
+                                  type: string
+                              type: object
                           type: object
-                        type: array
-                      versions:
-                        properties:
-                          controlPlane:
-                            type: string
-                          kubelet:
-                            type: string
-                        required:
-                        - kubelet
+                      type: object
+                    taints:
+                      items:
                         type: object
-                    required:
-                    - providerConfig
+                      type: array
+                    versions:
+                      properties:
+                        controlPlane:
+                          type: string
+                        kubelet:
+                          type: string
+                      required:
+                      - kubelet
+                      type: object
+                  required:
+                  - providerConfig
+                  type: object
+              type: object
           required:
           - selector
           - template
+          type: object
         status:
           properties:
             availableReplicas:

--- a/install/0000_50_machine-api-operator_06_machineclass.crd.yaml
+++ b/install/0000_50_machine-api-operator_06_machineclass.crd.yaml
@@ -12,29 +12,17 @@ spec:
   scope: Namespaced
   validation:
     openAPIV3Schema:
-      anyOf:
-      - properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          providerSpec:
-            type: object
-        required:
-        - providerSpec
-      - properties:
-          apiVersion:
-            type: string
-          kind:
-            type: string
-          metadata:
-            type: object
-          providerConfig:
-            type: object
-        required:
-        - providerConfig
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        providerConfig:
+          type: object
+      required:
+      - providerConfig
   version: v1alpha1
 status:
   acceptedNames:


### PR DESCRIPTION
Reverts openshift/machine-api-operator#155 and keeps only the providerSpec field.