### PR TITLE
Stop reporting unavailable when progressing and add support for multiple operands status

### DIFF
--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -1,0 +1,27 @@
+package operator
+
+import (
+	"testing"
+
+	osconfigv1 "github.com/openshift/api/config/v1"
+)
+
+func TestPrintOperandVersions(t *testing.T) {
+	optr := Operator{
+		operandVersions: []osconfigv1.OperandVersion{
+			{
+				Name:    "operator",
+				Version: "1.0",
+			},
+			{
+				Name:    "controller-manager",
+				Version: "2.0",
+			},
+		},
+	}
+	expectedOutput := "operator: 1.0, controller-manager: 2.0"
+	got := optr.printOperandVersions()
+	if got != expectedOutput {
+		t.Errorf("Expected: %s, got: %s", expectedOutput, got)
+	}
+}

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -24,13 +24,13 @@ const (
 func (optr *Operator) syncAll(config OperatorConfig) error {
 	glog.Infof("Syncing ClusterOperatorStatus")
 
-	if err := optr.statusProgressing(ReasonSyncing, "Running sync functions"); err != nil {
+	if err := optr.statusProgressing(); err != nil {
 		glog.Errorf("Error synching ClusterOperatorStatus: %v", err)
 		return fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
 	}
 
 	if err := optr.syncClusterAPIController(config); err != nil {
-		if err := optr.statusFailing(ReasonSyncFailed, err.Error()); err != nil {
+		if err := optr.statusFailing(err.Error()); err != nil {
 			// Just log the error here.  We still want to
 			// return the outer error.
 			glog.Errorf("Error synching ClusterOperatorStatus: %v", err)
@@ -42,7 +42,7 @@ func (optr *Operator) syncAll(config OperatorConfig) error {
 
 	glog.Info("Synched up cluster api controller")
 
-	if err := optr.statusAvailable(ReasonEmpty, "cluster-api ready"); err != nil {
+	if err := optr.statusAvailable(); err != nil {
 		glog.Errorf("Error synching ClusterOperatorStatus: %v", err)
 		return fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
 	}

--- a/test/integration/main.go
+++ b/test/integration/main.go
@@ -423,7 +423,8 @@ var rootCmd = &cobra.Command{
 		// TESTS
 		// verify the cluster-api is running
 		err = wait.Poll(pollInterval, timeoutPoolClusterAPIDeploymentInterval, func() (bool, error) {
-			if clusterAPIDeployment, err := testConfig.KubeClient.AppsV1beta2().Deployments(targetNamespace).Get("clusterapi-manager-controllers", metav1.GetOptions{}); err == nil {
+			clusterAPIDeployment, err := testConfig.KubeClient.AppsV1beta2().Deployments(targetNamespace).Get("clusterapi-manager-controllers", metav1.GetOptions{})
+			if err == nil {
 				// Check all the pods are running
 				log.Infof("Waiting for all clusterapi-manager-controllers deployment pods to be ready, have %v, expecting 1", clusterAPIDeployment.Status.ReadyReplicas)
 				if clusterAPIDeployment.Status.ReadyReplicas < 1 {
@@ -432,7 +433,7 @@ var rootCmd = &cobra.Command{
 				return true, nil
 			}
 
-			log.Info("Waiting for clusterapi-manager-controllers deployment to be created")
+			log.Infof("Waiting for clusterapi-manager-controllers deployment to be created: %v", err)
 			return false, nil
 		})
 

--- a/test/integration/manifests/status-crd.yaml
+++ b/test/integration/manifests/status-crd.yaml
@@ -30,8 +30,5 @@ spec:
   subresources:
     status: {}
   version: v1
-  versions:
-  - name: v1
-    served: true
 
 


### PR DESCRIPTION
Support for setting multiple operands in version dynamically
Stop setting `available=false` when `progressing`
Compare available (`status.Versions`) vs desired (`optr.Versions`)
Aligns with https://github.com/openshift/machine-config-operator/pull/351