### PR TITLE
Add system-critical priority class to controller

### DIFF
--- a/owned-manifests/clusterapi-manager-controllers.yaml
+++ b/owned-manifests/clusterapi-manager-controllers.yaml
@@ -21,6 +21,7 @@ spec:
         api: clusterapi
         k8s-app: controller
     spec:
+      priorityClassName: system-node-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:


### PR DESCRIPTION
Add system-cluster-critical priority class to controller,  without this there is a chance that scheduler evicts these pods when there is a resource crunch.