### PR TITLE
Reflect MetalKube rename to Metal3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This allows to convey desired state of machines in a cluster in a declarative fa
 
   - [cluster-api-provider-openstack](https://github.com/kubernetes-sigs/cluster-api-provider-openstack). Coming soon.
 
-  - [cluster-api-provider-baremetal](https://github.com/metalkube/cluster-api-provider-baremetal). Under development in [MetalKube](http://metalkube.org).
+  - [cluster-api-provider-baremetal](https://github.com/metal3-io/cluster-api-provider-baremetal). Under development in [Metal3](http://metal3.io).
 
 - [Node Controller](https://github.com/kubernetes-sigs/cluster-api/tree/master/pkg/controller)
   - Reconciles desired state of machines by matching IP addresses of machine objects with IP addresses of node objects. Annotating node with a special label containing machine name that the cluster-api node controller interprets and sets corresponding nodeRef field of each relevant machine.

--- a/config/machine-api-operator-patch.yaml
+++ b/config/machine-api-operator-patch.yaml
@@ -66,6 +66,17 @@ rules:
       - patch
 
   - apiGroups:
+      - metal3.io
+    resources:
+      - baremetalhosts
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+
+  - apiGroups:
       - apps
     resources:
       - deployments

--- a/install/0000_30_machine-api-operator_08_rbac.yaml
+++ b/install/0000_30_machine-api-operator_08_rbac.yaml
@@ -72,6 +72,17 @@ rules:
       - patch
 
   - apiGroups:
+      - metal3.io
+    resources:
+      - baremetalhosts
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - patch
+
+  - apiGroups:
       - apps
     resources:
       - deployments


### PR DESCRIPTION
The MetalKube project had to be renamed.  Reflect the new name here.
Leave the old API group in place for now while we complete the
transition.  We will come back and remove it later.