### PR TITLE
Require providerSpec field to be always set

### DIFF
--- a/install/0000_50_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_50_machine-api-operator_02_machine.crd.yaml
@@ -65,6 +65,11 @@ spec:
                       type: object
                   type: object
               type: object
+              oneOf:
+              - required:
+                - value
+              - required:
+                - valueFrom
             taints:
               items:
                 type: object

--- a/install/0000_50_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_50_machine-api-operator_03_machineset.crd.yaml
@@ -61,6 +61,11 @@ spec:
                               type: object
                           type: object
                       type: object
+                      oneOf:
+                      - required:
+                        - value
+                      - required:
+                        - valueFrom
                     taints:
                       items:
                         type: object

--- a/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
+++ b/install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml
@@ -79,6 +79,11 @@ spec:
                               type: object
                           type: object
                       type: object
+                      oneOf:
+                      - required:
+                        - value
+                      - required:
+                        - valueFrom
                     taints:
                       items:
                         type: object


### PR DESCRIPTION
Machines with no provider spec set have no use in a cluster (up to testing purposes). We need to make sure at least one of Value or ValueFrom fields is set. To avoid the case where:
1. a machine with a valid provider spec field is set
2. underlying cloud provider instance is created
3. the machine provider spec field is edited/cleared (for any reason) leaving empty provider spec
4. the machine is deleted without removing the underlying instance due to missing provider spec

Right now, any machine object without provider spec field set can not be removed since the aws actuator complains about missing `ProviderSpec.Value` and `ProviderSpec.ValueFrom` fields missing. Though, it's not an option to remove machines without provider spec set and potentially leaving dangling instance(s).

Upstream PR: https://github.com/kubernetes-sigs/cluster-api/pull/684