### PR TITLE
Use deployment client

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -8,7 +8,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"path/filepath"
@@ -91,10 +90,7 @@ func (optr *Operator) syncClusterAPIController(config OperatorConfig) error {
 
 func (optr *Operator) waitForDeploymentRollout(resource *appsv1.Deployment) error {
 	return wait.Poll(deploymentRolloutPollInterval, deploymentRolloutTimeout, func() (bool, error) {
-		// TODO(vikas): When using deployLister, an issue is happening related to the apiVersion of cluster-api objects.
-		// This will be debugged later on to find out the root cause. For now, working aound is to use kubeClient.AppsV1
-		// d, err := optr.deployLister.Deployments(resource.Namespace).Get(resource.Name)
-		d, err := optr.kubeClient.AppsV1().Deployments(resource.Namespace).Get(resource.Name, metav1.GetOptions{})
+		d, err := optr.deployLister.Deployments(resource.Namespace).Get(resource.Name)
 		if apierrors.IsNotFound(err) {
 			return false, nil
 		}


### PR DESCRIPTION
For listing deployments, ideally deployment lister based on shared informers should have been used because of security aspects. But in the past there was an issue happening and as a stop gap kubeclient was used directly. 
Now that issue is not happening with shared informers and deployLister is being used.