### PR TITLE
nodelink-controller: ensure node annotations is non nil before adding values

### DIFF
--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -375,7 +375,6 @@ func (c *Controller) processNode(node *corev1.Node) error {
 	}
 
 	if matchingMachine == nil {
-		glog.Warning("No machine was found for node %q", node.Name)
 		return fmt.Errorf("no machine was found for node: %q", node.Name)
 	}
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -380,6 +380,9 @@ func (c *Controller) processNode(node *corev1.Node) error {
 
 	glog.V(3).Infof("Found machine %s for node %s", machineKey, node.Name)
 	modNode := node.DeepCopy()
+	if modNode.Annotations == nil {
+		modNode.Annotations = map[string]string{}
+	}
 	modNode.Annotations[machineAnnotationKey] = fmt.Sprintf("%s/%s", matchingMachine.Namespace, matchingMachine.Name)
 
 	if modNode.Labels == nil {


### PR DESCRIPTION
I experienced two panics when testing/debugging the nodelink-controller using kubemark. In both cases the panic was because `node.Annotations` was nil.

Additional drive-by fixes to:
- make a logging statement more useful
- to remove a logging statement that was useless