### PR TITLE
Change operator failing to degraded

### DIFF
--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -127,10 +127,10 @@ func TestOperatorSync_NoOp(t *testing.T) {
 			expectedConditions := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
 				configv1.OperatorAvailable:   configv1.ConditionTrue,
 				configv1.OperatorProgressing: configv1.ConditionFalse,
-				configv1.OperatorFailing:     configv1.ConditionTrue,
+				configv1.OperatorDegraded:    configv1.ConditionTrue,
 			}
 			if tc.expectedNoop {
-				expectedConditions[configv1.OperatorFailing] = configv1.ConditionFalse
+				expectedConditions[configv1.OperatorDegraded] = configv1.ConditionFalse
 			}
 			actualConditions := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{}
 			for _, c := range o.Status.Conditions {

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -31,7 +31,7 @@ const (
 )
 
 // statusProgressing sets the Progressing condition to True, with the given
-// reason and message, and sets both the Available and Failing conditions to
+// reason and message, and sets both the Available and Degraded conditions to
 // False.
 func (optr *Operator) statusProgressing() error {
 	desiredVersions := optr.operandVersions
@@ -63,20 +63,20 @@ func (optr *Operator) statusProgressing() error {
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
 		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, isProgressing, string(ReasonSyncing), message),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, "", ""),
-		newClusterOperatorStatusCondition(osconfigv1.OperatorFailing, osconfigv1.ConditionFalse, "", ""),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
 	}
 
 	return optr.syncStatus(co, conds)
 }
 
 // statusAvailable sets the Available condition to True, with the given reason
-// and message, and sets both the Progressing and Failing conditions to False.
+// and message, and sets both the Progressing and Degraded conditions to False.
 func (optr *Operator) statusAvailable() error {
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
 		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty),
 			fmt.Sprintf("Cluster Machine API Operator is available at %s", optr.printOperandVersions())),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, "", ""),
-		newClusterOperatorStatusCondition(osconfigv1.OperatorFailing, osconfigv1.ConditionFalse, "", ""),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
 	}
 
 	co, err := optr.getOrCreateClusterOperator()
@@ -90,11 +90,11 @@ func (optr *Operator) statusAvailable() error {
 	return optr.syncStatus(co, conds)
 }
 
-// statusFailing sets the Failing condition to True, with the given reason and
+// statusDegraded sets the Degraded condition to True, with the given reason and
 // message, and sets the Progressing condition to False, and the Available
 // condition to True.  This indicates that the operator is present and may be
 // partially functioning, but is in a degraded or failing state.
-func (optr *Operator) statusFailing(error string) error {
+func (optr *Operator) statusDegraded(error string) error {
 	desiredVersions := optr.operandVersions
 	currentVersions, err := optr.getCurrentVersions()
 	if err != nil {
@@ -110,7 +110,7 @@ func (optr *Operator) statusFailing(error string) error {
 	}
 
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(osconfigv1.OperatorFailing, osconfigv1.ConditionTrue,
+		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionTrue,
 			string(ReasonSyncFailed), message),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, "", ""),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, "", ""),
@@ -120,8 +120,8 @@ func (optr *Operator) statusFailing(error string) error {
 	if err != nil {
 		return err
 	}
-	optr.eventRecorder.Eventf(co, v1.EventTypeWarning, "Status failing", error)
-	glog.V(2).Info("Syncing status: failing")
+	optr.eventRecorder.Eventf(co, v1.EventTypeWarning, "Status degraded", error)
+	glog.V(2).Info("Syncing status: degraded")
 	return optr.syncStatus(co, conds)
 }
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -29,7 +29,7 @@ func (optr *Operator) syncAll(config OperatorConfig) error {
 	}
 	if config.Controllers.Provider != clusterAPIControllerNoOp {
 		if err := optr.syncClusterAPIController(config); err != nil {
-			if err := optr.statusFailing(err.Error()); err != nil {
+			if err := optr.statusDegraded(err.Error()); err != nil {
 				// Just log the error here.  We still want to
 				// return the outer error.
 				glog.Errorf("Error syncing ClusterOperatorStatus: %v", err)


### PR DESCRIPTION
This commit renames statusFailing to statusDegraded
to conform with other openshift components.