### PR TITLE
Run make test-e2e from vendor cluster-api-actuator-pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -441,7 +441,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:7cbcae314ea9375bebbecfc8b520bbce9786f9c4d1b42824f2a1613695e3faad"
+  digest = "1:10a5ccf52b9b2af2f8e9bf51ef8e67324e9e999f73099ddea1c849ae5295ced8"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e",
@@ -454,7 +454,7 @@
     "pkg/types",
   ]
   pruneopts = ""
-  revision = "59a034672129ff21181ac38871a47dabbc900c7f"
+  revision = "7405f6233af2dd7ff0bc6ac815d4a7e954af8ade"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,8 @@ build-integration: ## Build integration test binary
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
-	go test -timeout 60m \
-		-v ./vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
-		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
-		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr true
+	cd ./vendor/github.com/openshift/cluster-api-actuator-pkg && \
+		make test-e2e
 
 .PHONY: deploy-kubemark
 deploy-kubemark:

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
@@ -372,7 +372,7 @@
 
 [[projects]]
   branch = "openshift-4.0-cluster-api-0.0.0-alpha.4"
-  digest = "1:dbd28c2d6b9c58d0dfbfaa7cb2efce07fc36f812c2eb52197856d40d91a635bb"
+  digest = "1:999aa1e8d36fbd410b276ef5a47d62d4a2caaece354e4377f7b8d27f9d75f3ca"
   name = "github.com/openshift/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -388,7 +388,7 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "5c833e464afbd8a9b3aca3f1d09943478bd90521"
+  revision = "776449739aa75bee4287469e3c82ded381f50b3c"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
@@ -45,22 +45,21 @@ build-e2e:
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
-	go test -timeout 90m \
-		-v github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
-		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
-		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr true
+	# Run operator tests first to preserve logs for troubleshooting test
+	# failures and flakes.
+	# Feature:Operator tests remove deployments. Thus loosing all the logs
+	# previously acquired.
+	E2EWORKDIR=${PWD} hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
+	E2EWORKDIR=${PWD} hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
 
 .PHONY: k8s-e2e
 k8s-e2e: ## Run k8s specific e2e test
-	go test -timeout 30m \
-		-v github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
-		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
-		-machine-api-namespace $${NAMESPACE:-kube-system} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr true
-
+	# Run operator tests first to preserve logs for troubleshooting test
+	# failures and flakes.
+	# Feature:Operator tests remove deployments. Thus loosing all the logs
+	# previously acquired.
+	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
+	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
 
 .PHONY: help
 help:

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/ci-integration.sh
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/ci-integration.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+go test -timeout 90m \
+  $E2EWORKDIR/pkg/e2e \
+  -kubeconfig ${KUBECONFIG:-~/.kube/config} \
+  -machine-api-namespace ${NAMESPACE:-openshift-machine-api} \
+  -args -v 5 -logtostderr \
+  $@

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/manifests/manifests.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/manifests/manifests.go
@@ -948,7 +948,7 @@ func TestingMachine(clusterID string, namespace string, providerSpec machinev1be
 			Namespace:    namespace,
 			GenerateName: "vs-master-",
 			Labels: map[string]string{
-				"sigs.k8s.io/cluster-api-cluster": clusterID,
+				"machine.openshift.io/cluster-api-cluster": clusterID,
 			},
 		},
 		Spec: machinev1beta1.MachineSpec{
@@ -976,7 +976,7 @@ func MasterMachine(clusterID, namespace string, providerSpec machinev1beta1.Prov
 			Namespace:    namespace,
 			GenerateName: "vs-master-",
 			Labels: map[string]string{
-				"sigs.k8s.io/cluster-api-cluster": clusterID,
+				"machine.openshift.io/cluster-api-cluster": clusterID,
 			},
 		},
 		Spec: machinev1beta1.MachineSpec{
@@ -1050,14 +1050,14 @@ func WorkerMachineSet(clusterID, namespace string, providerSpec machinev1beta1.P
 			Namespace:    namespace,
 			GenerateName: clusterID + "-worker-machine-" + randomUUID[:6] + "-",
 			Labels: map[string]string{
-				"sigs.k8s.io/cluster-api-cluster": clusterID,
+				"machine.openshift.io/cluster-api-cluster": clusterID,
 			},
 		},
 		Spec: machinev1beta1.MachineSetSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"sigs.k8s.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
-					"sigs.k8s.io/cluster-api-cluster":    clusterID,
+					"machine.openshift.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
+					"machine.openshift.io/cluster-api-cluster":    clusterID,
 				},
 			},
 			Replicas: &replicas,
@@ -1065,8 +1065,8 @@ func WorkerMachineSet(clusterID, namespace string, providerSpec machinev1beta1.P
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: clusterID + "-worker-machine-" + randomUUID[:6] + "-",
 					Labels: map[string]string{
-						"sigs.k8s.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
-						"sigs.k8s.io/cluster-api-cluster":    clusterID,
+						"machine.openshift.io/cluster-api-machineset": clusterID + "-worker-machineset-" + randomUUID[:6],
+						"machine.openshift.io/cluster-api-cluster":    clusterID,
 					},
 				},
 				Spec: machinev1beta1.MachineSpec{


### PR DESCRIPTION
This commit enables running make script directly from
cluster-api-actuator-pkg to reduce drift.