### PR TITLE
Delete openshift-cluster-api namespace

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace_cluster-api.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace_cluster-api.yaml
@@ -1,7 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: openshift-cluster-api
-  labels:
-    name: openshift-cluster-api
-    openshift.io/run-level: "1"


### PR DESCRIPTION
Since
https://github.com/openshift/installer/pull/1245/files and
https://github.com/openshift/installer/pull/1246/files#diff-a25ec653fe393c89c4ccac5a1edfe38fR56
This can be dropped now