### PR TITLE
Add additional EC2 permissions to CloudCredential request

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -15,17 +15,18 @@ spec:
     statementEntries:
     - effect: Allow
       action:
-      - ec2:DescribeImages
-      - ec2:DescribeVpcs
-      - ec2:DescribeSubnets
+      - ec2:CreateTags
       - ec2:DescribeAvailabilityZones
-      - ec2:DescribeSecurityGroups
-      - ec2:RunInstances
+      - ec2:DescribeImages
       - ec2:DescribeInstances
+      - ec2:DescribeSecurityGroups
+      - ec2:DescribeSubnets
+      - ec2:DescribeVpcs
+      - ec2:RunInstances
       - ec2:TerminateInstances
-      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:DescribeLoadBalancers
       - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:RegisterTargets
       - iam:PassRole
       resource: "*"


### PR DESCRIPTION
One additional permission (`ec2:CreateTags`) was added, everything else was just sorted alphabetically.

FYI: https://github.com/openshift/cloud-credential-operator/pull/37

`ec2:CreateTags` is needed since the `ec2: RunInstances` call creates tags for the newly created instances. Before we used the Instance role which had `ec2:*` so this problem didn't show up.