### PR TITLE
Fix case of BareMetal provider type.

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -16,7 +16,7 @@ const (
 	clusterAPIControllerKubemark = "docker.io/gofed/kubemark-machine-controllers:v1.0"
 	clusterAPIControllerNoOp     = "no-op"
 	kubemarkPlatform             = configv1.PlatformType("kubemark")
-	bareMetalPlatform            = configv1.PlatformType("baremetal")
+	bareMetalPlatform            = configv1.PlatformType("BareMetal")
 )
 
 type Provider string


### PR DESCRIPTION
The provider type in the Infrastructure config object is "BareMetal".
This code was expecting "baremetal", which cuased the
machine-api-operator to fall back to the no-op provider instead of
launching the correct clusterapi-manager-controllers pod.