### PR TITLE
Fix related objects to be included in status

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -71,6 +71,7 @@ func New(
 	recorder record.EventRecorder,
 ) *Operator {
 	// we must report the version from the release payload when we report available at that level
+	// TODO we will report the version of the operands (so our machine api implementation version)
 	operandVersions := []osconfigv1.OperandVersion{}
 	if releaseVersion := os.Getenv("RELEASE_VERSION"); len(releaseVersion) > 0 {
 		operandVersions = append(operandVersions, osconfigv1.OperandVersion{Name: "operator", Version: releaseVersion})


### PR DESCRIPTION
As related objects belong to status subresource they were not being udpated as part of the client `Create` request.
This ensures they are included. In a follow up we'll include machines and machineSets
https://bugzilla.redhat.com/show_bug.cgi?id=1717633
