### PR TITLE
status: report cluster operator version from payload

### DIFF
--- a/install/0000_30_machine-api-operator_09_deployment.yaml
+++ b/install/0000_30_machine-api-operator_09_deployment.yaml
@@ -23,6 +23,9 @@ spec:
         args:
         - "start"
         - "--images-json=/etc/machine-api-operator-config/images/images.json"
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
         resources:
           limits:
             cpu: 20m

--- a/install/0000_30_machine-api-operator_10_clusteroperator.yaml
+++ b/install/0000_30_machine-api-operator_10_clusteroperator.yaml
@@ -3,3 +3,7 @@ kind: ClusterOperator
 metadata:
   name: machine-api
 spec: {}
+status:
+  versions:
+    - name: operator
+      version: "0.0.1-snapshot"

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -96,6 +96,8 @@ func (optr *Operator) statusAvailable() error {
 	if err != nil {
 		return err
 	}
+
+	// 	important: we only write the version field if we report available at the present level
 	co.Status.Versions = optr.operandVersions
 	return optr.syncStatus(co, conds)
 }


### PR DESCRIPTION
Every operator shall report a version with name=operator whose value is equal to the RELEASE_VERSION provided by the cluster version operator.

will be enforced via [openshift/origin#22156](https://github.com/openshift/origin/pull/22156)