### PR TITLE
manifests: update resource requirements

### DIFF
--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -44,11 +44,8 @@ spec:
           - --v=3
         resources:
           requests:
-            cpu: 100m
+            cpu: 10m
             memory: 20Mi
-          limits:
-            cpu: 100m
-            memory: 30Mi
       - name: machine-controller
         image: {{ .Controllers.Provider }}
         env:
@@ -70,11 +67,8 @@ spec:
           - --v=3
         resources:
           requests:
-            cpu: 100m
+            cpu: 10m
             memory: 20Mi
-          limits:
-            cpu: 100m
-            memory: 30Mi
       - name: machine-healthcheck
         image: {{ .Controllers.MachineHealthCheck }}
         command:
@@ -84,8 +78,5 @@ spec:
           - --v=3
         resources:
           requests:
-            cpu: 100m
+            cpu: 10m
             memory: 20Mi
-          limits:
-            cpu: 100m
-            memory: 30Mi


### PR DESCRIPTION
Updated resource requirements with following guidelines:
- components that run on master nodes should never specify cpu limits as they introduce latency even when there is no resource contention
- components that run on master nodes should specify cpu requests relative to other components.  in this case, i have updated to 10m which means your component will get 1/10th CPU time as kube-controller-manager when there is contention on the node (which is appropriate given fewer controllers).
- removed usage of memory limits in favor of normal kubelet and kernel driven response to memory exhaustion (oom killer targets containers whose memory usage is greatest relative to request)

Cleanup related to smoke testing efforts in origin here:
https://github.com/openshift/origin/pull/22095
