### PR TITLE
Update links to different CRD's in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ However you can run it in a vanilla Kubernetes cluster by precreating some asset
 
 - Create a `openshift-machine-api-operator` namespace
 - Create a [CRD Status definition](test/integration/manifests/status-crd.yaml)
-- Create a [CRD Machine definition](test/integration/manifests/0000_50_machine-api-operator_02_machine.crd.yaml)
-- Create a [CRD MachineSet definition](test/integration/manifests/0000_50_machine-api-operator_03_machineset.crd.yaml)
-- Create a [CRD MachineDeployment definition](test/integration/manifests/0000_50_machine-api-operator_04_machinedeployment.crd.yaml)
-- Create a [CRD Cluster definition](test/integration/manifests/0000_50_machine-api-operator_05_cluster.crd.yaml)
+- Create a [CRD Machine definition](install/0000_50_machine-api-operator_02_machine.crd.yaml)
+- Create a [CRD MachineSet definition](install/0000_50_machine-api-operator_03_machineset.crd.yaml)
+- Create a [CRD MachineDeployment definition](install/0000_50_machine-api-operator_04_machinedeployment.crd.yaml)
+- Create a [CRD Cluster definition](install/0000_50_machine-api-operator_05_cluster.crd.yaml)
 - Create a [Installer config](test/integration/manifests/install-config.yaml)
 - Then you can run it as a [deployment](install/0000_50_machine-api-operator_08_deployment.yaml)
 - You should then be able to deploy a [cluster](test/integration/manifests/cluster.yaml) and a [machineSet](test/integration/manifests/machineset.yaml) object


### PR DESCRIPTION
Right now if someone wants to try out that `Dev` workflow he/she need to first go to the current links which are part of test directory but those contains the symlink to actual file which is not intuitive.