### PR TITLE
verify staleness of vendored cluster-api-actuator-pkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ else
 endif
 
 .PHONY: check
-check: lint fmt vet verify-codegen test ## Run code validations
+check: lint fmt vet verify-codegen check-pkg test ## Run code validations
+
+.PHONY: check-pkg
+check-pkg:
+	dep check | grep -q cluster-api-actuator-pkg && exit 1 || exit 0
 
 .PHONY: build
 build: machine-api-operator nodelink-controller machine-healthcheck ## Build binaries


### PR DESCRIPTION
Simple way to verify if we are vendoring latest actuator-pkg. This should be executed as a separate optional CI job.

/assign	@enxebre @michaelgugino 