### PR TITLE
Add baremetal to the machine-api-manager ClusterRole.

### DIFF
--- a/install/0000_30_machine-api-operator_08_rbac.yaml
+++ b/install/0000_30_machine-api-operator_08_rbac.yaml
@@ -44,6 +44,17 @@ rules:
       - get
 
   - apiGroups:
+      - metalkube.org
+    resources:
+      - baremetalhosts
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+
+  - apiGroups:
       - apps
     resources:
       - deployments


### PR DESCRIPTION
When the machine-api-operator runs the BareMetal machine controller,
it needs access to the BareMetalHost resource.  This patch adds that
necessary access to the ClusterRole.