### PR TITLE
Don't expose kubemark image to clusters

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -10,7 +10,6 @@ data:
       "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
       "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0",
       "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
-      "clusterAPIControllerKubemark": "docker.io/gofed/kubemark-machine-controllers:v1.0",
       "clusterAPIControllerBareMetal": "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0",
       "clusterAPIControllerAzure": "quay.io/openshift/origin-azure-machine-controllers:v4.0.0"
     }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -17,6 +17,8 @@ import (
 )
 
 const (
+	// TODO(alberto): move to "quay.io/openshift/origin-kubemark-machine-controllers:v4.0.0" once available
+	clusterAPIControllerKubemark = "docker.io/gofed/kubemark-machine-controllers:v1.0"
 	// ClusterConfigNamespace is the namespace containing the cluster config
 	ClusterConfigNamespace = "kube-system"
 	// ClusterConfigName is the name of the cluster config configmap
@@ -57,7 +59,6 @@ type Images struct {
 	ClusterAPIControllerAWS       string `json:"clusterAPIControllerAWS"`
 	ClusterAPIControllerOpenStack string `json:"clusterAPIControllerOpenStack"`
 	ClusterAPIControllerLibvirt   string `json:"clusterAPIControllerLibvirt"`
-	ClusterAPIControllerKubemark  string `json:"clusterAPIControllerKubemark"`
 	ClusterAPIControllerBareMetal string `json:"clusterAPIControllerBareMetal"`
 	ClusterAPIControllerAzure     string `json:"clusterAPIControllerAzure"`
 }
@@ -173,7 +174,7 @@ func getProviderControllerFromImages(provider Provider, images Images) (string, 
 	case OpenStackProvider:
 		return images.ClusterAPIControllerOpenStack, nil
 	case KubemarkProvider:
-		return images.ClusterAPIControllerKubemark, nil
+		return clusterAPIControllerKubemark, nil
 	case BareMetalProvider:
 		return images.ClusterAPIControllerBareMetal, nil
 	case AzureProvider:


### PR DESCRIPTION
Kubemark is only for testing against vanilla kubernetes
This *must* not go to ART, and *must* not be referenced in another  operator’s image-references
This stop exposing kubemark image to clusters