### PR TITLE
Generate CRDs with metadata schema.

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -1,0 +1,3 @@
+version: v1beta1
+domain: openshift.io
+repo: github.com/openshift/machine-api-operator

--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -2,6 +2,9 @@
 
 set -eu
 
+echo "Can not generate CRDS until https://github.com/kubernetes-sigs/controller-tools/pull/195 gets merged"
+exit 1
+
 echo "Building controller-gen tool..."
 # github.com/openshift/machine-api-operator/vendor/
 go build -o bin/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -3,7 +3,8 @@
 set -eu
 
 echo "Building controller-gen tool..."
-go build -o bin/controller-gen github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
+# github.com/openshift/machine-api-operator/vendor/
+go build -o bin/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen
 
 dir=$(mktemp -d -t XXXXXXXX)
 echo $dir
@@ -11,6 +12,7 @@ mkdir -p $dir/src/github.com/openshift/machine-api-operator/pkg/apis
 mkdir -p $dir/src/github.com/openshift/machine-api-operator/vendor
 
 cp -r pkg/apis/healthchecking $dir/src/github.com/openshift/machine-api-operator/pkg/apis/.
+cp -r PROJECT $dir/src/github.com/openshift/machine-api-operator/.
 cp -r vendor/github.com/openshift/cluster-api/pkg/apis/machine $dir/src/github.com/openshift/machine-api-operator/pkg/apis
 # Some dependencies need to be coppied as well. Othwerwise, controller-gen will complain about non-existing kind Unsupported
 cp -r vendor/k8s.io $dir/src/github.com/openshift/machine-api-operator/vendor/.
@@ -18,7 +20,7 @@ cp -r vendor/github.com $dir/src/github.com/openshift/machine-api-operator/vendo
 
 cwd=$(pwd)
 pushd $dir/src/github.com/openshift/machine-api-operator
-GOPATH=$dir ${cwd}/bin/controller-gen crd --domain openshift.io
+GOPATH=$dir ${cwd}/bin/controller-gen crd --domain openshift.io --skip-map-validation=false
 popd
 
 echo "Coping generated CRDs"

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -68,13 +68,16 @@ spec:
                 going to ignore it if set in create or update request.
               type: string
             creationTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'CreationTimestamp is a timestamp representing the server
                 time when this object was created. It is not guaranteed to be set
                 in happens-before order across separate operations. Clients may not
                 set this value. It is represented in RFC3339 form and is in UTC.  Populated
                 by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             deletionGracePeriodSeconds:
               description: Number of seconds allowed for this object to gracefully
                 terminate before it will be removed from the system. Only set when
@@ -82,6 +85,11 @@ spec:
               format: int64
               type: integer
             deletionTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'DeletionTimestamp is RFC 3339 date and time at which this
                 resource will be deleted. This field is set by the server when a graceful
                 deletion is requested by the user, and is not directly settable by
@@ -101,8 +109,6 @@ spec:
                 fully terminated. If not set, graceful deletion of the object has
                 not been requested.  Populated by the system when a graceful deletion
                 is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             finalizers:
               description: Must be empty before the object is deleted from the registry.
                 Each entry is an identifier for the responsible component that will
@@ -226,14 +232,17 @@ spec:
                     request.
                   type: string
                 creationTimestamp:
+                  anyOf:
+                  - format: date-time
+                    type: string
+                  - enum:
+                    - "null"
                   description: 'CreationTimestamp is a timestamp representing the
                     server time when this object was created. It is not guaranteed
                     to be set in happens-before order across separate operations.
                     Clients may not set this value. It is represented in RFC3339 form
                     and is in UTC.  Populated by the system. Read-only. Null for lists.
                     More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  format: date-time
-                  type: string
                 deletionGracePeriodSeconds:
                   description: Number of seconds allowed for this object to gracefully
                     terminate before it will be removed from the system. Only set
@@ -241,6 +250,11 @@ spec:
                   format: int64
                   type: integer
                 deletionTimestamp:
+                  anyOf:
+                  - format: date-time
+                    type: string
+                  - enum:
+                    - "null"
                   description: 'DeletionTimestamp is RFC 3339 date and time at which
                     this resource will be deleted. This field is set by the server
                     when a graceful deletion is requested by the user, and is not
@@ -261,8 +275,6 @@ spec:
                     the resource is fully terminated. If not set, graceful deletion
                     of the object has not been requested.  Populated by the system
                     when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                  format: date-time
-                  type: string
                 finalizers:
                   description: Must be empty before the object is deleted from the
                     registry. Each entry is an identifier for the responsible component
@@ -487,10 +499,13 @@ spec:
                     last operation.
                   type: string
                 lastUpdated:
+                  anyOf:
+                  - format: date-time
+                    type: string
+                  - enum:
+                    - "null"
                   description: LastUpdated is the timestamp at which LastOperation
                     API was last-updated.
-                  format: date-time
-                  type: string
                 state:
                   description: State is the current status of the last performed operation.
                     E.g. Processing, Failed, Successful etc
@@ -501,9 +516,12 @@ spec:
                   type: string
               type: object
             lastUpdated:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: LastUpdated identifies when this status was last observed.
-              format: date-time
-              type: string
             nodeRef:
               description: NodeRef will point to the corresponding Node if it exists.
               type: object

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -52,6 +52,149 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: 'CreationTimestamp is a timestamp representing the server
+                time when this object was created. It is not guaranteed to be set
+                in happens-before order across separate operations. Clients may not
+                set this value. It is represented in RFC3339 form and is in UTC.  Populated
+                by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: 'DeletionTimestamp is RFC 3339 date and time at which this
+                resource will be deleted. This field is set by the server when a graceful
+                deletion is requested by the user, and is not directly settable by
+                a client. The resource is expected to be deleted (no longer visible
+                from resource lists, and not reachable by name) after the time in
+                this field, once the finalizers list is empty. As long as the finalizers
+                list contains items, deletion is blocked. Once the deletionTimestamp
+                is set, this value may not be unset or be set further into the future,
+                although it may be shortened or the resource may be deleted prior
+                to this time. For example, a user may request that a pod is deleted
+                in 30 seconds. The Kubelet will react by sending a graceful termination
+                signal to the containers in the pod. After that 30 seconds, the Kubelet
+                will send a hard termination signal (SIGKILL) to the container and
+                after cleanup, remove the pod from the API. In the presence of network
+                partitions, this object may still exist after this timestamp, until
+                an administrator or automated process can determine the resource is
+                fully terminated. If not set, graceful deletion of the object has
+                not been requested.  Populated by the system when a graceful deletion
+                is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed. +patchStrategy=merge
+              items:
+                type: string
+              type: array
+            generateName:
+              description: 'GenerateName is an optional prefix, used by the server,
+                to generate a unique name ONLY IF the Name field has not been provided.
+                If this field is used, the name returned to the client will be different
+                than the name passed. This value will also be combined with a unique
+                suffix. The provided value has the same validation rules as the Name
+                field, and may be truncated by the length of the suffix required to
+                make the value unique on the server.  If this field is specified and
+                the generated name exists, the server will NOT return a 409 - instead,
+                it will either return 201 Created or 500 with Reason ServerTimeout
+                indicating a unique name could not be found in the time allotted,
+                and the client should retry (optionally after the time indicated in
+                the Retry-After header).  Applied only if Name is not specified. More
+                info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: An initializer is a controller which enforces some system
+                invariant at object creation time. This field is a list of initializers
+                that have not yet acted on this object. If nil or empty, this object
+                has been completely initialized. Otherwise, the object is considered
+                uninitialized and is hidden (in list/watch and get calls) from clients
+                that haven't explicitly asked to observe uninitialized objects.  When
+                an object is created, the system will populate this list with the
+                current set of initializers. Only privileged users may set or modify
+                this list. Once it is empty, it may not be modified further by any
+                user.
+              type: object
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: 'Namespace defines the space within each name must be unique.
+                An empty namespace is equivalent to the "default" namespace, but "default"
+                is the canonical representation. Not all objects are required to be
+                scoped to a namespace - the value of this field for those objects
+                will be empty.  Must be a DNS_LABEL. Cannot be updated. More info:
+                http://kubernetes.io/docs/user-guide/namespaces'
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller. +patchMergeKey=uid
+                +patchStrategy=merge
+              items:
+                type: object
+              type: array
+            resourceVersion:
+              description: 'An opaque value that represents the internal version of
+                this object that can be used by clients to determine when objects
+                have changed. May be used for optimistic concurrency, change detection,
+                and the watch operation on a resource or set of resources. Clients
+                must treat these values as opaque and passed unmodified back to the
+                server. They may only be valid for a particular resource or set of
+                resources.  Populated by the system. Read-only. Value must be treated
+                as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: 'UID is the unique in time and space value for this object.
+                It is typically generated by the server on successful creation of
+                a resource and is not allowed to change on PUT operations.  Populated
+                by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+              type: string
           type: object
         spec:
           properties:
@@ -66,6 +209,154 @@ spec:
               description: ObjectMeta will autopopulate the Node created. Use this
                 to indicate what labels, annotations, name prefix, etc., should be
                 used when creating the Node.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: 'Annotations is an unstructured key value map stored
+                    with a resource that may be set by external tools to store and
+                    retrieve arbitrary metadata. They are not queryable and should
+                    be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                  type: object
+                clusterName:
+                  description: The name of the cluster which the object belongs to.
+                    This is used to distinguish resources with same name and namespace
+                    in different clusters. This field is not set anywhere right now
+                    and apiserver is going to ignore it if set in create or update
+                    request.
+                  type: string
+                creationTimestamp:
+                  description: 'CreationTimestamp is a timestamp representing the
+                    server time when this object was created. It is not guaranteed
+                    to be set in happens-before order across separate operations.
+                    Clients may not set this value. It is represented in RFC3339 form
+                    and is in UTC.  Populated by the system. Read-only. Null for lists.
+                    More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  format: date-time
+                  type: string
+                deletionGracePeriodSeconds:
+                  description: Number of seconds allowed for this object to gracefully
+                    terminate before it will be removed from the system. Only set
+                    when deletionTimestamp is also set. May only be shortened. Read-only.
+                  format: int64
+                  type: integer
+                deletionTimestamp:
+                  description: 'DeletionTimestamp is RFC 3339 date and time at which
+                    this resource will be deleted. This field is set by the server
+                    when a graceful deletion is requested by the user, and is not
+                    directly settable by a client. The resource is expected to be
+                    deleted (no longer visible from resource lists, and not reachable
+                    by name) after the time in this field, once the finalizers list
+                    is empty. As long as the finalizers list contains items, deletion
+                    is blocked. Once the deletionTimestamp is set, this value may
+                    not be unset or be set further into the future, although it may
+                    be shortened or the resource may be deleted prior to this time.
+                    For example, a user may request that a pod is deleted in 30 seconds.
+                    The Kubelet will react by sending a graceful termination signal
+                    to the containers in the pod. After that 30 seconds, the Kubelet
+                    will send a hard termination signal (SIGKILL) to the container
+                    and after cleanup, remove the pod from the API. In the presence
+                    of network partitions, this object may still exist after this
+                    timestamp, until an administrator or automated process can determine
+                    the resource is fully terminated. If not set, graceful deletion
+                    of the object has not been requested.  Populated by the system
+                    when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  format: date-time
+                  type: string
+                finalizers:
+                  description: Must be empty before the object is deleted from the
+                    registry. Each entry is an identifier for the responsible component
+                    that will remove the entry from the list. If the deletionTimestamp
+                    of the object is non-nil, entries in this list can only be removed.
+                    +patchStrategy=merge
+                  items:
+                    type: string
+                  type: array
+                generateName:
+                  description: 'GenerateName is an optional prefix, used by the server,
+                    to generate a unique name ONLY IF the Name field has not been
+                    provided. If this field is used, the name returned to the client
+                    will be different than the name passed. This value will also be
+                    combined with a unique suffix. The provided value has the same
+                    validation rules as the Name field, and may be truncated by the
+                    length of the suffix required to make the value unique on the
+                    server.  If this field is specified and the generated name exists,
+                    the server will NOT return a 409 - instead, it will either return
+                    201 Created or 500 with Reason ServerTimeout indicating a unique
+                    name could not be found in the time allotted, and the client should
+                    retry (optionally after the time indicated in the Retry-After
+                    header).  Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+                  type: string
+                generation:
+                  description: A sequence number representing a specific generation
+                    of the desired state. Populated by the system. Read-only.
+                  format: int64
+                  type: integer
+                initializers:
+                  description: An initializer is a controller which enforces some
+                    system invariant at object creation time. This field is a list
+                    of initializers that have not yet acted on this object. If nil
+                    or empty, this object has been completely initialized. Otherwise,
+                    the object is considered uninitialized and is hidden (in list/watch
+                    and get calls) from clients that haven't explicitly asked to observe
+                    uninitialized objects.  When an object is created, the system
+                    will populate this list with the current set of initializers.
+                    Only privileged users may set or modify this list. Once it is
+                    empty, it may not be modified further by any user.
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: 'Map of string keys and values that can be used to
+                    organize and categorize (scope and select) objects. May match
+                    selectors of replication controllers and services. More info:
+                    http://kubernetes.io/docs/user-guide/labels'
+                  type: object
+                name:
+                  description: 'Name must be unique within a namespace. Is required
+                    when creating resources, although some resources may allow a client
+                    to request the generation of an appropriate name automatically.
+                    Name is primarily intended for creation idempotence and configuration
+                    definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                  type: string
+                namespace:
+                  description: 'Namespace defines the space within each name must
+                    be unique. An empty namespace is equivalent to the "default" namespace,
+                    but "default" is the canonical representation. Not all objects
+                    are required to be scoped to a namespace - the value of this field
+                    for those objects will be empty.  Must be a DNS_LABEL. Cannot
+                    be updated. More info: http://kubernetes.io/docs/user-guide/namespaces'
+                  type: string
+                ownerReferences:
+                  description: List of objects depended by this object. If ALL objects
+                    in the list have been deleted, this object will be garbage collected.
+                    If this object is managed by a controller, then an entry in this
+                    list will point to this controller, with the controller field
+                    set to true. There cannot be more than one managing controller.
+                    +patchMergeKey=uid +patchStrategy=merge
+                  items:
+                    type: object
+                  type: array
+                resourceVersion:
+                  description: 'An opaque value that represents the internal version
+                    of this object that can be used by clients to determine when objects
+                    have changed. May be used for optimistic concurrency, change detection,
+                    and the watch operation on a resource or set of resources. Clients
+                    must treat these values as opaque and passed unmodified back to
+                    the server. They may only be valid for a particular resource or
+                    set of resources.  Populated by the system. Read-only. Value must
+                    be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                  type: string
+                selfLink:
+                  description: SelfLink is a URL representing this object. Populated
+                    by the system. Read-only.
+                  type: string
+                uid:
+                  description: 'UID is the unique in time and space value for this
+                    object. It is typically generated by the server on successful
+                    creation of a resource and is not allowed to change on PUT operations.  Populated
+                    by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                  type: string
               type: object
             providerID:
               description: ProviderID is the identification ID of the machine provided

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -68,13 +68,16 @@ spec:
                 going to ignore it if set in create or update request.
               type: string
             creationTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'CreationTimestamp is a timestamp representing the server
                 time when this object was created. It is not guaranteed to be set
                 in happens-before order across separate operations. Clients may not
                 set this value. It is represented in RFC3339 form and is in UTC.  Populated
                 by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             deletionGracePeriodSeconds:
               description: Number of seconds allowed for this object to gracefully
                 terminate before it will be removed from the system. Only set when
@@ -82,6 +85,11 @@ spec:
               format: int64
               type: integer
             deletionTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'DeletionTimestamp is RFC 3339 date and time at which this
                 resource will be deleted. This field is set by the server when a graceful
                 deletion is requested by the user, and is not directly settable by
@@ -101,8 +109,6 @@ spec:
                 fully terminated. If not set, graceful deletion of the object has
                 not been requested.  Populated by the system when a graceful deletion
                 is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             finalizers:
               description: Must be empty before the object is deleted from the registry.
                 Each entry is an identifier for the responsible component that will
@@ -239,14 +245,17 @@ spec:
                         or update request.
                       type: string
                     creationTimestamp:
+                      anyOf:
+                      - format: date-time
+                        type: string
+                      - enum:
+                        - "null"
                       description: 'CreationTimestamp is a timestamp representing
                         the server time when this object was created. It is not guaranteed
                         to be set in happens-before order across separate operations.
                         Clients may not set this value. It is represented in RFC3339
                         form and is in UTC.  Populated by the system. Read-only. Null
                         for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                      format: date-time
-                      type: string
                     deletionGracePeriodSeconds:
                       description: Number of seconds allowed for this object to gracefully
                         terminate before it will be removed from the system. Only
@@ -255,6 +264,11 @@ spec:
                       format: int64
                       type: integer
                     deletionTimestamp:
+                      anyOf:
+                      - format: date-time
+                        type: string
+                      - enum:
+                        - "null"
                       description: 'DeletionTimestamp is RFC 3339 date and time at
                         which this resource will be deleted. This field is set by
                         the server when a graceful deletion is requested by the user,
@@ -277,8 +291,6 @@ spec:
                         of the object has not been requested.  Populated by the system
                         when a graceful deletion is requested. Read-only. More info:
                         https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                      format: date-time
-                      type: string
                     finalizers:
                       description: Must be empty before the object is deleted from
                         the registry. Each entry is an identifier for the responsible
@@ -413,14 +425,17 @@ spec:
                             it if set in create or update request.
                           type: string
                         creationTimestamp:
+                          anyOf:
+                          - format: date-time
+                            type: string
+                          - enum:
+                            - "null"
                           description: 'CreationTimestamp is a timestamp representing
                             the server time when this object was created. It is not
                             guaranteed to be set in happens-before order across separate
                             operations. Clients may not set this value. It is represented
                             in RFC3339 form and is in UTC.  Populated by the system.
                             Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                          format: date-time
-                          type: string
                         deletionGracePeriodSeconds:
                           description: Number of seconds allowed for this object to
                             gracefully terminate before it will be removed from the
@@ -429,6 +444,11 @@ spec:
                           format: int64
                           type: integer
                         deletionTimestamp:
+                          anyOf:
+                          - format: date-time
+                            type: string
+                          - enum:
+                            - "null"
                           description: 'DeletionTimestamp is RFC 3339 date and time
                             at which this resource will be deleted. This field is
                             set by the server when a graceful deletion is requested
@@ -452,8 +472,6 @@ spec:
                             set, graceful deletion of the object has not been requested.  Populated
                             by the system when a graceful deletion is requested. Read-only.
                             More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-                          format: date-time
-                          type: string
                         finalizers:
                           description: Must be empty before the object is deleted
                             from the registry. Each entry is an identifier for the

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -52,6 +52,149 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: 'CreationTimestamp is a timestamp representing the server
+                time when this object was created. It is not guaranteed to be set
+                in happens-before order across separate operations. Clients may not
+                set this value. It is represented in RFC3339 form and is in UTC.  Populated
+                by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: 'DeletionTimestamp is RFC 3339 date and time at which this
+                resource will be deleted. This field is set by the server when a graceful
+                deletion is requested by the user, and is not directly settable by
+                a client. The resource is expected to be deleted (no longer visible
+                from resource lists, and not reachable by name) after the time in
+                this field, once the finalizers list is empty. As long as the finalizers
+                list contains items, deletion is blocked. Once the deletionTimestamp
+                is set, this value may not be unset or be set further into the future,
+                although it may be shortened or the resource may be deleted prior
+                to this time. For example, a user may request that a pod is deleted
+                in 30 seconds. The Kubelet will react by sending a graceful termination
+                signal to the containers in the pod. After that 30 seconds, the Kubelet
+                will send a hard termination signal (SIGKILL) to the container and
+                after cleanup, remove the pod from the API. In the presence of network
+                partitions, this object may still exist after this timestamp, until
+                an administrator or automated process can determine the resource is
+                fully terminated. If not set, graceful deletion of the object has
+                not been requested.  Populated by the system when a graceful deletion
+                is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed. +patchStrategy=merge
+              items:
+                type: string
+              type: array
+            generateName:
+              description: 'GenerateName is an optional prefix, used by the server,
+                to generate a unique name ONLY IF the Name field has not been provided.
+                If this field is used, the name returned to the client will be different
+                than the name passed. This value will also be combined with a unique
+                suffix. The provided value has the same validation rules as the Name
+                field, and may be truncated by the length of the suffix required to
+                make the value unique on the server.  If this field is specified and
+                the generated name exists, the server will NOT return a 409 - instead,
+                it will either return 201 Created or 500 with Reason ServerTimeout
+                indicating a unique name could not be found in the time allotted,
+                and the client should retry (optionally after the time indicated in
+                the Retry-After header).  Applied only if Name is not specified. More
+                info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: An initializer is a controller which enforces some system
+                invariant at object creation time. This field is a list of initializers
+                that have not yet acted on this object. If nil or empty, this object
+                has been completely initialized. Otherwise, the object is considered
+                uninitialized and is hidden (in list/watch and get calls) from clients
+                that haven't explicitly asked to observe uninitialized objects.  When
+                an object is created, the system will populate this list with the
+                current set of initializers. Only privileged users may set or modify
+                this list. Once it is empty, it may not be modified further by any
+                user.
+              type: object
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: 'Namespace defines the space within each name must be unique.
+                An empty namespace is equivalent to the "default" namespace, but "default"
+                is the canonical representation. Not all objects are required to be
+                scoped to a namespace - the value of this field for those objects
+                will be empty.  Must be a DNS_LABEL. Cannot be updated. More info:
+                http://kubernetes.io/docs/user-guide/namespaces'
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller. +patchMergeKey=uid
+                +patchStrategy=merge
+              items:
+                type: object
+              type: array
+            resourceVersion:
+              description: 'An opaque value that represents the internal version of
+                this object that can be used by clients to determine when objects
+                have changed. May be used for optimistic concurrency, change detection,
+                and the watch operation on a resource or set of resources. Clients
+                must treat these values as opaque and passed unmodified back to the
+                server. They may only be valid for a particular resource or set of
+                resources.  Populated by the system. Read-only. Value must be treated
+                as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: 'UID is the unique in time and space value for this object.
+                It is typically generated by the server on successful creation of
+                a resource and is not allowed to change on PUT operations.  Populated
+                by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+              type: string
           type: object
         spec:
           properties:
@@ -79,6 +222,162 @@ spec:
               properties:
                 metadata:
                   description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations is an unstructured key value map stored
+                        with a resource that may be set by external tools to store
+                        and retrieve arbitrary metadata. They are not queryable and
+                        should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    clusterName:
+                      description: The name of the cluster which the object belongs
+                        to. This is used to distinguish resources with same name and
+                        namespace in different clusters. This field is not set anywhere
+                        right now and apiserver is going to ignore it if set in create
+                        or update request.
+                      type: string
+                    creationTimestamp:
+                      description: 'CreationTimestamp is a timestamp representing
+                        the server time when this object was created. It is not guaranteed
+                        to be set in happens-before order across separate operations.
+                        Clients may not set this value. It is represented in RFC3339
+                        form and is in UTC.  Populated by the system. Read-only. Null
+                        for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                      format: date-time
+                      type: string
+                    deletionGracePeriodSeconds:
+                      description: Number of seconds allowed for this object to gracefully
+                        terminate before it will be removed from the system. Only
+                        set when deletionTimestamp is also set. May only be shortened.
+                        Read-only.
+                      format: int64
+                      type: integer
+                    deletionTimestamp:
+                      description: 'DeletionTimestamp is RFC 3339 date and time at
+                        which this resource will be deleted. This field is set by
+                        the server when a graceful deletion is requested by the user,
+                        and is not directly settable by a client. The resource is
+                        expected to be deleted (no longer visible from resource lists,
+                        and not reachable by name) after the time in this field, once
+                        the finalizers list is empty. As long as the finalizers list
+                        contains items, deletion is blocked. Once the deletionTimestamp
+                        is set, this value may not be unset or be set further into
+                        the future, although it may be shortened or the resource may
+                        be deleted prior to this time. For example, a user may request
+                        that a pod is deleted in 30 seconds. The Kubelet will react
+                        by sending a graceful termination signal to the containers
+                        in the pod. After that 30 seconds, the Kubelet will send a
+                        hard termination signal (SIGKILL) to the container and after
+                        cleanup, remove the pod from the API. In the presence of network
+                        partitions, this object may still exist after this timestamp,
+                        until an administrator or automated process can determine
+                        the resource is fully terminated. If not set, graceful deletion
+                        of the object has not been requested.  Populated by the system
+                        when a graceful deletion is requested. Read-only. More info:
+                        https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                      format: date-time
+                      type: string
+                    finalizers:
+                      description: Must be empty before the object is deleted from
+                        the registry. Each entry is an identifier for the responsible
+                        component that will remove the entry from the list. If the
+                        deletionTimestamp of the object is non-nil, entries in this
+                        list can only be removed. +patchStrategy=merge
+                      items:
+                        type: string
+                      type: array
+                    generateName:
+                      description: 'GenerateName is an optional prefix, used by the
+                        server, to generate a unique name ONLY IF the Name field has
+                        not been provided. If this field is used, the name returned
+                        to the client will be different than the name passed. This
+                        value will also be combined with a unique suffix. The provided
+                        value has the same validation rules as the Name field, and
+                        may be truncated by the length of the suffix required to make
+                        the value unique on the server.  If this field is specified
+                        and the generated name exists, the server will NOT return
+                        a 409 - instead, it will either return 201 Created or 500
+                        with Reason ServerTimeout indicating a unique name could not
+                        be found in the time allotted, and the client should retry
+                        (optionally after the time indicated in the Retry-After header).  Applied
+                        only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+                      type: string
+                    generation:
+                      description: A sequence number representing a specific generation
+                        of the desired state. Populated by the system. Read-only.
+                      format: int64
+                      type: integer
+                    initializers:
+                      description: An initializer is a controller which enforces some
+                        system invariant at object creation time. This field is a
+                        list of initializers that have not yet acted on this object.
+                        If nil or empty, this object has been completely initialized.
+                        Otherwise, the object is considered uninitialized and is hidden
+                        (in list/watch and get calls) from clients that haven't explicitly
+                        asked to observe uninitialized objects.  When an object is
+                        created, the system will populate this list with the current
+                        set of initializers. Only privileged users may set or modify
+                        this list. Once it is empty, it may not be modified further
+                        by any user.
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Map of string keys and values that can be used
+                        to organize and categorize (scope and select) objects. May
+                        match selectors of replication controllers and services. More
+                        info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: 'Name must be unique within a namespace. Is required
+                        when creating resources, although some resources may allow
+                        a client to request the generation of an appropriate name
+                        automatically. Name is primarily intended for creation idempotence
+                        and configuration definition. Cannot be updated. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace defines the space within each name must
+                        be unique. An empty namespace is equivalent to the "default"
+                        namespace, but "default" is the canonical representation.
+                        Not all objects are required to be scoped to a namespace -
+                        the value of this field for those objects will be empty.  Must
+                        be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces'
+                      type: string
+                    ownerReferences:
+                      description: List of objects depended by this object. If ALL
+                        objects in the list have been deleted, this object will be
+                        garbage collected. If this object is managed by a controller,
+                        then an entry in this list will point to this controller,
+                        with the controller field set to true. There cannot be more
+                        than one managing controller. +patchMergeKey=uid +patchStrategy=merge
+                      items:
+                        type: object
+                      type: array
+                    resourceVersion:
+                      description: 'An opaque value that represents the internal version
+                        of this object that can be used by clients to determine when
+                        objects have changed. May be used for optimistic concurrency,
+                        change detection, and the watch operation on a resource or
+                        set of resources. Clients must treat these values as opaque
+                        and passed unmodified back to the server. They may only be
+                        valid for a particular resource or set of resources.  Populated
+                        by the system. Read-only. Value must be treated as opaque
+                        by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    selfLink:
+                      description: SelfLink is a URL representing this object. Populated
+                        by the system. Read-only.
+                      type: string
+                    uid:
+                      description: 'UID is the unique in time and space value for
+                        this object. It is typically generated by the server on successful
+                        creation of a resource and is not allowed to change on PUT
+                        operations.  Populated by the system. Read-only. More info:
+                        http://kubernetes.io/docs/user-guide/identifiers#uids'
+                      type: string
                   type: object
                 spec:
                   description: 'Specification of the desired behavior of the machine.
@@ -96,6 +395,167 @@ spec:
                       description: ObjectMeta will autopopulate the Node created.
                         Use this to indicate what labels, annotations, name prefix,
                         etc., should be used when creating the Node.
+                      properties:
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          description: 'Annotations is an unstructured key value map
+                            stored with a resource that may be set by external tools
+                            to store and retrieve arbitrary metadata. They are not
+                            queryable and should be preserved when modifying objects.
+                            More info: http://kubernetes.io/docs/user-guide/annotations'
+                          type: object
+                        clusterName:
+                          description: The name of the cluster which the object belongs
+                            to. This is used to distinguish resources with same name
+                            and namespace in different clusters. This field is not
+                            set anywhere right now and apiserver is going to ignore
+                            it if set in create or update request.
+                          type: string
+                        creationTimestamp:
+                          description: 'CreationTimestamp is a timestamp representing
+                            the server time when this object was created. It is not
+                            guaranteed to be set in happens-before order across separate
+                            operations. Clients may not set this value. It is represented
+                            in RFC3339 form and is in UTC.  Populated by the system.
+                            Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                          format: date-time
+                          type: string
+                        deletionGracePeriodSeconds:
+                          description: Number of seconds allowed for this object to
+                            gracefully terminate before it will be removed from the
+                            system. Only set when deletionTimestamp is also set. May
+                            only be shortened. Read-only.
+                          format: int64
+                          type: integer
+                        deletionTimestamp:
+                          description: 'DeletionTimestamp is RFC 3339 date and time
+                            at which this resource will be deleted. This field is
+                            set by the server when a graceful deletion is requested
+                            by the user, and is not directly settable by a client.
+                            The resource is expected to be deleted (no longer visible
+                            from resource lists, and not reachable by name) after
+                            the time in this field, once the finalizers list is empty.
+                            As long as the finalizers list contains items, deletion
+                            is blocked. Once the deletionTimestamp is set, this value
+                            may not be unset or be set further into the future, although
+                            it may be shortened or the resource may be deleted prior
+                            to this time. For example, a user may request that a pod
+                            is deleted in 30 seconds. The Kubelet will react by sending
+                            a graceful termination signal to the containers in the
+                            pod. After that 30 seconds, the Kubelet will send a hard
+                            termination signal (SIGKILL) to the container and after
+                            cleanup, remove the pod from the API. In the presence
+                            of network partitions, this object may still exist after
+                            this timestamp, until an administrator or automated process
+                            can determine the resource is fully terminated. If not
+                            set, graceful deletion of the object has not been requested.  Populated
+                            by the system when a graceful deletion is requested. Read-only.
+                            More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                          format: date-time
+                          type: string
+                        finalizers:
+                          description: Must be empty before the object is deleted
+                            from the registry. Each entry is an identifier for the
+                            responsible component that will remove the entry from
+                            the list. If the deletionTimestamp of the object is non-nil,
+                            entries in this list can only be removed. +patchStrategy=merge
+                          items:
+                            type: string
+                          type: array
+                        generateName:
+                          description: 'GenerateName is an optional prefix, used by
+                            the server, to generate a unique name ONLY IF the Name
+                            field has not been provided. If this field is used, the
+                            name returned to the client will be different than the
+                            name passed. This value will also be combined with a unique
+                            suffix. The provided value has the same validation rules
+                            as the Name field, and may be truncated by the length
+                            of the suffix required to make the value unique on the
+                            server.  If this field is specified and the generated
+                            name exists, the server will NOT return a 409 - instead,
+                            it will either return 201 Created or 500 with Reason ServerTimeout
+                            indicating a unique name could not be found in the time
+                            allotted, and the client should retry (optionally after
+                            the time indicated in the Retry-After header).  Applied
+                            only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+                          type: string
+                        generation:
+                          description: A sequence number representing a specific generation
+                            of the desired state. Populated by the system. Read-only.
+                          format: int64
+                          type: integer
+                        initializers:
+                          description: An initializer is a controller which enforces
+                            some system invariant at object creation time. This field
+                            is a list of initializers that have not yet acted on this
+                            object. If nil or empty, this object has been completely
+                            initialized. Otherwise, the object is considered uninitialized
+                            and is hidden (in list/watch and get calls) from clients
+                            that haven't explicitly asked to observe uninitialized
+                            objects.  When an object is created, the system will populate
+                            this list with the current set of initializers. Only privileged
+                            users may set or modify this list. Once it is empty, it
+                            may not be modified further by any user.
+                          type: object
+                        labels:
+                          additionalProperties:
+                            type: string
+                          description: 'Map of string keys and values that can be
+                            used to organize and categorize (scope and select) objects.
+                            May match selectors of replication controllers and services.
+                            More info: http://kubernetes.io/docs/user-guide/labels'
+                          type: object
+                        name:
+                          description: 'Name must be unique within a namespace. Is
+                            required when creating resources, although some resources
+                            may allow a client to request the generation of an appropriate
+                            name automatically. Name is primarily intended for creation
+                            idempotence and configuration definition. Cannot be updated.
+                            More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                          type: string
+                        namespace:
+                          description: 'Namespace defines the space within each name
+                            must be unique. An empty namespace is equivalent to the
+                            "default" namespace, but "default" is the canonical representation.
+                            Not all objects are required to be scoped to a namespace
+                            - the value of this field for those objects will be empty.  Must
+                            be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces'
+                          type: string
+                        ownerReferences:
+                          description: List of objects depended by this object. If
+                            ALL objects in the list have been deleted, this object
+                            will be garbage collected. If this object is managed by
+                            a controller, then an entry in this list will point to
+                            this controller, with the controller field set to true.
+                            There cannot be more than one managing controller. +patchMergeKey=uid
+                            +patchStrategy=merge
+                          items:
+                            type: object
+                          type: array
+                        resourceVersion:
+                          description: 'An opaque value that represents the internal
+                            version of this object that can be used by clients to
+                            determine when objects have changed. May be used for optimistic
+                            concurrency, change detection, and the watch operation
+                            on a resource or set of resources. Clients must treat
+                            these values as opaque and passed unmodified back to the
+                            server. They may only be valid for a particular resource
+                            or set of resources.  Populated by the system. Read-only.
+                            Value must be treated as opaque by clients and . More
+                            info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+                          type: string
+                        selfLink:
+                          description: SelfLink is a URL representing this object.
+                            Populated by the system. Read-only.
+                          type: string
+                        uid:
+                          description: 'UID is the unique in time and space value
+                            for this object. It is typically generated by the server
+                            on successful creation of a resource and is not allowed
+                            to change on PUT operations.  Populated by the system.
+                            Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                          type: string
                       type: object
                     providerID:
                       description: ProviderID is the identification ID of the machine

--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -41,13 +41,16 @@ spec:
                 going to ignore it if set in create or update request.
               type: string
             creationTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'CreationTimestamp is a timestamp representing the server
                 time when this object was created. It is not guaranteed to be set
                 in happens-before order across separate operations. Clients may not
                 set this value. It is represented in RFC3339 form and is in UTC.  Populated
                 by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             deletionGracePeriodSeconds:
               description: Number of seconds allowed for this object to gracefully
                 terminate before it will be removed from the system. Only set when
@@ -55,6 +58,11 @@ spec:
               format: int64
               type: integer
             deletionTimestamp:
+              anyOf:
+              - format: date-time
+                type: string
+              - enum:
+                - "null"
               description: 'DeletionTimestamp is RFC 3339 date and time at which this
                 resource will be deleted. This field is set by the server when a graceful
                 deletion is requested by the user, and is not directly settable by
@@ -74,8 +82,6 @@ spec:
                 fully terminated. If not set, graceful deletion of the object has
                 not been requested.  Populated by the system when a graceful deletion
                 is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-              format: date-time
-              type: string
             finalizers:
               description: Must be empty before the object is deleted from the registry.
                 Each entry is an identifier for the responsible component that will

--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -25,6 +25,149 @@ spec:
             submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
           type: string
         metadata:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: 'Annotations is an unstructured key value map stored with
+                a resource that may be set by external tools to store and retrieve
+                arbitrary metadata. They are not queryable and should be preserved
+                when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+              type: object
+            clusterName:
+              description: The name of the cluster which the object belongs to. This
+                is used to distinguish resources with same name and namespace in different
+                clusters. This field is not set anywhere right now and apiserver is
+                going to ignore it if set in create or update request.
+              type: string
+            creationTimestamp:
+              description: 'CreationTimestamp is a timestamp representing the server
+                time when this object was created. It is not guaranteed to be set
+                in happens-before order across separate operations. Clients may not
+                set this value. It is represented in RFC3339 form and is in UTC.  Populated
+                by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            deletionGracePeriodSeconds:
+              description: Number of seconds allowed for this object to gracefully
+                terminate before it will be removed from the system. Only set when
+                deletionTimestamp is also set. May only be shortened. Read-only.
+              format: int64
+              type: integer
+            deletionTimestamp:
+              description: 'DeletionTimestamp is RFC 3339 date and time at which this
+                resource will be deleted. This field is set by the server when a graceful
+                deletion is requested by the user, and is not directly settable by
+                a client. The resource is expected to be deleted (no longer visible
+                from resource lists, and not reachable by name) after the time in
+                this field, once the finalizers list is empty. As long as the finalizers
+                list contains items, deletion is blocked. Once the deletionTimestamp
+                is set, this value may not be unset or be set further into the future,
+                although it may be shortened or the resource may be deleted prior
+                to this time. For example, a user may request that a pod is deleted
+                in 30 seconds. The Kubelet will react by sending a graceful termination
+                signal to the containers in the pod. After that 30 seconds, the Kubelet
+                will send a hard termination signal (SIGKILL) to the container and
+                after cleanup, remove the pod from the API. In the presence of network
+                partitions, this object may still exist after this timestamp, until
+                an administrator or automated process can determine the resource is
+                fully terminated. If not set, graceful deletion of the object has
+                not been requested.  Populated by the system when a graceful deletion
+                is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+              format: date-time
+              type: string
+            finalizers:
+              description: Must be empty before the object is deleted from the registry.
+                Each entry is an identifier for the responsible component that will
+                remove the entry from the list. If the deletionTimestamp of the object
+                is non-nil, entries in this list can only be removed. +patchStrategy=merge
+              items:
+                type: string
+              type: array
+            generateName:
+              description: 'GenerateName is an optional prefix, used by the server,
+                to generate a unique name ONLY IF the Name field has not been provided.
+                If this field is used, the name returned to the client will be different
+                than the name passed. This value will also be combined with a unique
+                suffix. The provided value has the same validation rules as the Name
+                field, and may be truncated by the length of the suffix required to
+                make the value unique on the server.  If this field is specified and
+                the generated name exists, the server will NOT return a 409 - instead,
+                it will either return 201 Created or 500 with Reason ServerTimeout
+                indicating a unique name could not be found in the time allotted,
+                and the client should retry (optionally after the time indicated in
+                the Retry-After header).  Applied only if Name is not specified. More
+                info: https://git.k8s.io/community/contributors/devel/api-conventions.md#idempotency'
+              type: string
+            generation:
+              description: A sequence number representing a specific generation of
+                the desired state. Populated by the system. Read-only.
+              format: int64
+              type: integer
+            initializers:
+              description: An initializer is a controller which enforces some system
+                invariant at object creation time. This field is a list of initializers
+                that have not yet acted on this object. If nil or empty, this object
+                has been completely initialized. Otherwise, the object is considered
+                uninitialized and is hidden (in list/watch and get calls) from clients
+                that haven't explicitly asked to observe uninitialized objects.  When
+                an object is created, the system will populate this list with the
+                current set of initializers. Only privileged users may set or modify
+                this list. Once it is empty, it may not be modified further by any
+                user.
+              type: object
+            labels:
+              additionalProperties:
+                type: string
+              description: 'Map of string keys and values that can be used to organize
+                and categorize (scope and select) objects. May match selectors of
+                replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+              type: object
+            name:
+              description: 'Name must be unique within a namespace. Is required when
+                creating resources, although some resources may allow a client to
+                request the generation of an appropriate name automatically. Name
+                is primarily intended for creation idempotence and configuration definition.
+                Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+              type: string
+            namespace:
+              description: 'Namespace defines the space within each name must be unique.
+                An empty namespace is equivalent to the "default" namespace, but "default"
+                is the canonical representation. Not all objects are required to be
+                scoped to a namespace - the value of this field for those objects
+                will be empty.  Must be a DNS_LABEL. Cannot be updated. More info:
+                http://kubernetes.io/docs/user-guide/namespaces'
+              type: string
+            ownerReferences:
+              description: List of objects depended by this object. If ALL objects
+                in the list have been deleted, this object will be garbage collected.
+                If this object is managed by a controller, then an entry in this list
+                will point to this controller, with the controller field set to true.
+                There cannot be more than one managing controller. +patchMergeKey=uid
+                +patchStrategy=merge
+              items:
+                type: object
+              type: array
+            resourceVersion:
+              description: 'An opaque value that represents the internal version of
+                this object that can be used by clients to determine when objects
+                have changed. May be used for optimistic concurrency, change detection,
+                and the watch operation on a resource or set of resources. Clients
+                must treat these values as opaque and passed unmodified back to the
+                server. They may only be valid for a particular resource or set of
+                resources.  Populated by the system. Read-only. Value must be treated
+                as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#concurrency-control-and-consistency'
+              type: string
+            selfLink:
+              description: SelfLink is a URL representing this object. Populated by
+                the system. Read-only.
+              type: string
+            uid:
+              description: 'UID is the unique in time and space value for this object.
+                It is typically generated by the server on successful creation of
+                a resource and is not allowed to change on PUT operations.  Populated
+                by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+              type: string
           type: object
         spec:
           properties:

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
@@ -39,6 +39,12 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".status.providerStatus.instanceId",description="Instance ID of machine created in AWS"
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.providerStatus.instanceState",description="State of the AWS instance"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.providerSpec.value.instanceType",description="Type of instance"
+// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".spec.providerSpec.value.placement.region",description="Region associated with machine"
+// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".spec.providerSpec.value.placement.availabilityZone",description="Zone associated with machine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machine age"
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
@@ -35,6 +35,11 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Current Replicas"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Ready Replicas"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.availableReplicas",description="Observed number of available replicas"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machineset age"
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Schema generated with https://github.com/kubernetes-sigs/controller-tools/pull/195 applied.

- master HEAD of controller-gen has changed and requires PROJECT file to exist now
- disabling the crd generator until https://github.com/kubernetes-sigs/controller-tools/pull/195 gets resolved.

https://bugzilla.redhat.com/show_bug.cgi?id=1702089