### PR TITLE
Remove cluster e2e test since it's not relevant for actuator

### DIFF
--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -68,13 +68,6 @@ func runSuite() error {
 	}
 	glog.Info("PASS: ExpectOperatorAvailable")
 
-	glog.Info("RUN: ExpectNoClusterObject")
-	if err := testConfig.ExpectNoClusterObject(); err != nil {
-		glog.Errorf("FAIL: ExpectNoClusterObject: %v", err)
-		return err
-	}
-	glog.Info("PASS: ExpectOneClusterObject")
-
 	glog.Info("RUN: ExpectClusterOperatorStatusAvailable")
 	if err := testConfig.ExpectClusterOperatorStatusAvailable(); err != nil {
 		glog.Errorf("FAIL: ExpectClusterOperatorStatusAvailable: %v", err)

--- a/test/e2e/operator_expectations.go
+++ b/test/e2e/operator_expectations.go
@@ -51,25 +51,6 @@ func (tc *testConfig) ExpectOperatorAvailable() error {
 	return err
 }
 
-func (tc *testConfig) ExpectNoClusterObject() error {
-	listOptions := client.ListOptions{
-		Namespace: namespace,
-	}
-	clusterList := mapiv1beta1.ClusterList{}
-
-	err := wait.PollImmediate(1*time.Second, waitShort, func() (bool, error) {
-		if err := tc.client.List(context.TODO(), &listOptions, &clusterList); err != nil {
-			glog.Errorf("error querying api for clusterList object: %v, retrying...", err)
-			return false, nil
-		}
-		if len(clusterList.Items) > 0 {
-			return false, errors.New("a cluster object was found")
-		}
-		return true, nil
-	})
-	return err
-}
-
 func (tc *testConfig) ExpectClusterOperatorStatusAvailable() error {
 	name := "machine-api"
 	key := types.NamespacedName{


### PR DESCRIPTION
Since this [openshift/installer@37b25ea#diff-a25ec653fe393c89c4ccac5a1edfe38fL51](https://github.com/openshift/installer/commit/37b25ea64964ad0671e6f498b57646efe641ad6f#diff-a25ec653fe393c89c4ccac5a1edfe38fL51) got in the cluster obejct needs to exist however is circumstantial for the actuator and no need to validate it exist or not here. See https://jira.coreos.com/browse/CLOUD-357

https://github.com/openshift/cluster-api-provider-aws/pull/163