### PR TITLE
Create dedicated service account for mao

### DIFF
--- a/config/machine-api-operator-patch.yaml
+++ b/config/machine-api-operator-patch.yaml
@@ -1,0 +1,140 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: machine-api-manager
+rules:
+  - apiGroups:
+      - cluster.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+
+  - apiGroups:
+      - healthchecking.openshift.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - clusteroperators
+      - clusteroperators/status
+    verbs:
+      - create
+      - get
+      - update
+
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+
+  - apiGroups:
+      - metalkube.org
+    resources:
+      - baremetalhosts
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - watch
+      - list
+      - patch
+
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - ""
+    resources:
+      - pods/eviction
+    verbs:
+      - create
+
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+    verbs:
+      - get
+      - list
+      - watch

--- a/config/machine-api-operator-patch.yaml
+++ b/config/machine-api-operator-patch.yaml
@@ -122,6 +122,10 @@ rules:
       - get
       - list
       - watch
+      # Only these two additional lines are needed for kubemark actuator to
+      # create and remove kubemark instances
+      - create
+      - delete
 
   - apiGroups:
       - ""

--- a/install/0000_30_machine-api-operator_08_rbac.yaml
+++ b/install/0000_30_machine-api-operator_08_rbac.yaml
@@ -1,3 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: machine-api-operator
+  namespace: openshift-machine-api
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -149,5 +156,5 @@ roleRef:
   name: machine-api-manager
 subjects:
   - kind: ServiceAccount
-    name: default
+    name: machine-api-operator
     namespace: openshift-machine-api

--- a/install/0000_30_machine-api-operator_09_deployment.yaml
+++ b/install/0000_30_machine-api-operator_09_deployment.yaml
@@ -16,6 +16,7 @@ spec:
         k8s-app: machine-api-operator
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: machine-api-operator
       containers:
       - name: machine-api-operator
         image: docker.io/openshift/origin-machine-api-operator:v4.0.0

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -20,3 +20,6 @@ resources:
 - install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
 - install/0000_30_machine-api-operator_08_rbac.yaml
 - install/0000_30_machine-api-operator_09_deployment.yaml
+
+patches:
+- config/machine-api-operator-patch.yaml

--- a/owned-manifests/machine-api-controllers.yaml
+++ b/owned-manifests/machine-api-controllers.yaml
@@ -22,6 +22,7 @@ spec:
         k8s-app: controller
     spec:
       priorityClassName: system-node-critical
+      serviceAccountName: machine-api-operator
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:


### PR DESCRIPTION
FYI: Copying install/0000_30_machine-api-operator_08_rbac.yaml under config/machine-api-operator-patch.yaml and adding
pods.create and pods.delete permissions for kubemark. Since kustomize patch operation replaces entire lists, entire list
of RBAC rules need to be copy pasted into the patch.

Building on top of https://github.com/openshift/machine-api-operator/pull/276