### PR TITLE
operator: use infrastructure.config.openshfit.io for platformtype

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test-e2e: ## Run openshift specific e2e test
 deploy-kubemark:
 	kustomize build config | kubectl apply -f -
 	kustomize build | kubectl apply -f -
-	kubectl apply -f config/kubemark-install-config.yaml
+	kubectl apply -f config/kubemark-config-infra.yaml
 
 .PHONY: test
 test: ## Run tests

--- a/README.md
+++ b/README.md
@@ -161,22 +161,36 @@ INFO: For development and testing purposes only
    $ kustomize build config | kubectl apply -f -
    ```
 
-3. Create `cluster-config-v1` configmap to tell the MAO to deploy `kubemark` provider:
+3. Create `cluster` `infrastructure.config.openshift.io` to tell the MAO to deploy `kubemark` provider:
    ```yaml
-   apiVersion: v1
-   kind: ConfigMap
+   apiVersion: apiextensions.k8s.io/v1beta1
+   kind: CustomResourceDefinition
    metadata:
-     name: cluster-config-v1
-     namespace: kube-system
-   data:
-     install-config: |-
-       platform:
-         kubemark: {}
+     name: infrastructures.config.openshift.io
+   spec:
+     group: config.openshift.io
+     names:
+       kind: Infrastructure
+       listKind: InfrastructureList
+       plural: infrastructures
+       singular: infrastructure
+     scope: Cluster
+     versions:
+     - name: v1
+       served: true
+   storage: true
+   ---
+   apiVersion: config.openshift.io/v1
+   kind: Infrastructure
+   metadata:
+     name: cluster
+   status:
+     platform: kubemark
    ```
 
-   The file is already present under `config/kubemark-install-config.yaml` so it's sufficient to run:
+   The file is already present under `config/kubemark-config-infra.yaml` so it's sufficient to run:
    ```sh
-   $ kubectl apply -f config/kubemark-install-config.yaml
+   $ kubectl apply -f config/kubemark-config-infra.yaml
    ```
 
 ## CI & tests

--- a/config/kubemark-config-infra.yaml
+++ b/config/kubemark-config-infra.yaml
@@ -1,0 +1,23 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: infrastructures.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Infrastructure
+    listKind: InfrastructureList
+    plural: infrastructures
+    singular: infrastructure
+  scope: Cluster
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: config.openshift.io/v1
+kind: Infrastructure
+metadata:
+  name: cluster
+status:
+  platform: kubemark

--- a/config/kubemark-install-config.yaml
+++ b/config/kubemark-install-config.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cluster-config-v1
-  namespace: kube-system
-data:
-  install-config: |-
-    platform:
-      kubemark: {}

--- a/install/0000_30_machine-api-operator_08_rbac.yaml
+++ b/install/0000_30_machine-api-operator_08_rbac.yaml
@@ -36,6 +36,14 @@ rules:
       - update
 
   - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -10,6 +10,7 @@ import (
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
@@ -171,7 +172,7 @@ func (optr *Operator) sync(key string) error {
 		glog.V(4).Infof("Finished syncing operator %q (%v)", key, time.Since(startTime))
 	}()
 
-	operatorConfig, err := optr.maoConfigFromInstallConfig()
+	operatorConfig, err := optr.maoConfigFromInfrastructure()
 	if err != nil {
 		glog.Errorf("Failed getting operator config: %v", err)
 		return err
@@ -187,13 +188,13 @@ func (optr *Operator) sync(key string) error {
 	return optr.syncAll(*operatorConfig)
 }
 
-func (optr *Operator) maoConfigFromInstallConfig() (*OperatorConfig, error) {
-	installConfig, err := getInstallConfig(optr.kubeClient)
+func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
+	infra, err := optr.osClient.ConfigV1().Infrastructures().Get("cluster", metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	provider, err := getProviderFromInstallConfig(installConfig)
+	provider, err := getProviderFromInfrastructure(infra)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
cluster operators must use the config.openshit.io as source for their top level config.
Rebase and follow up for https://github.com/openshift/machine-api-operator/pull/256