### PR TITLE
Integrate machine disruption with machine health check

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -14,6 +14,8 @@ spec:
     - mhc
     - mhcs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
@@ -27,6 +27,8 @@ spec:
     - mdb
     - mdbs
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -67,7 +69,15 @@ spec:
         status:
           description: Most recently observed status of the MachineDisruptionBudget.
           properties:
-            DisruptedMachines:
+            currentHealthy:
+              description: current number of healthy machines
+              format: int32
+              type: integer
+            desiredHealthy:
+              description: minimum desired number of healthy machines
+              format: int32
+              type: integer
+            disruptedMachines:
               description: DisruptedMachines contains information about machines whose
                 deletion was processed by the API server but has not yet been observed
                 by the MachineDisruptionBudget controller. A machine will be in this
@@ -81,14 +91,6 @@ spec:
                 goes smooth this map should be empty for the most of the time. Large
                 number of entries in the map may indicate problems with machines deletions.
               type: object
-            currentHealthy:
-              description: current number of healthy machines
-              format: int32
-              type: integer
-            desiredHealthy:
-              description: minimum desired number of healthy machines
-              format: int32
-              type: integer
             disruptionsAllowed:
               description: Number of machines disruptions that are currently allowed.
               format: int32

--- a/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
@@ -44,7 +44,7 @@ type MachineDisruptionBudgetStatus struct {
 	// If everything goes smooth this map should be empty for the most of the time.
 	// Large number of entries in the map may indicate problems with machines deletions.
 	// +optional
-	DisruptedMachines map[string]metav1.Time `json:"DisruptedMachines,omitempty" protobuf:"bytes,2,rep,name=DisruptedMachines"`
+	DisruptedMachines map[string]metav1.Time `json:"disruptedMachines,omitempty" protobuf:"bytes,2,rep,name=DisruptedMachines"`
 
 	// Number of machines disruptions that are currently allowed.
 	MachineDisruptionsAllowed int32 `json:"disruptionsAllowed" protobuf:"varint,3,opt,name=disruptionsAllowed"`
@@ -63,7 +63,7 @@ type MachineDisruptionBudgetStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MachineDisruptionBudget is an object to define the max disruption that a collection of machines can experience
-// kubebuilder:subresource:status
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mdb;mdbs
 // +kubebuilder:printcolumn:name="Healthy",type="integer",JSONPath=".status.currentHealthy",description="The number of healthy machines"
 // +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.expectedMachines",description="The total number of machines"

--- a/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
@@ -14,7 +14,7 @@ type RemediationStrategyType string
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // MachineHealthCheck is the Schema for the machinehealthchecks API
-// kubebuilder:subresource:status
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mhc;mhcs
 // +k8s:openapi-gen=true
 type MachineHealthCheck struct {

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -102,7 +102,7 @@ type ReconcileMachineDisruption struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileMachineDisruption) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	glog.Infof("Reconciling MachineDisruption triggered by %s/%s\n", request.Namespace, request.Name)
+	glog.V(4).Infof("Reconciling MachineDisruption triggered by %s/%s\n", request.Namespace, request.Name)
 
 	// Get machine from request
 	mdb := &healthcheckingv1alpha1.MachineDisruptionBudget{}

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -11,6 +11,7 @@ import (
 	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 	"github.com/openshift/machine-api-operator/pkg/util/conditions"
 	maotesting "github.com/openshift/machine-api-operator/pkg/util/testing"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/util/machines/machines.go
+++ b/pkg/util/machines/machines.go
@@ -19,7 +19,7 @@ import (
 // IsMachineHealthy returns true if the the machine is running and machine node is healthy
 func IsMachineHealthy(c client.Client, machine *mapiv1.Machine) bool {
 	if machine.Status.NodeRef == nil {
-		glog.Infof("machine %s does not have NodeRef", machine.Name)
+		glog.V(4).Infof("machine %s does not have NodeRef", machine.Name)
 		return false
 	}
 
@@ -33,12 +33,12 @@ func IsMachineHealthy(c client.Client, machine *mapiv1.Machine) bool {
 
 	readyCond := conditions.GetNodeCondition(node, v1.NodeReady)
 	if readyCond == nil {
-		glog.Infof("node %s does have 'Ready' condition", machine.Name)
+		glog.V(4).Infof("node %s does have 'Ready' condition", machine.Name)
 		return false
 	}
 
 	if readyCond.Status != v1.ConditionTrue {
-		glog.Infof("node %s does have has 'Ready' condition with the status %s", machine.Name, readyCond.Status)
+		glog.V(4).Infof("node %s does have has 'Ready' condition with the status %s", machine.Name, readyCond.Status)
 		return false
 	}
 	return true


### PR DESCRIPTION
This PR integrates `MachineDisruptionBudget` check into the machine health check controller, it makes possible to prevent machine deletion if the cluster has not enough healthy machines.