### PR TITLE
Add AWS credentials request.

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -1,0 +1,32 @@
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: aws-cloud-credentials
+    namespace: openshift-machine-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - ec2:DescribeImages
+      - ec2:DescribeVpcs
+      - ec2:DescribeSubnets
+      - ec2:DescribeAvailabilityZones
+      - ec2:DescribeSecurityGroups
+      - ec2:RunInstances
+      - ec2:DescribeInstances
+      - ec2:TerminateInstances
+      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+      - elasticloadbalancing:DescribeLoadBalancers
+      - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:RegisterTargets
+      - iam:PassRole
+      resource: "*"
+---


### PR DESCRIPTION
This is not currently used by the actuators but does get used by
installer for pre-flight checking of permissions (soon). When ready to
start using your fine grained credential it will be defined here and
under your control.