### PR TITLE
Add cluster-critical priorityClass to machine-api

### DIFF
--- a/install/0000_30_machine-api-operator_09_deployment.yaml
+++ b/install/0000_30_machine-api-operator_09_deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         k8s-app: machine-api-operator
     spec:
+      priorityClassName: system-node-critical
       containers:
       - name: machine-api-operator
         image: docker.io/openshift/origin-machine-api-operator:v4.0.0


### PR DESCRIPTION
As of now, machine-api-operator doesn't have `system-node-critical` priority, the pods created for this deployment may get evicted by scheduler, if this priorityClass is not available. The rationale behind adding `system-node-critical` is we have nodeSelector to ensure that we are running on master nodes.