### PR TITLE
Adding new reviewers beekhof and cynepco3hahue for health check controller

### DIFF
--- a/pkg/controller/machinehealthcheck/OWNERS
+++ b/pkg/controller/machinehealthcheck/OWNERS
@@ -1,0 +1,11 @@
+approvers:
+  - enxebre
+  - frobware
+  - ingvagabund
+  - bison
+reviewers:
+  - vikaschoudhary16
+  - paulfantom
+  - spangenberg
+  - beekhof
+  - cynepco3hahue


### PR DESCRIPTION
@beekhof @cynepco3hahue on CNV team are using the machine API Operator domain for building solutions for machine health checking on bare metal.
