### PR TITLE
Fix links to operator status and install config

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ $ make nodelink-controller
      data:
        conditions: |
          items:
-         - name: NetworkUnavailable 
+         - name: NetworkUnavailable
            timeout: 5m
            status: True
      ```
-  
+
   1. Pick a node that is managed by one of the machineset's machines
   1. SSH into the node, disable and stop the kubelet services:
      ```
@@ -138,14 +138,14 @@ You can see it in action by running an [OpenShift Cluster deployed by the Instal
 However you can run it in a vanilla Kubernetes cluster by precreating some assets:
 
 - Create a `openshift-machine-api-operator` namespace
-- Create a [CRD Status definition](test/integration/manifests/status-crd.yaml)
+- Create a [CRD Status definition](config/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml)
 - Create a [CRD Machine definition](install/0000_30_machine-api-operator_02_machine.crd.yaml)
 - Create a [CRD MachineSet definition](install/0000_30_machine-api-operator_03_machineset.crd.yaml)
 - Create a [CRD MachineDeployment definition](install/0000_30_machine-api-operator_04_machinedeployment.crd.yaml)
 - Create a [CRD Cluster definition](install/0000_30_machine-api-operator_05_cluster.crd.yaml)
-- Create a [Installer config](test/integration/manifests/install-config.yaml)
+- Create a [Installer config](config/kubemark-config-infra.yaml)
 - Then you can run it as a [deployment](install/0000_30_machine-api-operator_09_deployment.yaml)
-- You should then be able to deploy a [cluster](test/integration/manifests/cluster.yaml) and a [machineSet](test/integration/manifests/machineset.yaml) object
+- You should then be able to deploy a [machineSet](config/machineset.yaml) object
 
 ## Machine API operator with Kubemark over Kubernetes
 

--- a/config/machineset.yaml
+++ b/config/machineset.yaml
@@ -1,0 +1,53 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: {{ .ClusterID }}
+    machine.openshift.io/cluster-api-machine-role: worker
+    machine.openshift.io/cluster-api-machine-type: worker
+  name: worker
+  namespace: openshift-machine-api
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: {{ .ClusterID }}
+      machine.openshift.io/cluster-api-machineset: worker
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: {{ .ClusterID }}
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: worker
+    spec:
+      providerSpec:
+        value:
+          credentialsSecret:
+            name: aws-credentials-secret
+          ami:
+            id: ami-05c79276d240b93bc
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          iamInstanceProfile:
+            id: {{ .ClusterID }}-worker-profile
+          instanceType: t2.medium
+          kind: AWSMachineProviderConfig
+          placement:
+            region: us-east-1
+          securityGroups:
+          - filters:
+            - name: tag:Name
+              values:
+              - {{ .ClusterID }}_worker_sg
+          subnet:
+            filters:
+            - name: tag:Name
+              values:
+              - {{ .ClusterID }}-worker-*
+          tags:
+          - name: openshiftClusterID
+            value: {{ .ClusterID }}
+          userDataSecret:
+            name: ignition-worker
+      versions:
+        kubelet: ""


### PR DESCRIPTION
`install-config.yaml` and `config/status-crd.yaml` were removed by https://github.com/openshift/machine-api-operator/pull/240. Adding the files back and updating links to them.