### PR TITLE
Deploy components into openshift-machine-api namespace

### DIFF
--- a/cmd/machine-api-operator/main.go
+++ b/cmd/machine-api-operator/main.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	componentName      = "machine-api-operator"
-	componentNamespace = "openshift-cluster-api"
+	componentNamespace = "openshift-machine-api"
 )
 
 var (

--- a/install/0000_30_machine-api-operator_00_namespace_cluster-api.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace_cluster-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-machine-api
+  name: openshift-cluster-api
   labels:
-    name: openshift-machine-api
+    name: openshift-cluster-api
     openshift.io/run-level: "1"

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: machine-api-operator-images
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 data:
   images.json: '{"machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0", "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0", "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"}'

--- a/install/0000_30_machine-api-operator_13_rbac.yaml
+++ b/install/0000_30_machine-api-operator_13_rbac.yaml
@@ -2,11 +2,11 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-openshift-cluster-api
+  name: default-account-openshift-machine-api
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/install/0000_30_machine-api-operator_14_deployment.yaml
+++ b/install/0000_30_machine-api-operator_14_deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: machine-api-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   labels:
     k8s-app: machine-api-operator
 spec:

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	namespace = "openshift-cluster-api"
+	deprecatedNamespace = "openshift-cluster-api"
+	namespace           = "openshift-machine-api"
 )
 
 func init() {

--- a/test/e2e/operator_expectations.go
+++ b/test/e2e/operator_expectations.go
@@ -53,7 +53,7 @@ func (tc *testConfig) ExpectOperatorAvailable() error {
 
 func (tc *testConfig) ExpectNoClusterObject() error {
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 	}
 	clusterList := mapiv1beta1.ClusterList{}
 
@@ -96,7 +96,7 @@ func (tc *testConfig) ExpectClusterOperatorStatusAvailable() error {
 func (tc *testConfig) ExpectAllMachinesLinkedToANode() error {
 	machineAnnotationKey := "machine.openshift.io/machine"
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 	}
 	machineList := mapiv1beta1.MachineList{}
 	nodeList := corev1.NodeList{}
@@ -128,7 +128,7 @@ func (tc *testConfig) ExpectAllMachinesLinkedToANode() error {
 				return false, nil
 			}
 			nodeName := machine.Status.NodeRef.Name
-			if nodeNameToMachineAnnotation[nodeName] != fmt.Sprintf("%s/%s", namespace, machine.Name) {
+			if nodeNameToMachineAnnotation[nodeName] != fmt.Sprintf("%s/%s", deprecatedNamespace, machine.Name) {
 				glog.Errorf("node name %s does not match expected machine name %s, retrying...", nodeName, machine.Name)
 				return false, nil
 			}
@@ -185,7 +185,7 @@ func (tc *testConfig) ExpectReconcileControllersDeployment() error {
 func (tc *testConfig) ExpectAdditiveReconcileMachineTaints() error {
 	glog.Info("Verify machine taints are getting applied to node")
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 	}
 	machineList := mapiv1beta1.MachineList{}
 
@@ -201,7 +201,7 @@ func (tc *testConfig) ExpectAdditiveReconcileMachineTaints() error {
 	glog.Infof("Got the machine, %s", machine.Name)
 	nodeName := machine.Status.NodeRef.Name
 	nodeKey := types.NamespacedName{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 		Name:      nodeName,
 	}
 	node := &corev1.Node{}
@@ -253,7 +253,7 @@ func (tc *testConfig) ExpectAdditiveReconcileMachineTaints() error {
 
 func (tc *testConfig) ExpectNewNodeWhenDeletingMachine() error {
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 	}
 	machineList := mapiv1beta1.MachineList{}
 	nodeList := corev1.NodeList{}
@@ -358,7 +358,7 @@ MachineLoop:
 // Ensure initial number of replicas and nodes
 func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	listOptions := client.ListOptions{
-		Namespace: namespace,
+		Namespace: deprecatedNamespace,
 	}
 	glog.Info("Get one machineSet")
 	machineSetList := mapiv1beta1.MachineSetList{}
@@ -386,7 +386,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	clusterAutoscaler := caov1alpha1.ClusterAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "default",
-			Namespace: namespace,
+			Namespace: deprecatedNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ClusterAutoscaler",
@@ -396,7 +396,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	machineAutoscaler := caov1alpha1.MachineAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("autoscale-%s", targetMachineSet.Name),
-			Namespace:    namespace,
+			Namespace:    deprecatedNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "MachineAutoscaler",
@@ -462,7 +462,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	workLoad := batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "workload",
-			Namespace: namespace,
+			Namespace: deprecatedNamespace,
 		},
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Job",
@@ -510,7 +510,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	glog.Info("Wait for cluster to scale out number of replicas")
 	err = wait.PollImmediate(1*time.Second, waitLong, func() (bool, error) {
 		msKey := types.NamespacedName{
-			Namespace: namespace,
+			Namespace: deprecatedNamespace,
 			Name:      targetMachineSet.Name,
 		}
 		ms := &mapiv1beta1.MachineSet{}
@@ -578,7 +578,7 @@ func (tc *testConfig) ExpectAutoscalerScalesOut() error {
 	glog.Infof("Ensure initial number of replicas: %d", initialNumberOfReplicas)
 	err = wait.PollImmediate(1*time.Second, waitShort, func() (bool, error) {
 		msKey := types.NamespacedName{
-			Namespace: namespace,
+			Namespace: deprecatedNamespace,
 			Name:      targetMachineSet.Name,
 		}
 		ms := &mapiv1beta1.MachineSet{}

--- a/test/integration/generate.sh
+++ b/test/integration/generate.sh
@@ -7,7 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: aws-credentials-secret
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 type: Opaque
 data:
   awsAccessKeyId: $(echo -n $(aws configure get aws_access_key_id) | base64)

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -38,7 +38,7 @@ const (
 	timeoutPoolMachineSetRunningInterval    = 10 * time.Minute
 
 	defaultLogLevel          = "info"
-	targetNamespace          = "openshift-cluster-api"
+	targetNamespace          = "openshift-machine-api"
 	awsCredentialsSecretName = "aws-credentials-secret"
 	region                   = "us-east-1"
 	machineSetReplicas       = 2

--- a/test/integration/manifests/cluster.yaml
+++ b/test/integration/manifests/cluster.yaml
@@ -2,7 +2,7 @@ apiVersion: machine.openshift.io/v1beta1
 kind: Cluster
 metadata:
   name: {{ .ClusterID }}
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 spec:
   clusterNetwork:
     pods:

--- a/test/integration/manifests/ign-config.yaml
+++ b/test/integration/manifests/ign-config.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ignition-worker
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 type: Opaque
 data:
   userData: ""

--- a/test/integration/manifests/images.configmap.yaml
+++ b/test/integration/manifests/images.configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: machine-api-operator-images
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 data:
   images.json: '{
 	"clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",

--- a/test/integration/manifests/machineset.yaml
+++ b/test/integration/manifests/machineset.yaml
@@ -6,7 +6,7 @@ metadata:
     sigs.k8s.io/cluster-api-machine-role: worker
     sigs.k8s.io/cluster-api-machine-type: worker
   name: worker
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 spec:
   replicas: 2
   selector:

--- a/test/integration/manifests/operator-deployment.yaml
+++ b/test/integration/manifests/operator-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: machine-api-operator
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
   labels:
     k8s-app: machine-api-operator
 spec:

--- a/test/integration/manifests/rbac.yaml
+++ b/test/integration/manifests/rbac.yaml
@@ -2,11 +2,11 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-openshift-cluster-api
+  name: default-account-openshift-machine-api
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: openshift-cluster-api
+  namespace: openshift-machine-api
 roleRef:
   kind: ClusterRole
   name: cluster-admin


### PR DESCRIPTION
Create openshift-machine-api namespace
Deploy components into openshift-machine-api namespace
Once this get merged we can update the namespace of the machines run by the installer https://github.com/openshift/installer/pull/1215
