### PR TITLE
Run make test-e2e from vendor cluster-api-actuator-pkg

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -441,7 +441,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c51e502153acd32f728210817c40fc8e1d6851d2b64a0be0b5c0186ee32218ac"
+  digest = "1:9941e130964f8b2d2f1b17084ed0d254e00d237fc5bb58e922fd22e2d949d2e0"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e",
@@ -454,7 +454,7 @@
     "pkg/types",
   ]
   pruneopts = ""
-  revision = "286578aa9fd0510b7c37fbd4b4ab9c0eab7b03eb"
+  revision = "0956b3853db225806a79284f3cffbf66ea32be1f"
 
 [[projects]]
   branch = "master"

--- a/Makefile
+++ b/Makefile
@@ -65,12 +65,7 @@ build-integration: ## Build integration test binary
 
 .PHONY: test-e2e
 test-e2e: ## Run openshift specific e2e test
-	go test -timeout 60m \
-		-v ./vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e \
-		-kubeconfig $${KUBECONFIG:-~/.kube/config} \
-		-machine-api-namespace $${NAMESPACE:-openshift-machine-api} \
-		-ginkgo.v \
-		-args -v 5 -logtostderr true
+	$(MAKE) -C ./vendor/github.com/openshift/cluster-api-actuator-pkg $@
 
 .PHONY: deploy-kubemark
 deploy-kubemark:

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/ci-integration.sh
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/ci-integration.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+go test -timeout 90m \
+  -v ./pkg/e2e \
+  -kubeconfig ${KUBECONFIG:-~/.kube/config} \
+  -machine-api-namespace ${NAMESPACE:-openshift-machine-api} \
+  -args -v 5 -logtostderr \
+  "$@"


### PR DESCRIPTION
This commit enables running make script directly from
cluster-api-actuator-pkg to reduce drift.

