### PR TITLE
[4.1] Feature gate HC by cluster feature gate object

### DIFF
--- a/pkg/operator/featuresgate.go
+++ b/pkg/operator/featuresgate.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// MachineAPIFeatureGateName contains a name of the machine API FeatureGate object
-	MachineAPIFeatureGateName = "machine-api"
+	MachineAPIFeatureGateName = "cluster"
 
 	// FeatureGateMachineHealthCheck contains the name of the MachineHealthCheck feature gate
 	FeatureGateMachineHealthCheck = "MachineHealthCheck"


### PR DESCRIPTION
Machine API created its own feature gate object key and diverged from all other
components expecting 'cluster' key instead. Renaming the key to 'cluster'
to minimize the confusion.