### PR TITLE
add back controllers using latest provider image so using machine.openshift.io

### DIFF
--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -35,6 +35,32 @@ spec:
         key: node.alpha.kubernetes.io/unreachable
         operator: Exists
       containers:
+      - name: controller-manager
+        image: {{ .Controllers.Provider }}
+        command:
+          - "./manager"
+        args:
+          - --logtostderr=true
+          - --v=3
+        resources:
+          requests:
+            cpu: 100m
+            memory: 20Mi
+          limits:
+            cpu: 100m
+            memory: 30Mi
+      - name: machine-controller
+        image: {{ .Controllers.Provider }}
+        env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+        command:
+          - /machine-controller-manager
+        args:
+          - --logtostderr=true
+          - --v=3
       - name: controller-manager-deprecated
         image: {{ .Controllers.ProviderDeprecated }}
         command:


### PR DESCRIPTION
- Add back controllers using latest provider image so using machine.openshift.io https://github.com/openshift/cluster-api-provider-aws/pull/147
- We have now all controllers for `cluster.k8s.io` and `machine.openshift.io`