### PR TITLE
Add support for managed bare metal platform.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This allows to convey desired state of machines in a cluster in a declarative fa
 
   - [cluster-api-provider-openstack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack). Coming soon.
 
+  - [cluster-api-provider-baremetal](https://github.com/metalkube/cluster-api-provider-baremetal). Under development in [MetalKube](http://metalkube.org).
+
 - [Node Controller](https://github.com/kubernetes-sigs/cluster-api/tree/master/pkg/controller)
   - Reconciles desired state of machines by matching IP addresses of machine objects with IP addresses of node objects. Annotating node with a special label containing machine name that the cluster-api node controller interprets and sets corresponding nodeRef field of each relevant machine.
 

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -4,4 +4,4 @@ metadata:
   name: machine-api-operator-images
   namespace: openshift-machine-api
 data:
-  images.json: '{"machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0", "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0", "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0", "clusterAPIControllerKubemark": "docker.io/gofed/kubemark-machine-controllers:v1.0"}'
+  images.json: '{"machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0", "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0", "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0", "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0", "clusterAPIControllerKubemark": "docker.io/gofed/kubemark-machine-controllers:v1.0", "clusterAPIControllerBareMetal": "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0"}'

--- a/install/image-references
+++ b/install/image-references
@@ -18,3 +18,7 @@ spec:
     from:
       kind: DockerImage
       name: docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0
+  - name: baremetal-machine-controllers
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -167,8 +167,7 @@ func getProviderControllerFromImages(provider Provider, images Images) (string, 
 	case KubemarkProvider:
 		return images.ClusterAPIControllerKubemark, nil
 	case BareMetalProvider:
-		//FIXME Replace with a proper controller once its available
-		return images.ClusterAPIControllerLibvirt, nil
+		return images.ClusterAPIControllerBareMetal, nil
 	case NoneProvider:
 		return "None", nil
 	}

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -12,6 +12,7 @@ var (
 	expectedLibvirtImage            = "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
 	expectedOpenstackImage          = "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0"
 	expectedMachineAPIOperatorImage = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
+	expectedBareMetalImage          = "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0"
 )
 
 func TestInstallConfigFromClusterConfig(t *testing.T) {
@@ -53,7 +54,7 @@ pullSecret: “"
 	if err != nil {
 		t.Errorf("failed to get install config: %v", err)
 	}
-	if res.InstallPlatform.AWS != nil && res.InstallPlatform.Libvirt == nil && res.InstallPlatform.OpenStack == nil {
+	if res.InstallPlatform.AWS != nil && res.InstallPlatform.Libvirt == nil && res.InstallPlatform.OpenStack == nil && res.InstallPlatform.BareMetal == nil {
 		t.Logf("got install config successfully: %+v", res)
 	} else {
 		t.Errorf("failed to getInstallConfigFromClusterConfig. Expected aws to be not nil, got: %+v", res)
@@ -71,6 +72,7 @@ func TestGetProviderFromInstallConfig(t *testing.T) {
 				AWS:       notNil,
 				Libvirt:   nil,
 				OpenStack: nil,
+				BareMetal: nil,
 			},
 		},
 		expected: AWSProvider,
@@ -81,6 +83,7 @@ func TestGetProviderFromInstallConfig(t *testing.T) {
 					AWS:       nil,
 					Libvirt:   notNil,
 					OpenStack: nil,
+					BareMetal: nil,
 				},
 			},
 			expected: LibvirtProvider,
@@ -102,9 +105,21 @@ func TestGetProviderFromInstallConfig(t *testing.T) {
 					AWS:       nil,
 					Libvirt:   nil,
 					OpenStack: notNil,
+					BareMetal: nil,
 				},
 			},
 			expected: OpenStackProvider,
+		},
+		{
+			ic: &InstallConfig{
+				InstallPlatform{
+					AWS:       nil,
+					Libvirt:   nil,
+					OpenStack: nil,
+					BareMetal: notNil,
+				},
+			},
+			expected: BareMetalProvider,
 		}}
 
 	for _, test := range tests {
@@ -123,6 +138,7 @@ func TestGetProviderFromInstallConfig(t *testing.T) {
 			AWS:       nil,
 			Libvirt:   notNil,
 			OpenStack: notNil,
+			BareMetal: nil,
 		},
 	}
 	res, err := getProviderFromInstallConfig(ic)
@@ -144,6 +160,9 @@ func TestGetImagesFromJSONFile(t *testing.T) {
 	}
 	if img.ClusterAPIControllerOpenStack != expectedOpenstackImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedOpenstackImage, img.ClusterAPIControllerOpenStack)
+	}
+	if img.ClusterAPIControllerBareMetal != expectedBareMetalImage {
+		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedBareMetalImage, img.ClusterAPIControllerBareMetal)
 	}
 }
 

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -2,5 +2,6 @@
   "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
   "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0",
   "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
-  "machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0"
+  "machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
+  "clusterAPIControllerBareMetal": "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0"
 }


### PR DESCRIPTION
This patch introduces support for the managed bare metal platform that
is currently under development under the metalkube github org.

More information about this platform type can be found in
documentation under https://github.com/metalkube/metalkube-docs/.

The actuator and other supporting components are still under active
devleopment, so we just point to an upstream metalkube image for the
actuator for now.  Having this in the machine-api-operator earlier
will make end-to-end testing a bit easier as the platform continues to
be developed.

Signed-off-by: Russell Bryant <rbryant@redhat.com>