### PR TITLE
Allow for the openshift-api-manager role to create secrets

### DIFF
--- a/install/0000_30_machine-api-operator_08_rbac.yaml
+++ b/install/0000_30_machine-api-operator_08_rbac.yaml
@@ -89,6 +89,7 @@ rules:
       - get
       - list
       - watch
+      - create
 
   - apiGroups:
       - ""


### PR DESCRIPTION
This is required by the cluster-api-provider-openstack so it can create a secret containing a token that is used in the boot process. This secret is passed to the `userData` render step, which is a bit different from the way the `AWS` actuator does things.

I'm working with upstream to improve this requirement but it also feels like a sane default permission to have for this service account.