### PR TITLE
Get node unhealthy conditions from the ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,22 @@ $ make nodelink-controller
            machine.openshift.io/cluster-api-machineset: cluster-worker-us-east-1a
      ```
 
+  1. By default, the machine health check controller recognize only `NotReady` condition and will remove
+     unhealthy machine after 5 minutes. If you want to customize unhealthy conditions you can create `node-unhealthy-conditions` config map, for example:
+     ```yaml
+     apiVersion: v1
+     kind: ConfigMap
+     metadata:
+       name: node-unhealthy-conditions
+       namespace: openshift-machine-api
+     data:
+       conditions: |
+         items:
+         - name: NetworkUnavailable 
+           timeout: 5m
+           status: True
+     ```
+  
   1. Pick a node that is managed by one of the machineset's machines
   1. SSH into the node, disable and stop the kubelet services:
      ```

--- a/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
@@ -4,6 +4,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// ConfigMapNodeUnhealthyConditions contains the name of the unhealthy conditions config map
+const ConfigMapNodeUnhealthyConditions = "node-unhealthy-conditions"
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 

--- a/pkg/util/conditions/conditions.go
+++ b/pkg/util/conditions/conditions.go
@@ -1,0 +1,79 @@
+package conditions
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+	"github.com/golang/glog"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// GetNodeCondition returns node condition by type
+func GetNodeCondition(node *corev1.Node, conditionType corev1.NodeConditionType) *corev1.NodeCondition {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
+}
+
+// UnhealthyConditions contains a list of UnhealthyCondition
+type UnhealthyConditions struct {
+	Items []UnhealthyCondition `json:"items"`
+}
+
+// UnhealthyCondition is the representation of unhealthy conditions under the config map
+type UnhealthyCondition struct {
+	Name    corev1.NodeConditionType `json:"name"`
+	Status  corev1.ConditionStatus   `json:"status"`
+	Timeout string                   `json:"timeout"`
+}
+
+// GetNodeUnhealthyConditions returns node unhealthy conditions
+func GetNodeUnhealthyConditions(node *corev1.Node, cmUnealthyConditions *corev1.ConfigMap) ([]UnhealthyCondition, error) {
+	data, ok := cmUnealthyConditions.Data["conditions"]
+	if !ok {
+		return nil, fmt.Errorf("can not find \"conditions\" under the configmap")
+	}
+
+	var unealthyConditions UnhealthyConditions
+	err := yaml.Unmarshal([]byte(data), &unealthyConditions)
+	if err != nil {
+		glog.Errorf("failed to umarshal: %v", err)
+		return nil, err
+	}
+
+	conditions := []UnhealthyCondition{}
+	for _, c := range unealthyConditions.Items {
+		cond := GetNodeCondition(node, c.Name)
+		if cond != nil && cond.Status == c.Status {
+			conditions = append(conditions, c)
+		}
+	}
+	return conditions, nil
+}
+
+// CreateDummyUnhealthyConditionsConfigMap creates dummy config map with default unhealthy conditions
+func CreateDummyUnhealthyConditionsConfigMap() (*corev1.ConfigMap, error) {
+	unhealthyConditions := &UnhealthyConditions{
+		Items: []UnhealthyCondition{
+			{
+				Name:    "Ready",
+				Status:  "Unknown",
+				Timeout: "300s",
+			},
+			{
+				Name:    "Ready",
+				Status:  "False",
+				Timeout: "300s",
+			},
+		},
+	}
+	conditionsData, err := yaml.Marshal(unhealthyConditions)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.ConfigMap{Data: map[string]string{"conditions": string(conditionsData)}}, nil
+}

--- a/pkg/util/conditions/conditions_test.go
+++ b/pkg/util/conditions/conditions_test.go
@@ -1,0 +1,196 @@
+package conditions
+
+import (
+	"reflect"
+	"testing"
+
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	namespace   = "openshift-machine-api"
+	correctData = `items:
+- name: Ready 
+  timeout: 60s
+  status: Unknown`
+	unrelatedConditionData = `items:
+- name: Unrelated 
+  timeout: 60s
+  status: Unknown`
+	unrelatedStatusData = `items:
+- name: Ready 
+  timeout: 60s
+  status: Unrelated`
+)
+
+type expectedConditions struct {
+	conditions []UnhealthyCondition
+	error      bool
+}
+
+func node(name string, ready bool) *v1.Node {
+	nodeReadyStatus := corev1.ConditionTrue
+	if !ready {
+		nodeReadyStatus = corev1.ConditionUnknown
+	}
+
+	return &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceNone,
+			Labels:    map[string]string{},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Node",
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:   corev1.NodeReady,
+					Status: nodeReadyStatus,
+				},
+			},
+		},
+	}
+}
+
+func configMap(name string, data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		Data: data,
+	}
+}
+func TestGetNodeUnhealthyConditions(t *testing.T) {
+	nodeHealthy := node("nodeHealthy", true)
+	nodeRecentlyUnhealthy := node("nodeRecentlyUnhealthy", false)
+
+	cmWithoutConditions := configMap(
+		healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		map[string]string{
+			"noconditions": "",
+		},
+	)
+	cmWithBadData := configMap(
+		healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		map[string]string{
+			"conditions": "unparsed-data",
+		},
+	)
+	cmWithUnrelatedCondition := configMap(
+		healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		map[string]string{
+			"conditions": unrelatedConditionData,
+		},
+	)
+	cmWithUnrelatedConditionStatus := configMap(
+		healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		map[string]string{
+			"conditions": unrelatedStatusData,
+		},
+	)
+	cmWithCorrectData := configMap(
+		healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		map[string]string{
+			"conditions": correctData,
+		},
+	)
+
+	testsCases := []struct {
+		name     string
+		node     *corev1.Node
+		cm       *corev1.ConfigMap
+		expected expectedConditions
+	}{
+		{
+			name: "healthy node",
+			node: nodeHealthy,
+			cm:   cmWithCorrectData,
+			expected: expectedConditions{
+				conditions: []UnhealthyCondition{},
+				error:      false,
+			},
+		},
+		{
+			name: "unhealthy node",
+			node: nodeRecentlyUnhealthy,
+			cm:   cmWithCorrectData,
+			expected: expectedConditions{
+				conditions: []UnhealthyCondition{
+					{
+						Name:    "Ready",
+						Timeout: "60s",
+						Status:  "Unknown",
+					},
+				},
+				error: false,
+			},
+		},
+		{
+			name: "configmap without conditions",
+			node: nodeRecentlyUnhealthy,
+			cm:   cmWithoutConditions,
+			expected: expectedConditions{
+				conditions: nil,
+				error:      true,
+			},
+		},
+		{
+			name: "configmap with bad data",
+			node: nodeRecentlyUnhealthy,
+			cm:   cmWithBadData,
+			expected: expectedConditions{
+				conditions: nil,
+				error:      true,
+			},
+		},
+		{
+			name: "configmap with unrelated condition",
+			node: nodeRecentlyUnhealthy,
+			cm:   cmWithUnrelatedCondition,
+			expected: expectedConditions{
+				conditions: []UnhealthyCondition{},
+				error:      false,
+			},
+		},
+		{
+			name: "configmap with unrelated condition status",
+			node: nodeRecentlyUnhealthy,
+			cm:   cmWithUnrelatedConditionStatus,
+			expected: expectedConditions{
+				conditions: []UnhealthyCondition{},
+				error:      false,
+			},
+		},
+	}
+
+	for _, tc := range testsCases {
+		conditions, err := GetNodeUnhealthyConditions(tc.node, tc.cm)
+		if tc.expected.error != (err != nil) {
+			var errorExpectation string
+			if !tc.expected.error {
+				errorExpectation = "no"
+			}
+			t.Errorf("Test case: %s. Expected %s error, got: %v", tc.name, errorExpectation, err)
+		}
+
+		numOfConditions := len(conditions)
+		expectedNumOfConditions := len(tc.expected.conditions)
+		if numOfConditions != expectedNumOfConditions {
+			t.Errorf("Test case: %s. Expected number of conditions %d ,got: %d", tc.name, expectedNumOfConditions, numOfConditions)
+		}
+
+		if !reflect.DeepEqual(tc.expected.conditions, conditions) {
+			t.Errorf("Test case: %s. Expected %s conditions, got: %s", tc.name, tc.expected.conditions, conditions)
+		}
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// ServiceAccountNamespaceFile contains path to the file that contains namespace
+const ServiceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+// GetNamespace returns the namespace of the pod where the code is running
+func GetNamespace(namespaceFile string) (string, error) {
+	data, err := ioutil.ReadFile(namespaceFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine namespace from %s: %v", namespaceFile, err)
+	}
+
+	return strings.TrimSpace(string(data)), nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,70 @@
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+type expectedNamespace struct {
+	namespace string
+	error     bool
+}
+
+func createNamespaceFile(t *testing.T, content []byte) string {
+	tmpfile, err := ioutil.TempFile("", "namespace")
+	if err != nil {
+		t.Error(err)
+	}
+
+	if _, err := tmpfile.Write(content); err != nil {
+		t.Error(err)
+	}
+	if err := tmpfile.Close(); err != nil {
+		t.Error(err)
+	}
+	return tmpfile.Name()
+}
+
+func TestGetNamespace(t *testing.T) {
+	nsFile := createNamespaceFile(t, []byte("default"))
+	defer os.Remove(nsFile)
+
+	testsCases := []struct {
+		name          string
+		namespaceFile string
+		expected      expectedNamespace
+	}{
+		{
+			name:          "namespace file exists",
+			namespaceFile: nsFile,
+			expected: expectedNamespace{
+				namespace: "default",
+				error:     false,
+			},
+		},
+		{
+			name:          "namespace file does not exist",
+			namespaceFile: "notexist",
+			expected: expectedNamespace{
+				namespace: "",
+				error:     true,
+			},
+		},
+	}
+
+	for _, tc := range testsCases {
+		ns, err := GetNamespace(tc.namespaceFile)
+		if tc.expected.error != (err != nil) {
+			var errorExpectation string
+			if !tc.expected.error {
+				errorExpectation = "no"
+			}
+			t.Errorf("Test case: %s. Expected %s error, got: %v", tc.name, errorExpectation, err)
+		}
+
+		if tc.expected.namespace != ns {
+			t.Errorf("Test case: %s. Expected %s namespace, got: %s", tc.name, tc.expected.namespace, ns)
+		}
+	}
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
@@ -41,7 +41,7 @@ vet: ## Apply go vet to all go files
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
-	go test -timeout 60m \
+	go test -timeout 90m \
 		-v github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
 		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
 		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/e2e_test.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/e2e_test.go
@@ -10,11 +10,13 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	caov1alpha1 "github.com/openshift/cluster-autoscaler-operator/pkg/apis"
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 	"k8s.io/client-go/kubernetes/scheme"
 
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/actuators"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/autoscaler"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/infra"
+	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck"
 	_ "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators"
 )
 
@@ -28,6 +30,10 @@ func init() {
 	}
 
 	if err := osconfigv1.AddToScheme(scheme.Scheme); err != nil {
+		glog.Fatal(err)
+	}
+
+	if err := healthcheckingv1alpha1.AddToScheme(scheme.Scheme); err != nil {
 		glog.Fatal(err)
 	}
 }

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/framework.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/framework.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/glog"
 
 	"github.com/openshift/cluster-api/pkg/client/clientset_generated/clientset"
+	healthcheckingclient "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -95,9 +96,11 @@ type SSHConfig struct {
 
 // Framework supports common operations used by tests
 type Framework struct {
-	KubeClient         *kubernetes.Clientset
-	CAPIClient         *clientset.Clientset
-	APIExtensionClient *apiextensionsclientset.Clientset
+	KubeClient           *kubernetes.Clientset
+	CAPIClient           *clientset.Clientset
+	APIExtensionClient   *apiextensionsclientset.Clientset
+	HealthCheckingClient *healthcheckingclient.Clientset
+
 	// APIRegistrationClient *apiregistrationclientset.Clientset
 	Kubeconfig string
 	RestConfig *rest.Config
@@ -204,6 +207,13 @@ func (f *Framework) buildClientsets() error {
 
 	if f.APIExtensionClient == nil {
 		f.APIExtensionClient, err = apiextensionsclientset.NewForConfig(f.RestConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	if f.HealthCheckingClient == nil {
+		f.HealthCheckingClient, err = healthcheckingclient.NewForConfig(f.RestConfig)
 		if err != nil {
 			return err
 		}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/machinehealthcheck.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/machinehealthcheck.go
@@ -1,0 +1,122 @@
+package framework
+
+import (
+	"context"
+
+	"github.com/ghodss/yaml"
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+	"github.com/openshift/machine-api-operator/pkg/util/conditions"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+const (
+	// KubeletKillerPodName contains the name of the pod that stops kubelet process
+	KubeletKillerPodName = "kubelet-killer"
+	// NodeWorkerLabel contains label that every worker node has
+	NodeWorkerLabel        = "node-role.kubernetes.io/worker"
+	// MachineHealthCheckName contains the name of the machinehealthcheck used for tests
+	MachineHealthCheckName = "workers-check"
+)
+
+// CreateUnhealthyConditionsConfigMap creates node-unhealthy-conditions configmap with relevant conditions
+func CreateUnhealthyConditionsConfigMap(unhealthyConditions *conditions.UnhealthyConditions) error {
+	client, err := LoadClient()
+	if err != nil {
+		return err
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: TestContext.MachineApiNamespace,
+			Name:      healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		},
+	}
+
+	conditionsData, err := yaml.Marshal(unhealthyConditions)
+	if err != nil {
+		return err
+	}
+
+	cm.Data = map[string]string{"conditions": string(conditionsData)}
+	return client.Create(context.TODO(), cm)
+}
+
+// DeleteUnhealthyConditionsConfigMap deletes node-unhealthy-conditions configmap
+func DeleteUnhealthyConditionsConfigMap() error {
+	client, err := LoadClient()
+	if err != nil {
+		return err
+	}
+
+	key := types.NamespacedName{
+		Name:      healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		Namespace: TestContext.MachineApiNamespace,
+	}
+	cm := &corev1.ConfigMap{}
+	err = client.Get(context.TODO(), key, cm)
+	if err != nil {
+		return err
+	}
+
+	return client.Delete(context.TODO(), cm)
+}
+
+// CreateMachineHealthCheck will create MachineHealthCheck CR with the relevant selector
+func CreateMachineHealthCheck(labels map[string]string) error {
+	client, err := LoadClient()
+	if err != nil {
+		return err
+	}
+
+	mhc := &healthcheckingv1alpha1.MachineHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MachineHealthCheckName,
+			Namespace: TestContext.MachineApiNamespace,
+		},
+		Spec: healthcheckingv1alpha1.MachineHealthCheckSpec{
+			Selector: metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		},
+	}
+	return client.Create(context.TODO(), mhc)
+}
+
+// StopKubelet creates pod in the node PID namespace that stops kubelet process
+func StopKubelet(nodeName string) error {
+	client, err := LoadClient()
+	if err != nil {
+		return err
+	}
+
+	_true := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      KubeletKillerPodName + rand.String(5),
+			Namespace: TestContext.MachineApiNamespace,
+			Labels: map[string]string{
+				KubeletKillerPodName: "",
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    KubeletKillerPodName,
+					Image:   "busybox",
+					Command: []string{"pkill", "-STOP", "hyperkube"},
+					SecurityContext: &corev1.SecurityContext{
+						Privileged: &_true,
+					},
+				},
+			},
+			NodeName: nodeName,
+			HostPID: true,
+		},
+	}
+	return client.Create(context.TODO(), pod)
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -1,0 +1,224 @@
+package machinehealthcheck
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/golang/glog"
+	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
+	mapiv1beta1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+	"github.com/openshift/machine-api-operator/pkg/util/conditions"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", func() {
+	var client runtimeclient.Client
+	var numberOfReadyWorkers int
+	var workerNode *corev1.Node
+	var workerMachine *mapiv1beta1.Machine
+
+	stopKubeletAndValidateMachineDeletion := func(workerNodeName *corev1.Node, workerMachine *mapiv1beta1.Machine, timeout time.Duration) {
+		By(fmt.Sprintf("Stopping kubelet service on the node %s", workerNode.Name))
+		err := e2e.StopKubelet(workerNode.Name)
+		Expect(err).ToNot(HaveOccurred())
+
+		By(fmt.Sprintf("Validating that node %s has 'NotReady' condition", workerNode.Name))
+		waitForNodeUnhealthyCondition(workerNode.Name)
+
+		By(fmt.Sprintf("Validating that machine %s is deleted", workerMachine.Name))
+		machine := &mapiv1beta1.Machine{}
+		key := types.NamespacedName{
+			Namespace: workerMachine.Namespace,
+			Name:      workerMachine.Name,
+		}
+		Eventually(func() bool {
+			err := client.Get(context.TODO(), key, machine)
+			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return true
+				}
+			}
+			return false
+		}, timeout, 5*time.Second).Should(BeTrue())
+	}
+
+	BeforeEach(func() {
+		var err error
+		client, err = e2e.LoadClient()
+		Expect(err).ToNot(HaveOccurred())
+
+		listOptions := runtimeclient.ListOptions{
+			Namespace: e2e.TestContext.MachineApiNamespace,
+		}
+		listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.NodeWorkerLabel))
+		workers := &corev1.NodeList{}
+		err = client.List(context.TODO(), &listOptions, workers)
+		Expect(err).ToNot(HaveOccurred())
+
+		numberOfReadyWorkers = 0
+		workerNode = nil
+		for i, w := range workers.Items {
+			readyCond := conditions.GetNodeCondition(&w, corev1.NodeReady)
+			if readyCond.Status == corev1.ConditionTrue {
+				numberOfReadyWorkers++
+				if workerNode == nil {
+					workerNode = &workers.Items[i]
+					glog.V(2).Infof("Worker node %s", workerNode.Name)
+				}
+			}
+		}
+		Expect(workerNode).ToNot(BeNil())
+
+		listOptions = runtimeclient.ListOptions{
+			Namespace: e2e.TestContext.MachineApiNamespace,
+		}
+		machineList := &mapiv1beta1.MachineList{}
+		err = client.List(context.TODO(), &listOptions, machineList)
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, m := range machineList.Items {
+			if m.Status.NodeRef != nil && m.Status.NodeRef.Name == workerNode.Name {
+				workerMachine = &m
+				glog.V(2).Infof("Worker machine %s", workerMachine.Name)
+			}
+		}
+		Expect(workerMachine).ToNot(BeNil())
+
+		glog.V(2).Infof("Create machine health check with label selector: %s", workerMachine.Labels)
+		err = e2e.CreateMachineHealthCheck(workerMachine.Labels)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Context("with node-unhealthy-conditions configmap", func() {
+		BeforeEach(func() {
+			unhealthyConditions := &conditions.UnhealthyConditions{
+				Items: []conditions.UnhealthyCondition{
+					{
+						Name:    "Ready",
+						Status:  "Unknown",
+						Timeout: "60s",
+					},
+				},
+			}
+			glog.V(2).Infof("Create node-unhealthy-conditions configmap")
+			err := e2e.CreateUnhealthyConditionsConfigMap(unhealthyConditions)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should delete unhealthy machine", func() {
+			stopKubeletAndValidateMachineDeletion(workerNode, workerMachine, 2*time.Minute)
+		})
+
+		AfterEach(func() {
+			glog.V(2).Infof("Delete node-unhealthy-conditions configmap")
+			err := e2e.DeleteUnhealthyConditionsConfigMap()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	It("should delete unhealthy machine", func() {
+		stopKubeletAndValidateMachineDeletion(workerNode, workerMachine, 6*time.Minute)
+	})
+
+	AfterEach(func() {
+		waitForWorkersToGetReady(numberOfReadyWorkers)
+		deleteMachineHealthCheck(e2e.MachineHealthCheckName)
+		deleteKubeletKillerPods()
+	})
+})
+
+func waitForNodeUnhealthyCondition(workerNodeName string) {
+	client, err := e2e.LoadClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	key := types.NamespacedName{
+		Name:      workerNodeName,
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	node := &corev1.Node{}
+	glog.Infof("Wait until node %s will have 'Ready' condition with the status %s", node.Name, corev1.ConditionUnknown)
+	Eventually(func() bool {
+		err := client.Get(context.TODO(), key, node)
+		if err != nil {
+			return false
+		}
+		readyCond := conditions.GetNodeCondition(node, corev1.NodeReady)
+		glog.V(2).Infof("Node %s has 'Ready' condition with the status %s", node.Name, readyCond.Status)
+		return readyCond.Status == corev1.ConditionUnknown
+	}, e2e.WaitLong, 10*time.Second).Should(BeTrue())
+}
+
+func waitForWorkersToGetReady(numberOfReadyWorkers int) {
+	client, err := e2e.LoadClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.NodeWorkerLabel))
+	workers := &corev1.NodeList{}
+	glog.V(2).Infof("Wait until the environment will have %d ready workers", numberOfReadyWorkers)
+	Eventually(func() bool {
+		err := client.List(context.TODO(), &listOptions, workers)
+		if err != nil {
+			return false
+		}
+
+		readyWorkers := 0
+		for _, w := range workers.Items {
+			readyCond := conditions.GetNodeCondition(&w, corev1.NodeReady)
+			if readyCond.Status == corev1.ConditionTrue {
+				readyWorkers++
+			}
+		}
+
+		glog.V(2).Infof("Number of ready workers %d", readyWorkers)
+		return readyWorkers == numberOfReadyWorkers
+	}, 15*time.Minute, 10*time.Second).Should(BeTrue())
+}
+
+func deleteMachineHealthCheck(healthcheckName string) {
+	client, err := e2e.LoadClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	key := types.NamespacedName{
+		Name:      healthcheckName,
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	healthcheck := &healthcheckingv1alpha1.MachineHealthCheck{}
+	err = client.Get(context.TODO(), key, healthcheck)
+	Expect(err).ToNot(HaveOccurred())
+
+	glog.V(2).Infof("Delete machine health check %s", healthcheck.Name)
+	err = client.Delete(context.TODO(), healthcheck)
+	Expect(err).ToNot(HaveOccurred())
+}
+
+func deleteKubeletKillerPods() {
+	client, err := e2e.LoadClient()
+	Expect(err).ToNot(HaveOccurred())
+
+	listOptions := runtimeclient.ListOptions{
+		Namespace: e2e.TestContext.MachineApiNamespace,
+	}
+	listOptions.SetLabelSelector(fmt.Sprintf("%s=", e2e.KubeletKillerPodName))
+	podList := &corev1.PodList{}
+	err = client.List(context.TODO(), &listOptions, podList)
+	Expect(err).ToNot(HaveOccurred())
+
+	for _, pod := range podList.Items {
+		glog.V(2).Infof("Delete kubelet killer pod %s", pod.Name)
+		err = client.Delete(context.TODO(), &pod)
+		Expect(err).ToNot(HaveOccurred())
+	}
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UTC().UnixNano())),
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}


### PR DESCRIPTION
ConfigMap includes node unhealthy conditions with condition status and timeout. The code will check if the node has the specific unhealthy condition more than condition timeout and if yes will delete the machine object.

ConfigMap has next structure:
```
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    noderecovery.kubevirt.io: ""
  name: node-unhealth-conditions
  namespace: openshift-machine-api
data:
  conditions: |
    items:
    - name: Ready 
      timeout: 60s  # support all duration units "ns", "us" (or "µs"), "ms", "s", "m", "h"
      status: Unknown
```