### PR TITLE
extend actuator-pkg staleness check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ check: lint fmt vet verify-codegen check-pkg test ## Run code validations
 
 .PHONY: check-pkg
 check-pkg:
-	dep check | grep -q cluster-api-actuator-pkg && exit 1 || exit 0
+	./hack/verify-actuator-pkg.sh
 
 .PHONY: build
 build: machine-api-operator nodelink-controller machine-healthcheck ## Build binaries

--- a/hack/verify-actuator-pkg.sh
+++ b/hack/verify-actuator-pkg.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+if ! command -v dep 1>/dev/null 2>&1; then
+	curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+fi
+
+if dep check | grep -q cluster-api-actuator-pkg; then
+	exit 1
+fi
+dep ensure -update github.com/openshift/cluster-api-actuator-pkg
+git diff --exit-code


### PR DESCRIPTION
During adding same check to other repositories it was observed that current implementation is insufficient. This extension tries to update actuator-pkg instead of only runnning `dep check`