### PR TITLE
Move common testing methods to the separate package

### DIFF
--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -1,7 +1,6 @@
 package disruption
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -9,8 +8,8 @@ import (
 
 	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+	maotesting "github.com/openshift/machine-api-operator/pkg/util/testing"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,10 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-const namespace = "openshift-machine-api"
-
-var knownDate = metav1.Time{Time: time.Date(1985, 06, 03, 0, 0, 0, 0, time.Local)}
 
 func init() {
 	// Add types to scheme
@@ -39,47 +34,7 @@ func newFakeReconciler(recorder record.EventRecorder, initObjects ...runtime.Obj
 		client:    fakeClient,
 		recorder:  recorder,
 		scheme:    scheme.Scheme,
-		namespace: namespace,
-	}
-}
-
-func fooBar() map[string]string {
-	return map[string]string{"foo": "bar"}
-}
-
-func newSelector(labels map[string]string) *metav1.LabelSelector {
-	return &metav1.LabelSelector{MatchLabels: labels}
-}
-
-func newSelectorFooBar() *metav1.LabelSelector {
-	return newSelector(fooBar())
-}
-
-func newMinAvailableMachineDisruptionBudget(minAvailable int32) *healthcheckingv1alpha1.MachineDisruptionBudget {
-	return &healthcheckingv1alpha1.MachineDisruptionBudget{
-		TypeMeta: metav1.TypeMeta{Kind: "MachineDisruptionBudget"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foobar",
-			Namespace: namespace,
-		},
-		Spec: healthcheckingv1alpha1.MachineDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
-			Selector:     newSelectorFooBar(),
-		},
-	}
-}
-
-func newMaxUnavailableMachineDisruptionBudget(maxUnavailable int32) *healthcheckingv1alpha1.MachineDisruptionBudget {
-	return &healthcheckingv1alpha1.MachineDisruptionBudget{
-		TypeMeta: metav1.TypeMeta{Kind: "MachineDisruptionBudget"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "foobar",
-			Namespace: namespace,
-		},
-		Spec: healthcheckingv1alpha1.MachineDisruptionBudgetSpec{
-			MaxUnavailable: &maxUnavailable,
-			Selector:       newSelectorFooBar(),
-		},
+		namespace: maotesting.Namespace,
 	}
 }
 
@@ -96,69 +51,18 @@ func updateMachineOwnerToMachineSet(machine *mapiv1.Machine, ms *mapiv1.MachineS
 	machine.OwnerReferences = append(machine.OwnerReferences, controllerReference)
 }
 
-func newNode(name string, ready bool) *v1.Node {
-	nodeReadyStatus := v1.ConditionTrue
-	if !ready {
-		nodeReadyStatus = v1.ConditionUnknown
-	}
-
-	return &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: metav1.NamespaceNone,
-			Annotations: map[string]string{
-				"machine": fmt.Sprintf("%s/%s", namespace, "fakeMachine"),
-			},
-			Labels: map[string]string{},
-			UID:    uuid.NewUUID(),
-		},
-		TypeMeta: metav1.TypeMeta{
-			Kind: "Node",
-		},
-		Status: v1.NodeStatus{
-			Conditions: []v1.NodeCondition{
-				{
-					Type:               v1.NodeReady,
-					Status:             nodeReadyStatus,
-					LastTransitionTime: knownDate,
-				},
-			},
-		},
-	}
-}
-
-func newMachine(name string, nodeName string, phase string) *mapiv1.Machine {
-	return &mapiv1.Machine{
-		TypeMeta: metav1.TypeMeta{Kind: "Machine"},
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: make(map[string]string),
-			Name:        name,
-			Namespace:   namespace,
-			Labels:      fooBar(),
-			UID:         uuid.NewUUID(),
-		},
-		Spec: mapiv1.MachineSpec{},
-		Status: mapiv1.MachineStatus{
-			NodeRef: &v1.ObjectReference{
-				Name: nodeName,
-			},
-			Phase: &phase,
-		},
-	}
-}
-
 func newMachineSet(name string, size int32) *mapiv1.MachineSet {
 	return &mapiv1.MachineSet{
 		TypeMeta: metav1.TypeMeta{Kind: "MachineSet"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
-			Labels:    fooBar(),
+			Namespace: maotesting.Namespace,
+			Labels:    maotesting.FooBar(),
 			UID:       uuid.NewUUID(),
 		},
 		Spec: mapiv1.MachineSetSpec{
 			Replicas: &size,
-			Selector: *newSelectorFooBar(),
+			Selector: *maotesting.NewSelectorFooBar(),
 		},
 	}
 }
@@ -181,13 +85,13 @@ func newMachineDeployment(name string, size int32) *mapiv1.MachineDeployment {
 		TypeMeta: metav1.TypeMeta{Kind: "MachineDeployment"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: namespace,
-			Labels:    fooBar(),
+			Namespace: maotesting.Namespace,
+			Labels:    maotesting.FooBar(),
 			UID:       uuid.NewUUID(),
 		},
 		Spec: mapiv1.MachineDeploymentSpec{
 			Replicas: &size,
-			Selector: *newSelectorFooBar(),
+			Selector: *maotesting.NewSelectorFooBar(),
 		},
 	}
 }
@@ -198,24 +102,24 @@ type expectedMachineCount struct {
 }
 
 func TestGetExpectedMachineCount(t *testing.T) {
-	mdbMinAvailable := newMinAvailableMachineDisruptionBudget(1)
-	mdbMaxUnavailable := newMaxUnavailableMachineDisruptionBudget(1)
+	mdbMinAvailable := maotesting.NewMinAvailableMachineDisruptionBudget(1)
+	mdbMaxUnavailable := maotesting.NewMaxUnavailableMachineDisruptionBudget(1)
 
-	node := newNode("node", true)
+	node := maotesting.NewNode("node", true)
 
 	// will check the expected result when the machine does not owned by controller
-	machine := newMachine("machine1", node.Name, "Running")
+	machine := maotesting.NewMachine("machine1", node.Name)
 
 	// will check the expected result when the machine owned by MachineSet controller
 	machineSet := newMachineSet("ms1", 3)
-	machineControlledByMachineSet := newMachine("machine2", node.Name, "Running")
+	machineControlledByMachineSet := maotesting.NewMachine("machine2", node.Name)
 	updateMachineOwnerToMachineSet(machineControlledByMachineSet, machineSet)
 
 	// will check the expected result when the machine owned by MachineDeployment controller
 	machineSetControlledByDeployment := newMachineSet("ms2", 4)
 	machineDeployment := newMachineDeployment("md1", 4)
 	updateMachineSetOwnerToMachineDeployment(machineSetControlledByDeployment, machineDeployment)
-	machineControlledByMachineDeployment := newMachine("machine3", node.Name, "Running")
+	machineControlledByMachineDeployment := maotesting.NewMachine("machine3", node.Name)
 	updateMachineOwnerToMachineSet(machineControlledByMachineDeployment, machineSetControlledByDeployment)
 
 	testsCases := []struct {
@@ -328,25 +232,25 @@ type expectedMachinesForMDB struct {
 }
 
 func TestGetMachinesForMachineDisruptionBudget(t *testing.T) {
-	mdbWithSelector := newMinAvailableMachineDisruptionBudget(3)
+	mdbWithSelector := maotesting.NewMinAvailableMachineDisruptionBudget(3)
 
-	mdbWithoutSelector := newMinAvailableMachineDisruptionBudget(3)
+	mdbWithoutSelector := maotesting.NewMinAvailableMachineDisruptionBudget(3)
 	mdbWithoutSelector.Spec.Selector = nil
 
-	mdbWithEmptySelector := newMinAvailableMachineDisruptionBudget(3)
+	mdbWithEmptySelector := maotesting.NewMinAvailableMachineDisruptionBudget(3)
 	mdbWithEmptySelector.Spec.Selector = &metav1.LabelSelector{}
 
-	mdbWithBadSelector := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithBadSelector := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithBadSelector.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels:      map[string]string{},
 		MatchExpressions: []metav1.LabelSelectorRequirement{{Operator: "fake"}},
 	}
 
-	node := newNode("node", true)
+	node := maotesting.NewNode("node", true)
 
-	machineWithLabels1 := newMachine("machineWithLabels1", node.Name, "Running")
-	machineWithLabels2 := newMachine("machineWithLabels2", node.Name, "Running")
-	machineWithoutLabels := newMachine("machineWithoutLabels", node.Name, "Running")
+	machineWithLabels1 := maotesting.NewMachine("machineWithLabels1", node.Name)
+	machineWithLabels2 := maotesting.NewMachine("machineWithLabels2", node.Name)
+	machineWithoutLabels := maotesting.NewMachine("machineWithoutLabels", node.Name)
 	machineWithoutLabels.Labels = map[string]string{}
 
 	testsCases := []struct {
@@ -416,24 +320,24 @@ type expectedDisrupteMachines struct {
 }
 
 func TestBuildDisruptedMachineMap(t *testing.T) {
-	node := newNode("node", true)
+	node := maotesting.NewNode("node", true)
 
 	currentTime := metav1.NewTime(time.Now())
 	timeAfterTwoMinutes := currentTime.Add(2 * time.Minute)
 	timeBeforeThreeMinutes := metav1.NewTime(currentTime.Add(-3 * time.Minute))
 
-	machine := newMachine("machine", node.Name, "Running")
-	deletedMachine := newMachine("deletedMachine", node.Name, "Running")
+	machine := maotesting.NewMachine("machine", node.Name)
+	deletedMachine := maotesting.NewMachine("deletedMachine", node.Name)
 	deletedMachine.DeletionTimestamp = &currentTime
-	disruptedMachineBeforeTimeout := newMachine("disruptedMachineBeforeTimeout", node.Name, "Running")
-	disruptedMachineAfterTimeout := newMachine("disruptedMachineAfterTimeout", node.Name, "Running")
+	disruptedMachineBeforeTimeout := maotesting.NewMachine("disruptedMachineBeforeTimeout", node.Name)
+	disruptedMachineAfterTimeout := maotesting.NewMachine("disruptedMachineAfterTimeout", node.Name)
 
-	mdbWithDisruptedMachines := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithDisruptedMachines := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithDisruptedMachines.Status.DisruptedMachines = map[string]metav1.Time{
 		disruptedMachineBeforeTimeout.Name: timeBeforeThreeMinutes,
 		disruptedMachineAfterTimeout.Name:  currentTime,
 	}
-	mdbWithoutDisruptedMachines := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithoutDisruptedMachines := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 
 	testsCases := []struct {
 		testName string
@@ -492,19 +396,19 @@ func TestBuildDisruptedMachineMap(t *testing.T) {
 }
 
 func TestCountHealthyMachines(t *testing.T) {
-	healthyNode := newNode("healthyNode", true)
-	unhealthyNode := newNode("unhealthyNode", false)
+	healthyNode := maotesting.NewNode("healthyNode", true)
+	unhealthyNode := maotesting.NewNode("unhealthyNode", false)
 
 	currentTime := metav1.NewTime(time.Now())
 	timeAfterThreeMinutes := metav1.NewTime(currentTime.Add(3 * time.Minute))
 	timeBeforeThreeMinutes := metav1.NewTime(currentTime.Add(-3 * time.Minute))
 
-	healthyMachine := newMachine("healthyMachine", healthyNode.Name, "Running")
-	unhealthyMachine := newMachine("unhealthyMachine", unhealthyNode.Name, "Running")
-	deletedMachine := newMachine("deletedMachine", healthyNode.Name, "Running")
+	healthyMachine := maotesting.NewMachine("healthyMachine", healthyNode.Name)
+	unhealthyMachine := maotesting.NewMachine("unhealthyMachine", unhealthyNode.Name)
+	deletedMachine := maotesting.NewMachine("deletedMachine", healthyNode.Name)
 	deletedMachine.DeletionTimestamp = &currentTime
-	disruptedMachineBeforeTimeout := newMachine("disruptedMachineBeforeTimeout", healthyNode.Name, "Running")
-	disruptedMachineAfterTimeout := newMachine("disruptedMachineAfterTimeout", healthyNode.Name, "Running")
+	disruptedMachineBeforeTimeout := maotesting.NewMachine("disruptedMachineBeforeTimeout", healthyNode.Name)
+	disruptedMachineAfterTimeout := maotesting.NewMachine("disruptedMachineAfterTimeout", healthyNode.Name)
 
 	r := newFakeReconciler(nil, healthyNode, unhealthyNode)
 	healthyMachinesCount := r.countHealthyMachines(
@@ -529,21 +433,21 @@ func TestCountHealthyMachines(t *testing.T) {
 }
 
 func TestGetMachineDisruptionBudgetForMachine(t *testing.T) {
-	node := newNode("node", true)
+	node := maotesting.NewNode("node", true)
 
-	machineWithoutLabels := newMachine("machineWithoutLabels", node.Name, "Running")
+	machineWithoutLabels := maotesting.NewMachine("machineWithoutLabels", node.Name)
 	machineWithoutLabels.Labels = map[string]string{}
-	machineWithWrongLabel := newMachine("machineWithoutLabels", node.Name, "Running")
+	machineWithWrongLabel := maotesting.NewMachine("machineWithoutLabels", node.Name)
 	machineWithWrongLabel.Labels = map[string]string{"wrongLabel": ""}
-	machineWithRightLabel := newMachine("machineWithRightLabel", node.Name, "Running")
+	machineWithRightLabel := maotesting.NewMachine("machineWithRightLabel", node.Name)
 
-	mdbWithRightLabel1 := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithRightLabel1 := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithRightLabel1.Name = "mdbWithRightLabel1"
-	mdbWithRightLabel2 := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithRightLabel2 := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithRightLabel2.Name = "mdbWithRightLabel2"
-	mdbWithWrongSelector := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithWrongSelector := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithWrongSelector.Name = "mdbWithWrongSelector"
-	mdbWithWrongSelector.Spec.Selector = newSelector(map[string]string{"wrongSelector": ""})
+	mdbWithWrongSelector.Spec.Selector = maotesting.NewSelector(map[string]string{"wrongSelector": ""})
 
 	testsCases := []struct {
 		testName string
@@ -609,25 +513,25 @@ type expectedReconcile struct {
 }
 
 func TestReconcile(t *testing.T) {
-	node := newNode("node", true)
+	node := maotesting.NewNode("node", true)
 
 	currentTime := metav1.NewTime(time.Now())
 	timeAfterTwoMinutes := currentTime.Add(2 * time.Minute)
 	timeBeforeThreeMinutes := metav1.NewTime(currentTime.Add(-3 * time.Minute))
 
-	machineWithWrongLabel := newMachine("machineWithWrongLabel", node.Name, "Running")
+	machineWithWrongLabel := maotesting.NewMachine("machineWithWrongLabel", node.Name)
 	machineWithWrongLabel.Labels = map[string]string{"wrongLabel": ""}
-	machineWithRightLabel := newMachine("machineWithRightLabel", node.Name, "Running")
-	disruptedMachineBeforeTimeout := newMachine("disruptedMachineBeforeTimeout", node.Name, "Running")
-	disruptedMachineAfterTimeout := newMachine("disruptedMachineAfterTimeout", node.Name, "Running")
+	machineWithRightLabel := maotesting.NewMachine("machineWithRightLabel", node.Name)
+	disruptedMachineBeforeTimeout := maotesting.NewMachine("disruptedMachineBeforeTimeout", node.Name)
+	disruptedMachineAfterTimeout := maotesting.NewMachine("disruptedMachineAfterTimeout", node.Name)
 
-	mdbWithRightLabel := newMinAvailableMachineDisruptionBudget(1)
-	mdbWithWrongSelector := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithRightLabel := maotesting.NewMinAvailableMachineDisruptionBudget(1)
+	mdbWithWrongSelector := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithWrongSelector.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels:      map[string]string{},
 		MatchExpressions: []metav1.LabelSelectorRequirement{{Operator: "fake"}},
 	}
-	mdbWithDisruptedMachines := newMinAvailableMachineDisruptionBudget(1)
+	mdbWithDisruptedMachines := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbWithDisruptedMachines.Status.DisruptedMachines = map[string]metav1.Time{
 		disruptedMachineBeforeTimeout.Name: timeBeforeThreeMinutes,
 		disruptedMachineAfterTimeout.Name:  currentTime,
@@ -700,7 +604,7 @@ func TestReconcile(t *testing.T) {
 		recorder := record.NewFakeRecorder(10)
 		key := types.NamespacedName{
 			Name:      "foobar",
-			Namespace: namespace,
+			Namespace: maotesting.Namespace,
 		}
 
 		objects := []runtime.Object{}

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -628,7 +628,7 @@ func TestReconcile(t *testing.T) {
 
 		if tc.expected.error != (err != nil) {
 			var errorExpectation string
-			if !tc.expected.error == true {
+			if !tc.expected.error {
 				errorExpectation = "no"
 			}
 			t.Errorf("Test case: %s. Expected: %s error, got: %v", tc.testName, errorExpectation, err)

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -12,7 +12,6 @@ import (
 	maotesting "github.com/openshift/machine-api-operator/pkg/util/testing"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -115,89 +114,6 @@ func TestGetNodeCondition(t *testing.T) {
 
 }
 
-type expectedReconcile struct {
-	result reconcile.Result
-	error  bool
-}
-
-func TestReconcile(t *testing.T) {
-	nodeHealthy := maotesting.NewNode("healthy", true)
-	nodeUnhealthy := maotesting.NewNode("unhealthy", false)
-	nodeWithNoMachineAnnotation := maotesting.NewNode("noAnnotated", true)
-	nodeWithNoMachineAnnotation.Annotations = map[string]string{}
-	nodeAnnotatedWithNoExistentMachine := maotesting.NewNode("noExistentMachine", true)
-	nodeAnnotatedWithNoExistentMachine.Annotations[machineAnnotationKey] = "noExistentMachine"
-	fakeMachine := maotesting.NewMachine("fakeMachine", "fakeNode")
-	fakeMachine.Status = mapiv1alpha1.MachineStatus{
-		NodeRef: &corev1.ObjectReference{
-			Namespace: "",
-			Name:      "healthy",
-		},
-	}
-
-	testsCases := []struct {
-		node     *v1.Node
-		expected expectedReconcile
-	}{
-		{
-			node: nodeHealthy,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-		{
-			node: nodeUnhealthy,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-		{
-			node: nodeWithNoMachineAnnotation,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-		{
-			node: nodeAnnotatedWithNoExistentMachine,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-	}
-
-	machineHealthCheck := maotesting.NewMachineHealthCheck("machineHealthCheck")
-	allMachineHealthChecks := &healthcheckingv1alpha1.MachineHealthCheckList{
-		Items: []healthcheckingv1alpha1.MachineHealthCheck{
-			*machineHealthCheck,
-		},
-	}
-
-	r := newFakeReconciler(nodeHealthy, nodeUnhealthy, fakeMachine, allMachineHealthChecks)
-	for _, tc := range testsCases {
-		request := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Namespace: "",
-				Name:      tc.node.Name,
-			},
-		}
-		result, err := r.Reconcile(request)
-		if result != tc.expected.result {
-			t.Errorf("Test case: %v. Expected: %v, got: %v", tc.node.Name, tc.expected.result, result)
-		}
-		if tc.expected.error != (err != nil) {
-			var errorExpectation string
-			if !tc.expected.error {
-				errorExpectation = "no"
-			}
-			t.Errorf("Test case: %s. Expected %s error, got: %v", tc.node.Name, errorExpectation, err)
-		}
-	}
-}
-
 // newFakeReconciler returns a new reconcile.Reconciler with a fake client
 func newFakeReconciler(initObjects ...runtime.Object) *ReconcileMachineHealthCheck {
 	fakeClient := fake.NewFakeClient(initObjects...)
@@ -206,6 +122,159 @@ func newFakeReconciler(initObjects ...runtime.Object) *ReconcileMachineHealthChe
 		scheme:    scheme.Scheme,
 		namespace: namespace,
 	}
+}
+
+type expectedReconcile struct {
+	result reconcile.Result
+	error  bool
+}
+
+func testReconcile(t *testing.T, remediationWaitTime time.Duration, initObjects ...runtime.Object) {
+	// healthy node
+	nodeHealthy := maotesting.NewNode("healthy", true)
+	nodeHealthy.Annotations = map[string]string{
+		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineWithNodehealthy"),
+	}
+	machineWithNodeHealthy := maotesting.NewMachine("machineWithNodehealthy", nodeHealthy.Name)
+
+	// recently unhealthy node
+	nodeRecentlyUnhealthy := maotesting.NewNode("recentlyUnhealthy", false)
+	nodeRecentlyUnhealthy.Status.Conditions[0].LastTransitionTime = metav1.Time{Time: time.Now()}
+	nodeRecentlyUnhealthy.Annotations = map[string]string{
+		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineWithNodeRecentlyUnhealthy"),
+	}
+	machineWithNodeRecentlyUnhealthy := maotesting.NewMachine("machineWithNodeRecentlyUnhealthy", nodeRecentlyUnhealthy.Name)
+
+	// node without machine annotation
+	nodeWithoutMachineAnnotation := maotesting.NewNode("withoutMachineAnnotation", true)
+	nodeWithoutMachineAnnotation.Annotations = map[string]string{}
+
+	// node annotated with machine that does not exist
+	nodeAnnotatedWithNoExistentMachine := maotesting.NewNode("annotatedWithNoExistentMachine", true)
+	nodeAnnotatedWithNoExistentMachine.Annotations[machineAnnotationKey] = "annotatedWithNoExistentMachine"
+
+	// node annotated with machine without owner reference
+	nodeAnnotatedWithMachineWithoutOwnerReference := maotesting.NewNode("annotatedWithMachineWithoutOwnerReference", true)
+	nodeAnnotatedWithMachineWithoutOwnerReference.Annotations = map[string]string{
+		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineWithoutOwnerController"),
+	}
+	machineWithoutOwnerController := maotesting.NewMachine("machineWithoutOwnerController", nodeAnnotatedWithMachineWithoutOwnerReference.Name)
+	machineWithoutOwnerController.OwnerReferences = nil
+
+	// node annotated with machine without node reference
+	nodeAnnotatedWithMachineWithoutNodeReference := maotesting.NewNode("annotatedWithMachineWithoutNodeReference", true)
+	nodeAnnotatedWithMachineWithoutNodeReference.Annotations = map[string]string{
+		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineWithoutNodeRef"),
+	}
+	machineWithoutNodeRef := maotesting.NewMachine("machineWithoutNodeRef", nodeAnnotatedWithMachineWithoutNodeReference.Name)
+	machineWithoutNodeRef.Status.NodeRef = nil
+
+	machineHealthCheck := maotesting.NewMachineHealthCheck("machineHealthCheck")
+
+	testsCases := []struct {
+		machine  *mapiv1alpha1.Machine
+		node     *corev1.Node
+		expected expectedReconcile
+	}{
+		{
+			machine: machineWithNodeHealthy,
+			node:    nodeHealthy,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+		},
+		{
+			machine: machineWithNodeRecentlyUnhealthy,
+			node:    nodeRecentlyUnhealthy,
+			expected: expectedReconcile{
+				result: reconcile.Result{
+					Requeue:      true,
+					RequeueAfter: remediationWaitTime,
+				},
+				error: false,
+			},
+		},
+		{
+			machine: nil,
+			node:    nodeWithoutMachineAnnotation,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+		},
+		{
+			machine: nil,
+			node:    nodeAnnotatedWithNoExistentMachine,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+		},
+		{
+			machine: machineWithoutOwnerController,
+			node:    nodeAnnotatedWithMachineWithoutOwnerReference,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+		},
+		{
+			machine: machineWithoutNodeRef,
+			node:    nodeAnnotatedWithMachineWithoutNodeReference,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  true,
+			},
+		},
+	}
+
+	for _, tc := range testsCases {
+		objects := []runtime.Object{}
+		objects = append(objects, initObjects...)
+		objects = append(objects, machineHealthCheck)
+		if tc.machine != nil {
+			objects = append(objects, tc.machine)
+		}
+		objects = append(objects, tc.node)
+		r := newFakeReconciler(objects...)
+
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: "",
+				Name:      tc.node.Name,
+			},
+		}
+		result, err := r.Reconcile(request)
+		if tc.expected.error != (err != nil) {
+			var errorExpectation string
+			if !tc.expected.error {
+				errorExpectation = "no"
+			}
+			t.Errorf("Test case: %s. Expected: %s error, got: %v", tc.node.Name, errorExpectation, err)
+		}
+
+		if result != tc.expected.result {
+			if tc.expected.result.Requeue {
+				before := tc.expected.result.RequeueAfter
+				after := tc.expected.result.RequeueAfter + time.Second
+				if after < result.RequeueAfter || before > result.RequeueAfter {
+					t.Errorf("Test case: %s. Expected RequeueAfter between: %v and %v, got: %v", tc.node.Name, before, after, result)
+				}
+			} else {
+				t.Errorf("Test case: %s. Expected: %v, got: %v", tc.node.Name, tc.expected.result, result)
+			}
+		}
+	}
+}
+
+func TestReconcileWithoutUnhealthyConditionsConfigMap(t *testing.T) {
+	testReconcile(t, 5*time.Minute)
+}
+
+func TestReconcileWithUnhealthyConditionsConfigMap(t *testing.T) {
+	cmBadConditions := maotesting.NewUnhealthyConditionsConfigMap(healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions, badConditionsData)
+	testReconcile(t, 1*time.Minute, cmBadConditions)
 }
 
 func TestHasMachineSetOwner(t *testing.T) {
@@ -257,146 +326,4 @@ func TestUnhealthyForTooLong(t *testing.T) {
 			t.Errorf("Test case: %s. Expected: %t, got: %t", tc.node.Name, tc.expected, got)
 		}
 	}
-}
-
-func testRemediation(t *testing.T, remediationWaitTime time.Duration, initObjects ...runtime.Object) {
-	nodeHealthy := maotesting.NewNode("nodeHealthy", true)
-	nodeHealthy.Annotations = map[string]string{
-		"machine": fmt.Sprintf("%s/%s", namespace, "machineWithNodehealthy"),
-	}
-
-	nodeRecentlyUnhealthy := maotesting.NewNode("nodeRecentlyUnhealthy", false)
-	nodeRecentlyUnhealthy.Status.Conditions[0].LastTransitionTime = metav1.Time{Time: time.Now()}
-	nodeRecentlyUnhealthy.Annotations = map[string]string{
-		"machine": fmt.Sprintf("%s/%s", namespace, "machineWithNodeRecentlyUnhealthy"),
-	}
-
-	machineWithNodeRecentlyUnhealthy := maotesting.NewMachine("machineWithNodeRecentlyUnhealthy", nodeRecentlyUnhealthy.Name)
-
-	machineWithNodeHealthy := maotesting.NewMachine("machineWithNodehealthy", nodeHealthy.Name)
-
-	machineWithNoOwnerController := maotesting.NewMachine("machineWithNoOwnerController", "node")
-	machineWithNoOwnerController.OwnerReferences = nil
-
-	machineWithNoNodeRef := maotesting.NewMachine("machineWithNoNodeRef", "node")
-	machineWithNoNodeRef.Status.NodeRef = nil
-
-	testsCases := []struct {
-		machine  *mapiv1alpha1.Machine
-		expected expectedReconcile
-	}{
-		{
-			machine: machineWithNodeHealthy,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-		{
-			machine: machineWithNodeRecentlyUnhealthy,
-			expected: expectedReconcile{
-				result: reconcile.Result{
-					Requeue:      true,
-					RequeueAfter: remediationWaitTime,
-				},
-				error: false,
-			},
-		},
-		{
-			machine: machineWithNoOwnerController,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  false,
-			},
-		},
-		{
-			machine: machineWithNoNodeRef,
-			expected: expectedReconcile{
-				result: reconcile.Result{},
-				error:  true,
-			},
-		},
-	}
-
-	initObjects = append(initObjects, nodeHealthy)
-	initObjects = append(initObjects, nodeRecentlyUnhealthy)
-	initObjects = append(initObjects, machineWithNodeHealthy)
-	initObjects = append(initObjects, machineWithNodeRecentlyUnhealthy)
-	initObjects = append(initObjects, machineWithNoOwnerController)
-	initObjects = append(initObjects, machineWithNoNodeRef)
-
-	r := newFakeReconciler(initObjects...)
-	for _, tc := range testsCases {
-		result, err := remediate(r, tc.machine)
-		if result != tc.expected.result {
-			if tc.expected.result.Requeue {
-				before := tc.expected.result.RequeueAfter
-				after := tc.expected.result.RequeueAfter + time.Second
-				if after < result.RequeueAfter || before > result.RequeueAfter {
-					t.Errorf("Test case: %s. Expected RequeueAfter between: %v and %v, got: %v", tc.machine.Name, before, after, result)
-				}
-			} else {
-				t.Errorf("Test case: %s. Expected: %v, got: %v", tc.machine.Name, tc.expected.result, result)
-			}
-		}
-		if tc.expected.error != (err != nil) {
-			var errorExpectation string
-			if !tc.expected.error == true {
-				errorExpectation = "no"
-			}
-			t.Errorf("Test case: %s. Expected: %s error, got: %v", tc.machine.Name, errorExpectation, err)
-		}
-	}
-}
-
-func TestRemediateWithoutUnhealthyConditionsConfigMap(t *testing.T) {
-	testRemediation(t, 5*time.Minute)
-}
-
-func TestRemediateWithUnhealthyConditionsConfigMap(t *testing.T) {
-	cmBadConditions := maotesting.NewUnhealthyConditionsConfigMap(healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions, badConditionsData)
-	testRemediation(t, 1*time.Minute, cmBadConditions)
-}
-
-func TestIsMaster(t *testing.T) {
-	masterMachine := maotesting.NewMachine("master", "master")
-	masterMachine.Labels["machine.openshift.io/cluster-api-machine-role"] = "master"
-	masterMachine.Labels["machine.openshift.io/cluster-api-machine-type"] = "master"
-
-	masterNode := maotesting.NewNode("master", true)
-	masterNode.Annotations = map[string]string{
-		"machine": fmt.Sprintf("%s/%s", namespace, "master"),
-	}
-	masterNode.Labels["node-role.kubernetes.io/master"] = ""
-
-	workerMachine := maotesting.NewMachine("worker", "worker")
-	workerMachine.Labels["machine.openshift.io/cluster-api-machine-role"] = "worker"
-	workerMachine.Labels["machine.openshift.io/cluster-api-machine-type"] = "worker"
-
-	workerNode := maotesting.NewNode("worker", true)
-	workerNode.Annotations = map[string]string{
-		"machine": fmt.Sprintf("%s/%s", namespace, "worker"),
-	}
-	workerNode.Labels["node-role.kubernetes.io/worker"] = ""
-
-	testCases := []struct {
-		machine  *mapiv1alpha1.Machine
-		expected bool
-	}{
-		{
-			machine:  masterMachine,
-			expected: true,
-		},
-		{
-			machine:  workerMachine,
-			expected: false,
-		},
-	}
-	fakeClient := fake.NewFakeClient(masterNode, workerNode)
-	for _, tc := range testCases {
-		if got := isMaster(*tc.machine, fakeClient); got != tc.expected {
-			t.Errorf("Test case: %s. Expected: %t, got: %t", tc.machine.Name, tc.expected, got)
-		}
-	}
-
 }

--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -1,0 +1,157 @@
+package testing
+
+import (
+	"fmt"
+	"time"
+
+	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+const (
+	// Namespace contains the default namespace for machine-api components
+	Namespace = "openshift-machine-api"
+	// MachineAnnotationKey contains default machine node annotation
+	MachineAnnotationKey = "machine.openshift.io/machine"
+)
+
+var (
+	// KnownDate contains date that can be used under tests
+	KnownDate = metav1.Time{Time: time.Date(1985, 06, 03, 0, 0, 0, 0, time.Local)}
+)
+
+// FooBar returns foo:bar map that can be used as default label
+func FooBar() map[string]string {
+	return map[string]string{"foo": "bar"}
+}
+
+// NewSelector returns new LabelSelector
+func NewSelector(labels map[string]string) *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: labels}
+}
+
+// NewSelectorFooBar returns new foo:bar label selector
+func NewSelectorFooBar() *metav1.LabelSelector {
+	return NewSelector(FooBar())
+}
+
+// NewMinAvailableMachineDisruptionBudget returns new MachineDisruptionBudget with min available parameter
+func NewMinAvailableMachineDisruptionBudget(minAvailable int32) *healthcheckingv1alpha1.MachineDisruptionBudget {
+	return &healthcheckingv1alpha1.MachineDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{Kind: "MachineDisruptionBudget"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foobar",
+			Namespace: Namespace,
+		},
+		Spec: healthcheckingv1alpha1.MachineDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector:     NewSelectorFooBar(),
+		},
+	}
+}
+
+// NewMaxUnavailableMachineDisruptionBudget returns new MachineDisruptionBudget with max unavailable parameter
+func NewMaxUnavailableMachineDisruptionBudget(maxUnavailable int32) *healthcheckingv1alpha1.MachineDisruptionBudget {
+	return &healthcheckingv1alpha1.MachineDisruptionBudget{
+		TypeMeta: metav1.TypeMeta{Kind: "MachineDisruptionBudget"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foobar",
+			Namespace: Namespace,
+		},
+		Spec: healthcheckingv1alpha1.MachineDisruptionBudgetSpec{
+			MaxUnavailable: &maxUnavailable,
+			Selector:       NewSelectorFooBar(),
+		},
+	}
+}
+
+// NewNode returns new node object that can be used for testing
+func NewNode(name string, ready bool) *corev1.Node {
+	nodeReadyStatus := corev1.ConditionTrue
+	if !ready {
+		nodeReadyStatus = corev1.ConditionUnknown
+	}
+
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceNone,
+			Annotations: map[string]string{
+				MachineAnnotationKey: fmt.Sprintf("%s/%s", Namespace, "fakeMachine"),
+			},
+			Labels: map[string]string{},
+			UID:    uuid.NewUUID(),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Node",
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{
+					Type:               corev1.NodeReady,
+					Status:             nodeReadyStatus,
+					LastTransitionTime: KnownDate,
+				},
+			},
+		},
+	}
+}
+
+// NewMachine returns new machine object that can be used for testing
+func NewMachine(name string, nodeName string) *mapiv1.Machine {
+	return &mapiv1.Machine{
+		TypeMeta: metav1.TypeMeta{Kind: "Machine"},
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:     make(map[string]string),
+			Name:            name,
+			Namespace:       Namespace,
+			Labels:          FooBar(),
+			UID:             uuid.NewUUID(),
+			OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
+		},
+		Spec: mapiv1.MachineSpec{},
+		Status: mapiv1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name:      nodeName,
+				Namespace: metav1.NamespaceNone,
+			},
+		},
+	}
+}
+
+// NewMachineHealthCheck returns new MachineHealthCheck object that can be used for testing
+func NewMachineHealthCheck(name string) *healthcheckingv1alpha1.MachineHealthCheck {
+	return &healthcheckingv1alpha1.MachineHealthCheck{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: Namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "MachineHealthCheck",
+		},
+		Spec: healthcheckingv1alpha1.MachineHealthCheckSpec{
+			Selector: *NewSelectorFooBar(),
+		},
+		Status: healthcheckingv1alpha1.MachineHealthCheckStatus{},
+	}
+}
+
+// NewUnhealthyConditionsConfigMap returns new config map object with unhealthy conditions
+func NewUnhealthyConditionsConfigMap(name string, data string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: Namespace,
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ConfigMap",
+		},
+		Data: map[string]string{
+			"conditions": data,
+		},
+	}
+}


### PR DESCRIPTION
- move methods from the machine health check tests
- move methods from the machine disruption tests