### PR TITLE
Add CLI printer columns for machine, machinesets

### DIFF
--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -5,6 +5,30 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: machines.cluster.k8s.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.providerStatus.instanceId
+    name: Instance
+    description: Instance ID of machine created in AWS
+    type: string
+  - JSONPath: .status.providerStatus.instanceState
+    name: State
+    description: State of the AWS instance
+    type: string
+  - JSONPath: .spec.providerSpec.value.instanceType
+    name: Type
+    description: Type of instance
+    type: string
+  - JSONPath: .spec.providerSpec.value.placement.region
+    name: Region
+    description: Region associated with machine
+    type: string
+  - JSONPath: .spec.providerSpec.value.placement.availabilityZone
+    name: Zone
+    description: Zone associated with machine
+    type: string
+  - JSONPath: .metadata.creationTimestamp    
+    name: Age
+    type: date
   group: cluster.k8s.io
   names:
     kind: Machine

--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -26,7 +26,7 @@ spec:
     name: Zone
     description: Zone associated with machine
     type: string
-  - JSONPath: .metadata.creationTimestamp    
+  - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date
   group: cluster.k8s.io

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: machinesets.cluster.k8s.io
-spec:  
+spec:
   group: cluster.k8s.io
   names:
     kind: MachineSet
@@ -119,7 +119,7 @@ spec:
   - JSONPath: .status.availableReplicas
     name: Available
     description: Observed number of available replicas
-    type: string    
+    type: string
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
   name: machinesets.cluster.k8s.io
-spec:
+spec:  
   group: cluster.k8s.io
   names:
     kind: MachineSet
@@ -116,6 +116,10 @@ spec:
     description: Ready Replicas
     name: Ready
     type: integer
+  - JSONPath: .status.availableReplicas
+    name: Available
+    description: Observed number of available replicas
+    type: string    
   - JSONPath: .metadata.creationTimestamp
     name: Age
     type: date


### PR DESCRIPTION
This adds pretty printers when rendering tables in CLI.

Machines
```sh
oc get machines -n openshift-cluster-api
NAME                                 INSTANCE              STATE     TYPE       REGION      ZONE         AGE
decarr-dev-master-0                  i-0c5c6028992720b04   running   m4.large   us-east-2   us-east-2a   4h
```

MachineSets
```sh
oc get machinesets -n openshift-cluster-api
NAME                           DESIRED   CURRENT   READY     AVAILABLE   AGE
decarr-dev-worker-us-east-2a   1         1         1         1           4h
```