### PR TITLE
Simplify Gopkg.toml and update vendor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -378,8 +378,7 @@
   version = "v1.4.3"
 
 [[projects]]
-  branch = "rebase-1.13.4"
-  digest = "1:8f6432915758d422dd8a1e023c6f11ed58feb2f79fc42ad43971829886263788"
+  digest = "1:d399751e77e2460e41253b656863f6b68da4fe91ea26f46e045227b7556c93f1"
   name = "github.com/openshift/api"
   packages = [
     "config/v1",
@@ -389,7 +388,7 @@
     "security/v1",
   ]
   pruneopts = "NUT"
-  revision = "3a6077f1f910bfaec1f34ae9db3492a52e804ae0"
+  revision = "8e476cb7322e59919cbb6482fd076ec5a214df25"
 
 [[projects]]
   branch = "rebase-1.13.4"
@@ -442,7 +441,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:5feaa2a91b1c3e75c33e0b22c0ee984cb2c4e8deb40baa7c1098fc27a746f611"
+  digest = "1:7cbcae314ea9375bebbecfc8b520bbce9786f9c4d1b42824f2a1613695e3faad"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e",
@@ -455,7 +454,7 @@
     "pkg/types",
   ]
   pruneopts = ""
-  revision = "f9b241eadbe0f38b075e4c307f4e50d655d62155"
+  revision = "59a034672129ff21181ac38871a47dabbc900c7f"
 
 [[projects]]
   branch = "master"
@@ -479,7 +478,7 @@
     "lib/resourceread",
   ]
   pruneopts = "NUT"
-  revision = "797a840d7ea27fa6985b9da4601a6fd1e9286e94"
+  revision = "a928be9f42cac2f65296402019daa6f0badea1aa"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,16 +45,8 @@ required = [
   source = "github.com/openshift/kubernetes-kube-aggregator"
 
 [[override]]
-  name = "github.com/openshift/cluster-api"
-  branch = "openshift-4.0-cluster-api-0.0.0-alpha.4"
-
-[[override]]
   name = "github.com/openshift/cluster-api-actuator-pkg"
   branch = "master"
-
-[[override]]
-  name = "github.com/openshift/api"
-  branch = "rebase-1.13.4"
 
 [[override]]
   name = "github.com/openshift/client-go"

--- a/vendor/github.com/openshift/api/config/v1/types_cluster_operator.go
+++ b/vendor/github.com/openshift/api/config/v1/types_cluster_operator.go
@@ -127,10 +127,13 @@ const (
 	// operator (eg: openshift-apiserver for the openshift-apiserver-operator).
 	OperatorProgressing ClusterStatusConditionType = "Progressing"
 
-	// Failing indicates that the operator has encountered an error that is preventing it from working properly.
-	// The binary maintained by the operator (eg: openshift-apiserver for the openshift-apiserver-operator) may still be
-	// available, but the user intent cannot be fulfilled.
+	// OperatorFailing is DEPRECATED
 	OperatorFailing ClusterStatusConditionType = "Failing"
+
+	// Degraded indicates that the operand is not functioning completely. An example of a degraded state
+	// would be if there should be 5 copies of the operand running but only 4 are running. It may still be available,
+	// but it is degraded
+	OperatorDegraded ClusterStatusConditionType = "Degraded"
 
 	// Upgradeable indicates whether the operator is in a state that is safe to upgrade. When status is `False`
 	// administrators should not upgrade their cluster and the message field should contain a human readable description

--- a/vendor/github.com/openshift/api/config/v1/types_feature.go
+++ b/vendor/github.com/openshift/api/config/v1/types_feature.go
@@ -66,7 +66,7 @@ type FeatureGateEnabledDisabled struct {
 //
 // If you put an item in either of these lists, put your area and name on it so we can find owners.
 var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
-	Default: &FeatureGateEnabledDisabled{
+	Default: {
 		Enabled: []string{
 			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
@@ -76,11 +76,12 @@ var FeatureSets = map[FeatureSet]*FeatureGateEnabledDisabled{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning
 		},
 	},
-	TechPreviewNoUpgrade: &FeatureGateEnabledDisabled{
+	TechPreviewNoUpgrade: {
 		Enabled: []string{
 			"ExperimentalCriticalPodAnnotation", // sig-pod, sjenning
 			"RotateKubeletServerCertificate",    // sig-pod, sjenning
 			"SupportPodPidsLimit",               // sig-pod, sjenning
+			"CSIBlockVolume",                    // sig-storage, j-griffith
 		},
 		Disabled: []string{
 			"LocalStorageCapacityIsolation", // sig-pod, sjenning

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -41,7 +41,7 @@ type InfrastructureStatus struct {
 	// value controls whether infrastructure automation such as service load
 	// balancers, dynamic volume provisioning, machine creation and deletion, and
 	// other integrations are enabled. If None, no infrastructure automation is
-	// enabled. Allowed values are "AWS", "Azure", "GCP", "Libvirt",
+	// enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt",
 	// "OpenStack", "VSphere", and "None". Individual components may not support
 	// all platforms, and must handle unrecognized platforms as None if they do
 	// not support that platform.
@@ -67,6 +67,9 @@ const (
 
 	// AzurePlatformType represents Microsoft Azure infrastructure.
 	AzurePlatformType PlatformType = "Azure"
+
+	// BareMetalPlatformType represents managed bare metal infrastructure.
+	BareMetalPlatformType PlatformType = "BareMetal"
 
 	// GCPPlatformType represents Google Cloud Platform infrastructure.
 	GCPPlatformType PlatformType = "GCP"

--- a/vendor/github.com/openshift/api/config/v1/types_scheduling.go
+++ b/vendor/github.com/openshift/api/config/v1/types_scheduling.go
@@ -27,24 +27,24 @@ type SchedulerSpec struct {
 	// The namespace for this configmap is openshift-config.
 	// +optional
 	Policy ConfigMapNameReference `json:"policy"`
-	// defaultNodeSelector helps set the cluster-wide default node selector to 
-	// restrict pod placement to specific nodes. This is applied to the pods 
+	// defaultNodeSelector helps set the cluster-wide default node selector to
+	// restrict pod placement to specific nodes. This is applied to the pods
 	// created in all namespaces without a specified nodeSelector value.
 	// For example,
 	// defaultNodeSelector: "type=user-node,region=east" would set nodeSelector
 	// field in pod spec to "type=user-node,region=east" to all pods created
-	// in all namespaces. Namespaces having project-wide node selectors won't be 
-	// impacted even if this field is set. This adds an annotation section to 
-	// the namespace. 
-	// For example, if a new namespace is created with 
+	// in all namespaces. Namespaces having project-wide node selectors won't be
+	// impacted even if this field is set. This adds an annotation section to
+	// the namespace.
+	// For example, if a new namespace is created with
 	// node-selector='type=user-node,region=east',
 	// the annotation openshift.io/node-selector: type=user-node,region=east
 	// gets added to the project. When the openshift.io/node-selector annotation
 	// is set on the project the value is used in preference to the value we are setting
-	// for defaultNodeSelector field. 
+	// for defaultNodeSelector field.
 	// For instance,
-	// openshift.io/node-selector: "type=user-node,region=west" means 
-	// that the default of "type=user-node,region=east" set in defaultNodeSelector 
+	// openshift.io/node-selector: "type=user-node,region=west" means
+	// that the default of "type=user-node,region=east" set in defaultNodeSelector
 	// would not be applied.
 	// +optional
 	DefaultNodeSelector string `json:"defaultNodeSelector,omitempty"`

--- a/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/config/v1/zz_generated.swagger_doc_generated.go
@@ -149,7 +149,7 @@ func (GenericControllerConfig) SwaggerDoc() map[string]string {
 }
 
 var map_HTTPServingInfo = map[string]string{
-	"": "HTTPServingInfo holds configuration for serving HTTP",
+	"":                      "HTTPServingInfo holds configuration for serving HTTP",
 	"maxRequestsInFlight":   "MaxRequestsInFlight is the number of concurrent requests allowed to the server. If zero, no limit.",
 	"requestTimeoutSeconds": "RequestTimeoutSeconds is the number of seconds before requests are timed out. The default is 60 minutes, if -1 there is no limit on requests.",
 }
@@ -729,7 +729,7 @@ func (InfrastructureSpec) SwaggerDoc() map[string]string {
 var map_InfrastructureStatus = map[string]string{
 	"":                    "InfrastructureStatus describes the infrastructure the cluster is leveraging.",
 	"infrastructureName":  "infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.",
-	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
+	"platform":            "platform is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.",
 	"etcdDiscoveryDomain": "etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery",
 	"apiServerURL":        "apiServerURL is a valid URL with scheme(http/https), address and port. apiServerURL can be used by components like kubelet on machines, to contact the `apisever` using the infrastructure provider rather than the kubernetes networking.",
 }
@@ -1027,7 +1027,7 @@ func (RequestHeaderIdentityProvider) SwaggerDoc() map[string]string {
 }
 
 var map_TokenConfig = map[string]string{
-	"": "TokenConfig holds the necessary configuration options for authorization and access tokens",
+	"":                                    "TokenConfig holds the necessary configuration options for authorization and access tokens",
 	"accessTokenMaxAgeSeconds":            "accessTokenMaxAgeSeconds defines the maximum age of access tokens",
 	"accessTokenInactivityTimeoutSeconds": "accessTokenInactivityTimeoutSeconds defines the default token inactivity timeout for tokens granted by any client. The value represents the maximum amount of time that can occur between consecutive uses of the token. Tokens become invalid if they are not used within this temporal window. The user will need to acquire a new token to regain access once a token times out. Valid values are integer values:\n  x < 0  Tokens time out is enabled but tokens never timeout unless configured per client (e.g. `-1`)\n  x = 0  Tokens time out is disabled (default)\n  x > 0  Tokens time out if there is no activity for x seconds\nThe current minimum allowed value for X is 300 (5 minutes)",
 }
@@ -1056,7 +1056,7 @@ func (ProjectList) SwaggerDoc() map[string]string {
 }
 
 var map_ProjectSpec = map[string]string{
-	"": "ProjectSpec holds the project creation configuration.",
+	"":                       "ProjectSpec holds the project creation configuration.",
 	"projectRequestMessage":  "projectRequestMessage is the string presented to a user if they are unable to request a project via the projectrequest api endpoint",
 	"projectRequestTemplate": "projectRequestTemplate is the template to use for creating projects in response to projectrequest. This must point to a template in 'openshift-config' namespace. It is optional. If it is not specified, a default template is used.",
 }

--- a/vendor/github.com/openshift/api/image/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/image/v1/zz_generated.swagger_doc_generated.go
@@ -232,10 +232,10 @@ func (ImageStreamSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ImageStreamStatus = map[string]string{
-	"": "ImageStreamStatus contains information about the state of this image stream.",
+	"":                            "ImageStreamStatus contains information about the state of this image stream.",
 	"dockerImageRepository":       "DockerImageRepository represents the effective location this stream may be accessed at. May be empty until the server determines where the repository is located",
 	"publicDockerImageRepository": "PublicDockerImageRepository represents the public location from where the image can be pulled outside the cluster. This field may be empty if the administrator has not exposed the integrated registry externally.",
-	"tags": "Tags are a historical record of images associated with each tag. The first entry in the TagEvent array is the currently tagged image.",
+	"tags":                        "Tags are a historical record of images associated with each tag. The first entry in the TagEvent array is the currently tagged image.",
 }
 
 func (ImageStreamStatus) SwaggerDoc() map[string]string {

--- a/vendor/github.com/openshift/api/security/v1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/security/v1/zz_generated.swagger_doc_generated.go
@@ -61,7 +61,7 @@ func (PodSecurityPolicyReviewSpec) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicyReviewStatus = map[string]string{
-	"": "PodSecurityPolicyReviewStatus represents the status of PodSecurityPolicyReview.",
+	"":                       "PodSecurityPolicyReviewStatus represents the status of PodSecurityPolicyReview.",
 	"allowedServiceAccounts": "allowedServiceAccounts returns the list of service accounts in *this* namespace that have the power to create the PodTemplateSpec.",
 }
 

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
@@ -364,12 +364,11 @@
   version = "v1.4.2"
 
 [[projects]]
-  branch = "master"
-  digest = "1:7c3defaa4c171d552da0ccedce06992efad4d102ea39cd37f8444a0403b5913c"
+  digest = "1:853f9ec7a92a4b87a9b660e838731623d098613ef3bd5443b8331790ff7bef10"
   name = "github.com/openshift/api"
   packages = ["config/v1"]
   pruneopts = ""
-  revision = "af79befc50a8223c8122e9e654f65763dd17a87e"
+  revision = "8e476cb7322e59919cbb6482fd076ec5a214df25"
 
 [[projects]]
   branch = "openshift-4.0-cluster-api-0.0.0-alpha.4"

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.toml
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.toml
@@ -42,6 +42,10 @@ required = [
     ]
 
 [[constraint]]
+  name = "github.com/openshift/api"
+  revision = "8e476cb7322e59919cbb6482fd076ec5a214df25"
+
+[[constraint]]
   name = "github.com/openshift/cluster-api"
   branch = "openshift-4.0-cluster-api-0.0.0-alpha.4"
 

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
@@ -84,8 +84,8 @@ func isStatusAvailable(client runtimeclient.Client, name string) bool {
 			glog.Errorf("Condition: %q is true", osconfigv1.OperatorProgressing)
 			return false, nil
 		}
-		if cov1helpers.IsStatusConditionTrue(clusterOperator.Status.Conditions, osconfigv1.OperatorFailing) {
-			glog.Errorf("Condition: %q is true", osconfigv1.OperatorFailing)
+		if cov1helpers.IsStatusConditionTrue(clusterOperator.Status.Conditions, osconfigv1.OperatorFailing) || cov1helpers.IsStatusConditionTrue(clusterOperator.Status.Conditions, osconfigv1.OperatorDegraded) {
+			glog.Errorf("Condition: %q is true", osconfigv1.OperatorDegraded)
 			return false, nil
 		}
 		return true, nil


### PR DESCRIPTION
This commit removes competing dependencies from Gopkg.toml
to allow us to utilize cluster-api-actuator-pkg as the
source of truth for these dependencies.