### PR TITLE
openstack: Add the deprecated controller image

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -215,6 +215,11 @@ func (optr *Operator) maoConfigFromInstallConfig() (*OperatorConfig, error) {
 	switch provider {
 	case AWSProvider:
 		providerDreprecatedControllerImage = images.ClusterAPIControllerAWSDeprecated
+	case OpenStackProvider:
+		// NOTE: OpenStack does not have a deprecated image, but the
+		// `clusterapi-manager-controllers` template requires this
+		// field to be set
+		providerDreprecatedControllerImage = images.ClusterAPIControllerOpenStack
 	case LibvirtProvider:
 		providerDreprecatedControllerImage = images.ClusterAPIControllerLibvirtDeprecated
 	}


### PR DESCRIPTION
The `machine-api-operator` pod was failing on OpenStack because the
`.Controllers.ProviderDeprecated` value was set to an empty string.

This makes sure that value is set for OpenStack as well to fix the
actuator coming up.