### PR TITLE
kubemark: Deploy feature gate CRDs

### DIFF
--- a/config/0000_05_config-operator_01_featuregate.crd.yaml
+++ b/config/0000_05_config-operator_01_featuregate.crd.yaml
@@ -1,0 +1,49 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: featuregates.config.openshift.io
+spec:
+  group: config.openshift.io
+  version: v1
+  scope: Cluster
+  names:
+    kind: FeatureGate
+    singular: featuregate
+    plural: featuregates
+    listKind: FeatureGateList
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: spec holds user settable values for configuration
+          properties:
+            featureSet:
+              description: featureSet changes the list of features in the cluster.  The
+                default is empty.  Be very careful adjusting this setting. Turning
+                on or off features may cause irreversible changes in your cluster
+                which cannot be undone.
+              type: string
+          type: object
+        status:
+          description: status holds observed values from the cluster. They may not
+            be overridden.
+          type: object
+      required:
+      - spec

--- a/config/machine-api-operator-patch.yaml
+++ b/config/machine-api-operator-patch.yaml
@@ -45,6 +45,16 @@ rules:
       - get
 
   - apiGroups:
+      - config.openshift.io
+    resources:
+      - featuregates
+      - featuregates/status
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
       - metalkube.org
     resources:
       - baremetalhosts

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -11,6 +11,9 @@ resources:
 # Pulled from https://github.com/openshift/cluster-version-operator/blob/master/install/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
 # and updated (delete depricated clusteroperators.operatorstatus.openshift.io CRD)
 - config/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml
+# Install feature gate CRD reguired by mao (so it can enable/disable features)
+# Pulled from https://raw.githubusercontent.com/openshift/cluster-config-operator/master/manifests/0000_05_config-operator_01_featuregate.crd.yaml
+- config/0000_05_config-operator_01_featuregate.crd.yaml
 # Install mao namespaces, CRDS and other resources to properly deploy machine API stack
 - install/0000_30_machine-api-operator_00_namespace.yaml
 - install/0000_30_machine-api-operator_01_images.configmap.yaml


### PR DESCRIPTION
So the kubemark-based deployment of machine API stack can test new features in technical preview.