### PR TITLE
mhc: re-queue after the unhealthy node with the remaining duration

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -232,9 +232,13 @@ func remediate(r *ReconcileMachineHealthCheck, machine *mapiv1.Machine) (reconci
 			durationUnhealthy.String(),
 		)
 
+		// calculate the duration until the node will be unhealthy for too long
+		// and re-queue after with this timeout, add one second just to be sure
+		// that we will not enter this loop again before the node unhealthy for too long
+		unhealthyTooLongTimeout := conditionTimeout - durationUnhealthy + time.Second
 		// be sure that we will use timeout with the minimal value for the reconcile.Result
-		if minimalConditionTimeout == 0 || minimalConditionTimeout > conditionTimeout {
-			minimalConditionTimeout = conditionTimeout
+		if minimalConditionTimeout == 0 || minimalConditionTimeout > unhealthyTooLongTimeout {
+			minimalConditionTimeout = unhealthyTooLongTimeout
 		}
 		result = &reconcile.Result{Requeue: true, RequeueAfter: minimalConditionTimeout}
 	}

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -448,7 +448,15 @@ func testRemediation(t *testing.T, remediationWaitTime time.Duration, initObject
 	for _, tc := range testsCases {
 		result, err := remediate(r, tc.machine)
 		if result != tc.expected.result {
-			t.Errorf("Test case: %s. Expected: %v, got: %v", tc.machine.Name, tc.expected.result, result)
+			if tc.expected.result.Requeue {
+				before := tc.expected.result.RequeueAfter
+				after := tc.expected.result.RequeueAfter + time.Second
+				if after < result.RequeueAfter || before > result.RequeueAfter {
+					t.Errorf("Test case: %s. Expected RequeueAfter between: %v and %v, got: %v", tc.machine.Name, before, after, result)
+				}
+			} else {
+				t.Errorf("Test case: %s. Expected: %v, got: %v", tc.machine.Name, tc.expected.result, result)
+			}
 		}
 		if tc.expected.error != (err != nil) {
 			var errorExpectation string


### PR DESCRIPTION
Before we re-queue the unhealthy node with the condition timeout duration, that can delay
the node remediation, to improve it now we re-queue the unhealthy node with the duration
equals to `conditionTimeout - nodeDurationUnhealthy + second`.