### PR TITLE
Update actuator-pkg dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -404,7 +404,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9e1247f48a1cad8b678ee1e8b11b9c864824008c5bace4893d599818a3defaf9"
+  digest = "1:36f79d74591f3d0de15f2adb8abfa7b2f3ff61eb7269ff898d818546d6acdc09"
   name = "github.com/openshift/cluster-api-actuator-pkg"
   packages = [
     "pkg/e2e",
@@ -417,7 +417,7 @@
     "pkg/types",
   ]
   pruneopts = ""
-  revision = "079636006a97adfbf6d610b006e25e77d03d4aec"
+  revision = "7b4382f95e0462d3d1aa6603facb953f2c0df23f"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:5d7e1e707b8da800c440797e744834ad6024ad31ab3bad70fad7183f38d9d843"
+  digest = "1:1a37f9f2ae10d161d9688fb6008ffa14e1631e5068cc3e9698008b9e8d40d575"
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
   pruneopts = ""
-  revision = "dfffe386c33fb24c34ee501e5723df5b97b98514"
-  version = "v0.30.0"
+  revision = "457ea5c15ccf3b87db582c450e80101989da35f7"
+  version = "v0.40.0"
 
 [[projects]]
   digest = "1:c0952fb3cf9506cff577b4edf4458889570dcbd2902a7b90a1fd96bfbb97ccd8"
@@ -34,12 +34,12 @@
   version = "1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
+  digest = "1:0d3deb8a6da8ffba5635d6fb1d2144662200def6c9d82a35a6d05d6c2d4a48f9"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
   pruneopts = ""
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+  revision = "4b2b341e8d7715fae06375aa633dbb6e91b3fb46"
+  version = "v1.0.0"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
@@ -50,23 +50,23 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:8a34d7a37b8f07239487752e14a5faafcbbc718fc385ad429a2c4ac6f27a207f"
+  digest = "1:7bb8712cb8f2c0b6a2aa63df15e861931c17cf7abb5caef59744278be2a122df"
   name = "github.com/emicklei/go-restful"
   packages = [
     ".",
     "log",
   ]
   pruneopts = ""
-  revision = "3eb9738c1697594ea6e71a7156a9bb32ed216cf0"
-  version = "v2.8.0"
+  revision = "6ac3b8eb89d325e5c750d77f344a6870464d03c3"
+  version = "v2.9.6"
 
 [[projects]]
-  digest = "1:8466756c66127d5ea10cc6c305a16174755ebd187e64ec2b4efc3eef58281dcd"
+  digest = "1:46ddeb9dd35d875ac7568c4dc1fc96ce424e034bdbb984239d8ffc151398ec01"
   name = "github.com/evanphx/json-patch"
   packages = ["."]
   pruneopts = ""
-  revision = "5858425f75500d40c52783dce87d085a483ce135"
-  version = "v4.2.0"
+  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
+  version = "v4.5.0"
 
 [[projects]]
   digest = "1:b13707423743d41665fd23f0c36b2f37bb49c30e94adb813319c44188a51ba22"
@@ -77,63 +77,63 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
   digest = "1:65587005c6fa4293c0b8a2e457e689df7fda48cc5e1f5449ea2c1e7784551558"
   name = "github.com/go-logr/logr"
   packages = ["."]
   pruneopts = ""
   revision = "9fb12b3b21c5415d16ac18dc5cd42c1cfdd40c4e"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:c8052dcf3ec378a9a6bc4f00ecc10d6d5eb3cc1f8faaf6b2f70f047e8881d446"
+  digest = "1:21911d0d3cecc86a42fd1920583c34a33b91035d77d4929772938961d7814ffc"
   name = "github.com/go-openapi/jsonpointer"
   packages = ["."]
   pruneopts = ""
-  revision = "ef5f0afec364d3b9396b7b77b43dbe26bf1f8004"
-  version = "v0.18.0"
+  revision = "a105a905c5e6ad147f08504784917f3e178e0ba5"
+  version = "v0.19.2"
 
 [[projects]]
-  digest = "1:1824e5330b35b2a2418d06aa55629cc59ad454b72e338aa125ba8ff98f16298b"
+  digest = "1:6ec9ec804d37dfca7ce0e488844fb069cfe4e3eb60793d163279083b8ec61a8d"
   name = "github.com/go-openapi/jsonreference"
   packages = ["."]
   pruneopts = ""
-  revision = "8483a886a90412cd6858df4ea3483dce9c8e35a3"
-  version = "v0.18.0"
+  revision = "2903bfd4bfbaf188694f1edf731f2725a8fa344f"
+  version = "v0.19.2"
 
 [[projects]]
-  digest = "1:54af405aae840f810418f3d25211012af1c4bfd56d07d3de6482a7a3b762528a"
+  digest = "1:0bf906c8db0e821fa588499950b59d349e4edccad44383c806319035b8bd5f89"
   name = "github.com/go-openapi/spec"
   packages = ["."]
   pruneopts = ""
-  revision = "5b6cdde3200976e3ecceb2868706ee39b6aff3e4"
-  version = "v0.18.0"
+  revision = "bdfd7e07daecc404d77868a88b2364d0aed0ee5a"
+  version = "v0.19.2"
 
 [[projects]]
-  digest = "1:417789264f7cc44cbb3431ac997473e085018b01bdd98df57e6039981428aca4"
+  digest = "1:5b2e21b92938a735f1a9b11b4c0e14c4bfac27111fa3ad5a8ec6a04bee7f1bfb"
   name = "github.com/go-openapi/swag"
   packages = ["."]
   pruneopts = ""
-  revision = "1d29f06aebd59ccdf11ae04aa0334ded96e2d909"
-  version = "v0.18.0"
+  revision = "7e8dd5ceab83c86d17bc967d09e195414fe2b47e"
+  version = "v0.19.2"
 
 [[projects]]
-  digest = "1:a51f75337287a485731485c646d701e237246f7c5d0e221dee18ca37b672538e"
+  digest = "1:a095a30432f90546e50015de1a7238c2ee552faf775bd4f94010d1db41292db6"
   name = "github.com/gobuffalo/envy"
   packages = ["."]
   pruneopts = ""
-  revision = "047ecc927cd0b7d27bab83eb948e120fb7d1ea68"
-  version = "v1.6.5"
+  revision = "043cb4b8af871b49563291e32c66bb84378a60ac"
+  version = "v1.7.0"
 
 [[projects]]
-  digest = "1:6e73003ecd35f4487a5e88270d3ca0a81bc80dc88053ac7e4dcfec5fba30d918"
+  digest = "1:fd53b471edb4c28c7d297f617f4da0d33402755f58d6301e7ca1197ef0a90937"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = ""
-  revision = "636bf0302bc95575d69441b25a2603156ffdddf1"
-  version = "v1.1.1"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
 
 [[projects]]
   branch = "master"
@@ -145,14 +145,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9854532d7b2fee9414d4fcd8d8bccd6b1c1e1663d8ec0337af63a19aaf4a778e"
+  digest = "1:f9714c0c017f2b821bccceeec2c7a93d29638346bb546c36ca5f90e751f91b9e"
   name = "github.com/golang/groupcache"
   packages = ["lru"]
   pruneopts = ""
-  revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
+  revision = "5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b"
 
 [[projects]]
-  digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"
+  digest = "1:529d738b7976c3848cae5cf3a8036440166835e389c1f617af701eeb12a0518d"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
@@ -162,27 +162,27 @@
     "ptypes/timestamp",
   ]
   pruneopts = ""
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
+  revision = "b5d812f8a3706043e23a9cd5babf2e5423744d30"
+  version = "v1.3.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:754f77e9c839b24778a4b64422236d38515301d2baeb63113aa3edc42e6af692"
+  digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
   name = "github.com/google/gofuzz"
   packages = ["."]
   pruneopts = ""
-  revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:c1d7e883c50a26ea34019320d8ae40fad86c9e5d56e63a1ba2cb618cef43e986"
+  digest = "1:ad92aa49f34cbc3546063c7eb2cabb55ee2278b72842eda80e2a20a8a06a8d73"
   name = "github.com/google/uuid"
   packages = ["."]
   pruneopts = ""
-  revision = "064e2069ce9c359c118179501254f67d7d37ba24"
-  version = "0.2"
+  revision = "0cd6bf5da1e1c83f8b45653022c74f71af0538a4"
+  version = "v1.1.1"
 
 [[projects]]
-  digest = "1:16b2837c8b3cf045fa2cdc82af0cf78b19582701394484ae76b2c3bc3c99ad73"
+  digest = "1:5facc3828b6a56f9aec988433ea33fb4407a89460952ed75be5347cec07318c0"
   name = "github.com/googleapis/gnostic"
   packages = [
     "OpenAPIv2",
@@ -190,19 +190,19 @@
     "extensions",
   ]
   pruneopts = ""
-  revision = "7c663266750e7d82587642f65e60bc4083f1f84e"
-  version = "v0.2.0"
+  revision = "e73c7ec21d36ddb0711cb36d1502d18363b5c2c9"
+  version = "v0.3.0"
 
 [[projects]]
-  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
+  digest = "1:85f8f8d390a03287a563e215ea6bd0610c858042731a8b42062435a0dcbc485f"
   name = "github.com/hashicorp/golang-lru"
   packages = [
     ".",
     "simplelru",
   ]
   pruneopts = ""
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
   digest = "1:b3c5b95e56c06f5aa72cb2500e6ee5f44fcd122872d4fec2023a488e561218bc"
@@ -219,12 +219,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:7ab38c15bd21e056e3115c8b526d201eaf74e0308da9370997c6b3c187115d36"
+  digest = "1:31bfd110d31505e9ffbc9478e31773bf05bf02adcaeb9b139af42684f9294c13"
   name = "github.com/imdario/mergo"
   packages = ["."]
   pruneopts = ""
-  revision = "9f23e2d6bd2a77f959b2bf6acdbefd708a83a4a4"
-  version = "v0.3.6"
+  revision = "7c29201646fa3de8506f701213473dd407f19646"
+  version = "v0.3.7"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -243,16 +243,16 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:b79fc583e4dc7055ed86742e22164ac41bf8c0940722dbcb600f1a3ace1a8cb5"
+  digest = "1:12d3de2c11e54ea37d7f00daf85088ad5e61ec4e8a1f828d6c8b657976856be7"
   name = "github.com/json-iterator/go"
   packages = ["."]
   pruneopts = ""
-  revision = "1624edc4454b8682399def8740d46db5e4362ba4"
-  version = "v1.1.5"
+  revision = "0ff49de124c6f76f8494e194af75bde0f1a49a29"
+  version = "v1.1.6"
 
 [[projects]]
   branch = "master"
-  digest = "1:02e7e5941a0607565391047b76eabdfff2c83285813b6d0479dfc63c36c21820"
+  digest = "1:101e8200d89dcff2cec2522e427298045bea6d81ef71f8fe10810faeae741efc"
   name = "github.com/mailru/easyjson"
   packages = [
     "buffer",
@@ -260,15 +260,15 @@
     "jwriter",
   ]
   pruneopts = ""
-  revision = "6243d8e04c3f819e79757e8bc3faa15c3cb27003"
+  revision = "b2ccc519800e761ac8000b95e5d57c80a897ff9e"
 
 [[projects]]
-  digest = "1:3d8a9dd6693e55d63b28634d66d11d647cd0b65362dedc18d686db01aa5f8678"
+  digest = "1:68145053d55a0fa6b5f259eb70de75cb3914f6440472007e67c87894e1c06697"
   name = "github.com/markbates/inflect"
   packages = ["."]
   pruneopts = ""
-  revision = "28bf78dadb0f64748ff13a0b6547e4972a5cea64"
-  version = "v1.0.1"
+  revision = "24b83195037b3bc61fcda2d28b7b0518bce293b6"
+  version = "v1.0.4"
 
 [[projects]]
   digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
@@ -295,7 +295,7 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:a7fd918fb5bd2188436785c0424f8a50b4addfedf37a2b14d796be2a927b8007"
+  digest = "1:a3735b0978a8b53fc2ac97a6f46ca1189f0712a00df86d6ec4cf26c1a25e6d77"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -318,11 +318,11 @@
     "types",
   ]
   pruneopts = ""
-  revision = "3774a09d95489ccaa16032e0770d08ea77ba6184"
-  version = "v1.6.0"
+  revision = "eea6ad008b96acdaa524f5b409513bf062b500ad"
+  version = "v1.8.0"
 
 [[projects]]
-  digest = "1:3ecd0a37c4a90c12a97e31c398cdbc173824351aa891898ee178120bfe71c478"
+  digest = "1:dbafce2fddb1ca331646fe2ac9c9413980368b19a60a4406a6e5861680bd73be"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -341,20 +341,40 @@
     "types",
   ]
   pruneopts = ""
-  revision = "7615b9433f86a8bdf29709bf288bc4fd0636a369"
-  version = "v1.4.2"
+  revision = "90e289841c1ed79b7a598a7cd9959750cb5e89e2"
+  version = "v1.5.0"
 
 [[projects]]
   branch = "master"
-  digest = "1:1267d3ab59b1de9f72b0bd74615c0926814806fbf2a6136cffc0fe1ee66a22f4"
+  digest = "1:41ab820304915dacf12d7fe44f4ec6f808d1a8909bf4b47525a7d24c9af8d091"
   name = "github.com/openshift/api"
-  packages = ["config/v1"]
+  packages = [
+    "config/v1",
+    "security/v1",
+  ]
   pruneopts = ""
-  revision = "77b8897ec79a562e85920134fc65b63300c4d27a"
+  revision = "da8f874733b4967e7a632fe6fc042a21f5dbbb6b"
+
+[[projects]]
+  branch = "master"
+  digest = "1:36418a1c5fce09c60bb56855d5b581fbbba762dc9afe2c5f06871a3894aa2fab"
+  name = "github.com/openshift/client-go"
+  packages = [
+    "config/clientset/versioned",
+    "config/clientset/versioned/scheme",
+    "config/clientset/versioned/typed/config/v1",
+    "config/informers/externalversions/config/v1",
+    "config/informers/externalversions/internalinterfaces",
+    "config/listers/config/v1",
+    "security/clientset/versioned/scheme",
+    "security/clientset/versioned/typed/security/v1",
+  ]
+  pruneopts = ""
+  revision = "8892c0adc000741c33af70e05f4ede47725d0773"
 
 [[projects]]
   branch = "openshift-4.2-cluster-api-0.1.0"
-  digest = "1:699a8c9731ec7c96edc8367424979eacf97fcfd62217e1a01ff420049c9d4c88"
+  digest = "1:36d4e0a2da2e067dd9bf71c4b65097a0b8b17bb07b5a8417c62f090b140e300e"
   name = "github.com/openshift/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -370,11 +390,11 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "e911af77e9a33cfb45f82ba9778876d715cdb4ea"
+  revision = "046d74a3bd9143fb650cb894ece0f088a3b26de3"
 
 [[projects]]
   branch = "master"
-  digest = "1:95fec9858a131c4cc1dc5bc012db639b946a49a359799e68ebd82b123ecf0552"
+  digest = "1:88fb33dea98f72dd2482a369fd9d4c9b482e62ccbab6d092c8c91e0cbdd82501"
   name = "github.com/openshift/cluster-autoscaler-operator"
   packages = [
     "pkg/apis",
@@ -382,18 +402,30 @@
     "pkg/apis/autoscaling/v1beta1",
   ]
   pruneopts = ""
-  revision = "62768a6ba48010d12c4d86b8b06689a6970a7841"
+  revision = "350eb7249737472e5ce0c98cebe90097c3913447"
 
 [[projects]]
   branch = "master"
-  digest = "1:8e51979e3c18f776e3199c091ea603b09cce802fe5d2afa7fbc6bb01f0370675"
+  digest = "1:bac26c4cdf469cd54519773b22eda4e8644eb13ebc42dc5c611b3cbd99ee6720"
+  name = "github.com/openshift/cluster-version-operator"
+  packages = [
+    "lib/resourceapply",
+    "lib/resourcemerge",
+  ]
+  pruneopts = ""
+  revision = "70c8b8f9713976a3e40d832bac207e41a3dcb89f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:5660d0216f6e3be26985d0040e2ea4e6b4dd857ed52d12a998f5ae27064410e2"
   name = "github.com/openshift/library-go"
   packages = ["pkg/config/clusteroperator/v1helpers"]
   pruneopts = ""
-  revision = "cd621d02d319d52b9ac1297674b9bd743ebe2687"
+  revision = "16a370625b52c7958783b8f74de58317236da6b4"
 
 [[projects]]
-  digest = "1:d499d0c870bf83afc8e077db22359f5064521d7ea197ce986b23e30ec9359535"
+  branch = "master"
+  digest = "1:b9644172bd11e3540f7919cccd4e387c4d5d6ccaf6e736c2ca632adbbe5ef6eb"
   name = "github.com/openshift/machine-api-operator"
   packages = [
     "pkg/apis/healthchecking",
@@ -401,10 +433,11 @@
     "pkg/generated/clientset/versioned",
     "pkg/generated/clientset/versioned/scheme",
     "pkg/generated/clientset/versioned/typed/healthchecking/v1alpha1",
+    "pkg/operator",
     "pkg/util/conditions",
   ]
   pruneopts = ""
-  revision = "9650e16c98802a4b57b7551201b0973fcae2f738"
+  revision = "a85d27ec08fb6e9c681c4b7f54a9bdb69419046f"
 
 [[projects]]
   digest = "1:a5484d4fa43127138ae6e7b2299a6a52ae006c7f803d98d717f60abf3e97192e"
@@ -415,15 +448,15 @@
   version = "v1.2"
 
 [[projects]]
-  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  digest = "1:1d7e1867c49a6dd9856598ef7c3123604ea3daabf5b83f303ff457bcbc410b1d"
   name = "github.com/pkg/errors"
   packages = ["."]
   pruneopts = ""
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
+  revision = "ba968bfe8b2f7e042a574c888954fccecfa385b4"
+  version = "v0.8.1"
 
 [[projects]]
-  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
+  digest = "1:c826496cad27bd9a7644a01230a79d472b4093dd33587236e8f8369bb1d8534e"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -431,8 +464,8 @@
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
-  version = "v0.9.2"
+  revision = "2641b987480bca71fb39738eb8c8b0d577cb1d76"
+  version = "v0.9.4"
 
 [[projects]]
   branch = "master"
@@ -443,7 +476,7 @@
   revision = "fd36f4220a901265f90734c3183c5f0c91daa0b8"
 
 [[projects]]
-  digest = "1:96af18a3819d2ff7d6aa07e6e50955b11e477dbc8b890324c67462b84adca56b"
+  digest = "1:0f2cee44695a3208fe5d6926076641499c72304e6f015348c9ab2df90a202cdf"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
@@ -451,41 +484,50 @@
     "model",
   ]
   pruneopts = ""
-  revision = "cfeb6f9992ffa54aaa4f2170ade4067ee478b250"
-  version = "v0.2.0"
+  revision = "31bed53e4047fd6c510e43a941f90cb31be0972a"
+  version = "v0.6.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1b7cd41afad7e1250d0582c2a12bccf995893b4e2a4265daf0f6a385005a87db"
+  digest = "1:9b33e539d6bf6e4453668a847392d1e9e6345225ea1426f9341212c652bcbee4"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
-    "internal/util",
-    "iostats",
-    "nfs",
-    "xfs",
+    "internal/fs",
   ]
   pruneopts = ""
-  revision = "e4d4a2206da023361ed100d85c5f2cf9c8364e9f"
+  revision = "3f98efb27840a48a7a2898ec80be07674d19f9c8"
+  version = "v0.0.3"
 
 [[projects]]
-  digest = "1:d0431c2fd72e39ee43ea7742322abbc200c3e704c9102c5c3c2e2e667095b0ca"
+  digest = "1:5ba8f069e4f3b867775f59ef435941c434e25d42818b4dad2c7c665fa04826b5"
+  name = "github.com/rogpeppe/go-internal"
+  packages = [
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = ""
+  revision = "438578804ca6f31be148c27683afc419ce47c06e"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:956f655c87b7255c6b1ae6c203ebb0af98cf2a13ef2507e34c9bf1c0332ac0f5"
   name = "github.com/spf13/afero"
   packages = [
     ".",
     "mem",
   ]
   pruneopts = ""
-  revision = "d40851caa0d747393da1ffb28f7f9d8b4eeffebd"
-  version = "v1.1.2"
+  revision = "588a75ec4f32903aa5e39a2619ba6a4631e28424"
+  version = "v1.2.2"
 
 [[projects]]
-  digest = "1:a1403cc8a94b8d7956ee5e9694badef0e7b051af289caad1cf668331e3ffa4f6"
+  digest = "1:0c63b3c7ad6d825a898f28cb854252a3b29d37700c68a117a977263f5ec94efe"
   name = "github.com/spf13/cobra"
   packages = ["."]
   pruneopts = ""
-  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
-  version = "v0.0.3"
+  revision = "f2b07da1e2c38d5f12845a4f607e2e1018cbb1f5"
+  version = "v0.0.5"
 
 [[projects]]
   digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
@@ -497,7 +539,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:78f41d38365ccef743e54ed854a2faf73313ba0750c621116a8eeb0395590bd0"
+  digest = "1:90722da867436e04650b8491e5d9f690aeb2a4e305d548666bdd541d68d6cdbd"
   name = "golang.org/x/crypto"
   packages = [
     "curve25519",
@@ -510,11 +552,11 @@
     "ssh/terminal",
   ]
   pruneopts = ""
-  revision = "0c41d7ab0a0ee717d4590a44bcb987dfd9e183eb"
+  revision = "cc06ce4a13d484c0101a9e92913248488a75786d"
 
 [[projects]]
   branch = "master"
-  digest = "1:6543c75ddc1efc0041202dd49378ee2e5711b7cc82c2845c0437eef6276cc984"
+  digest = "1:5c6b8395efd72ad4250b7747e2b1a0683c3edb7b0346a938ff45240c7ec53691"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -528,11 +570,11 @@
     "idna",
   ]
   pruneopts = ""
-  revision = "04a2e542c03f1d053ab3e4d6e5abcd4b66e2be8e"
+  revision = "3b0461eec859c4b73bb64fdc8285971fd33e3938"
 
 [[projects]]
   branch = "master"
-  digest = "1:77478892c6d9d841c7997858d6287884c65b760000f29a25d7b1a6b6ada5f308"
+  digest = "1:01bdbbc604dcd5afb6f66a717f69ad45e9643c72d5bc11678d44ffa5c50f9e42"
   name = "golang.org/x/oauth2"
   packages = [
     ".",
@@ -542,21 +584,22 @@
     "jwt",
   ]
   pruneopts = ""
-  revision = "9dcd33a902f40452422c2367fefcb95b54f9f8f8"
+  revision = "0f29369cfe4552d0e4bcddc57cc75f4d7e672a33"
 
 [[projects]]
   branch = "master"
-  digest = "1:2ed0bf267e44950120acd95570227e28184573ffb099bd85b529ee148e004ddb"
+  digest = "1:2579a16d8afda9c9a475808c13324f5e572852e8927905ffa15bb14e71baba4f"
   name = "golang.org/x/sys"
   packages = [
+    "cpu",
     "unix",
     "windows",
   ]
   pruneopts = ""
-  revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
+  revision = "04f50cda93cbb67f2afa353c52f342100e80e625"
 
 [[projects]]
-  digest = "1:5acd3512b047305d49e8763eef7ba423901e85d5dd2fd1e71778a0ea8de10bd4"
+  digest = "1:740b51a55815493a8d0f2b1e0d0ae48fe48953bf7eaf3fcc4198823bf67768c0"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -573,6 +616,8 @@
     "encoding/unicode",
     "internal/colltab",
     "internal/gen",
+    "internal/language",
+    "internal/language/compact",
     "internal/tag",
     "internal/triegen",
     "internal/ucd",
@@ -588,32 +633,40 @@
     "width",
   ]
   pruneopts = ""
-  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
-  version = "v0.3.0"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:55a681cb66f28755765fa5fa5104cbd8dc85c55c02d206f9f89566451e3fe1aa"
+  digest = "1:9522af4be529c108010f95b05f1022cb872f2b9ff8b101080f554245673466e1"
   name = "golang.org/x/time"
   packages = ["rate"]
   pruneopts = ""
-  revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
 
 [[projects]]
   branch = "master"
-  digest = "1:0e00fc89844319856bc8422297cc1d3bd1fecdf25278d7c3b87df8e731099bda"
+  digest = "1:b9523770118a3ba8f1fdcfb8f491c48ecbac31ece4f9dba2d13ea37893539990"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
     "imports",
     "internal/fastwalk",
     "internal/gopathwalk",
+    "internal/imports",
+    "internal/module",
+    "internal/semver",
   ]
   pruneopts = ""
-  revision = "4cdd33fd982acab76e378b4fe489ae197a381bb0"
+  revision = "4874f863e654449ac721e9d65f7467dbaba3da2e"
 
 [[projects]]
-  digest = "1:8c432632a230496c35a15cfdf441436f04c90e724ad99c8463ef0c82bbe93edb"
+  digest = "1:47f391ee443f578f01168347818cb234ed819521e49e4d2c8dd2fb80d48ee41a"
   name = "google.golang.org/appengine"
   packages = [
     ".",
@@ -628,8 +681,8 @@
     "urlfetch",
   ]
   pruneopts = ""
-  revision = "ae0ab99deb4dc413a2b4bd6c8bdd0eb67f1e4d06"
-  version = "v1.2.0"
+  revision = "b2f4a3cf3c67576a2ee09e1fe62656a5086ce880"
+  version = "v1.6.1"
 
 [[projects]]
   digest = "1:eb53021a8aa3f599d29c7102e65026242bdedce998a54837dc67f14b6a97c5fd"
@@ -657,12 +710,12 @@
   revision = "dd632973f1e7218eb1089048e0798ec9ae7dceb8"
 
 [[projects]]
-  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
+  digest = "1:cedccf16b71e86db87a24f8d4c70b0a855872eb967cb906a66b95de56aefbd0d"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = ""
-  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
 
 [[projects]]
   digest = "1:f123907ebd19568a24bc7d1db2dd9129d2fb5daed201c313e896882296ad05ec"
@@ -719,6 +772,7 @@
     "pkg/client/clientset/clientset",
     "pkg/client/clientset/clientset/scheme",
     "pkg/client/clientset/clientset/typed/apiextensions/v1beta1",
+    "pkg/client/listers/apiextensions/v1beta1",
   ]
   pruneopts = ""
   revision = "727a075fdec8319bf095330e344b3ccc668abc73"
@@ -953,7 +1007,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:8c04b6090a46cc65c180aab6f6c1fb9028ac935303b2b9cfda87c5d96e588d5e"
+  digest = "1:06c76c97e355e1861048b08e378ced3abe475674c93efe912e5f110ae9202d11"
   name = "k8s.io/code-generator"
   packages = [
     "cmd/deepcopy-gen",
@@ -961,11 +1015,11 @@
     "pkg/util",
   ]
   pruneopts = ""
-  revision = "40b92a94e6ad9e3314d9b1da1300776bd353a2f9"
+  revision = "d55040311883850cc5acf9472f2b8098f7b48f22"
 
 [[projects]]
   branch = "master"
-  digest = "1:4a75352fad3a8e993928462643415e8263f94ae845aa5e7dce1de2f34f961e36"
+  digest = "1:6a2a63e09a59caff3fd2d36d69b7b92c2fe7cf783390f0b7349fb330820f9a8e"
   name = "k8s.io/gengo"
   packages = [
     "args",
@@ -977,30 +1031,44 @@
     "types",
   ]
   pruneopts = ""
-  revision = "4242d8e6c5dba56827bb7bcf14ad11cda38f3991"
+  revision = "e17681d19d3ac4837a019ece36c2a0ec31ffe985"
 
 [[projects]]
-  digest = "1:4f5eb833037cc0ba0bf8fe9cae6be9df62c19dd1c869415275c708daa8ccfda5"
+  digest = "1:9eaf86f4f6fb4a8f177220d488ef1e3255d06a691cca95f14ef085d4cd1cef3c"
   name = "k8s.io/klog"
   packages = ["."]
   pruneopts = ""
-  revision = "a5bc97fbc634d635061f3146511332c7e313a55a"
-  version = "v0.1.0"
+  revision = "d98d8acdac006fb39831f1b25640813fef9c314f"
+  version = "v0.3.3"
+
+[[projects]]
+  branch = "release-1.14"
+  digest = "1:c72592440074f0096c4bc2dad5dbba2196072e305ba40ef10baaf65b60ab81b2"
+  name = "k8s.io/kube-aggregator"
+  packages = [
+    "pkg/apis/apiregistration",
+    "pkg/apis/apiregistration/v1",
+    "pkg/apis/apiregistration/v1beta1",
+    "pkg/client/clientset_generated/clientset/scheme",
+    "pkg/client/clientset_generated/clientset/typed/apiregistration/v1",
+  ]
+  pruneopts = ""
+  revision = "f5e124c822d616bd90f9b545b977d55df030f454"
 
 [[projects]]
   branch = "master"
-  digest = "1:bb17aab96138a89eb0550fbf135a9812f6be8bc9805080e36c9efe50f607261e"
+  digest = "1:d2aae07aa745223592ae668f6eb6c2ca0242d66a6dcf16b1e8e2711a79aad0f1"
   name = "k8s.io/kube-openapi"
   packages = [
     "pkg/common",
     "pkg/util/proto",
   ]
   pruneopts = ""
-  revision = "5d05df014ac640f14b5e777958248251c2ef5e86"
+  revision = "db7b694dc208eead64d38030265f702db593fcf2"
 
 [[projects]]
   branch = "master"
-  digest = "1:7200c2caa8e1069ec0bafe674980ff78d4ad287733fc23f020baa8a5e2720854"
+  digest = "1:4c5d39f7ca1c940d7e74dbc62d2221e2c59b3d35c54f1fa9c77f3fd3113bbcb1"
   name = "k8s.io/utils"
   packages = [
     "buffer",
@@ -1009,10 +1077,11 @@
     "trace",
   ]
   pruneopts = ""
-  revision = "c2654d5206da6b7b6ace12841e8f359bb89b443c"
+  revision = "c55fbcfc754a5b2ec2fbae8fb9dcac36bdba6a12"
 
 [[projects]]
-  digest = "1:02e4c146d9dd1256a912bde66585bed5960cc2fe189d8d29a6ec6306646b7511"
+  branch = "release-0.2"
+  digest = "1:ac7bcc71944b708efb30f80baf4b296ad981ce78f3fd3ad9f3183c33f494a0d1"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/cache",
@@ -1049,34 +1118,37 @@
     "pkg/webhook/internal/metrics",
   ]
   pruneopts = ""
-  revision = "96b67f231945a8e8550dbdd8bfbd550a0c68097b"
+  revision = "f60c87ec713cb8da81257228530605457ebf7220"
 
 [[projects]]
-  digest = "1:0fb3157cb64930e8fb7d5b3fbfcedb71b8b4b990d8babcc7c7cd28e1eb672e13"
+  digest = "1:3783317b20c843e6dd26bce6801d8ab3736fd1002ba06807aaf07afb92b82a5d"
   name = "sigs.k8s.io/controller-tools"
   packages = [
     "cmd/controller-gen",
     "pkg/crd/generator",
     "pkg/crd/util",
-    "pkg/generate/rbac",
     "pkg/internal/codegen",
     "pkg/internal/codegen/parse",
+    "pkg/internal/general",
+    "pkg/rbac",
     "pkg/util",
+    "pkg/webhook",
   ]
   pruneopts = ""
-  revision = "38b2f3f497ed6b8ea5d2844ecf00c28ac4b5c2c4"
-  version = "v0.1.6"
+  revision = "464fbed97efaced33902e262f09c5eae7315c3e3"
+  version = "v0.1.11"
 
 [[projects]]
-  branch = "master"
-  digest = "1:1ceb534a9ba96e74e7c31593822fc8b73b457aaaae1fd016b436ec52197125d4"
+  digest = "1:76b9c96854ab7950168f4f454331697a2dd71a1904514e6dac142c5873c82d55"
   name = "sigs.k8s.io/testing_frameworks"
   packages = [
     "integration",
+    "integration/addr",
     "integration/internal",
   ]
   pruneopts = ""
-  revision = "5818a3a284a11812aaed11d5ca0bcadec2c50e83"
+  revision = "d348cb12705b516376e0c323bacca72b00a78425"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:321081b4a44256715f2b68411d8eda9a17f17ebfe6f0cc61d2cc52d11c08acfa"
@@ -1106,6 +1178,7 @@
     "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers",
     "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1",
     "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned",
+    "github.com/openshift/machine-api-operator/pkg/operator",
     "github.com/openshift/machine-api-operator/pkg/util/conditions",
     "golang.org/x/crypto/ssh",
     "k8s.io/api/apps/v1",
@@ -1122,6 +1195,7 @@
     "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
+    "k8s.io/apimachinery/pkg/runtime/serializer",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/rand",

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.toml
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Gopkg.toml
@@ -55,7 +55,14 @@ required = [
 
 [[constraint]]
   name = "github.com/openshift/machine-api-operator"
-  revision = "9650e16c98802a4b57b7551201b0973fcae2f738"
+  branch = "master"
+
+ [[override]]
+  name = "github.com/openshift/cluster-version-operator"
+  branch = "master"
+
+ [[override]]
+  name = "k8s.io/utils"
 
 # We need to specify fsnotify source to avoid dep panic
 [[override]]

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/Makefile
@@ -7,7 +7,7 @@ ifeq ($(NO_DOCKER), 1)
   IMAGE_BUILD_CMD = imagebuilder
   CGO_ENABLED = 1
 else
-  DOCKER_CMD := docker run --rm -v "$(PWD)":/go/src/github.com/openshift/cluster-api-actuator-pkg:Z -w /go/src/github.com/openshift/cluster-api-actuator-pkg openshift/origin-release:golang-1.10
+  DOCKER_CMD := docker run --rm -v "$(PWD)":/go/src/github.com/openshift/cluster-api-actuator-pkg:Z -w /go/src/github.com/openshift/cluster-api-actuator-pkg openshift/origin-release:golang-1.12
   IMAGE_BUILD_CMD = docker build
 endif
 
@@ -50,7 +50,10 @@ test-e2e: ## Run openshift specific e2e test
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
 	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
-	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
+	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview"
+
+test-e2e-tech-preview:
+	hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "TechPreview"
 
 .PHONY: k8s-e2e
 k8s-e2e: ## Run k8s specific e2e test
@@ -59,7 +62,7 @@ k8s-e2e: ## Run k8s specific e2e test
 	# Feature:Operator tests remove deployments. Thus loosing all the logs
 	# previously acquired.
 	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.focus "Feature:Operators"
-	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators"
+	NAMESPACE=kube-system hack/ci-integration.sh -ginkgo.v -ginkgo.noColor=true -ginkgo.skip "Feature:Operators|TechPreview"
 
 .PHONY: help
 help:

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-fmt.sh
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-fmt.sh
@@ -11,6 +11,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/${REPO_NAME}:z" \
     --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
-    openshift/origin-release:golang-1.10 \
+    openshift/origin-release:golang-1.12 \
     ./hack/go-fmt.sh "${@}"
 fi

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-lint.sh
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-lint.sh
@@ -9,6 +9,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/${REPO_NAME}:z" \
     --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
-    openshift/origin-release:golang-1.10 \
+    openshift/origin-release:golang-1.12 \
     ./hack/go-lint.sh "${@}"
 fi

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-vet.sh
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/hack/go-vet.sh
@@ -7,6 +7,6 @@ else
     --env IS_CONTAINER=TRUE \
     --volume "${PWD}:/go/src/github.com/openshift/${REPO_NAME}:z" \
     --workdir "/go/src/github.com/openshift/${REPO_NAME}" \
-    openshift/origin-release:golang-1.10 \
+    openshift/origin-release:golang-1.12 \
     ./hack/go-vet.sh "${@}"
 fi;

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/common.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/common.go
@@ -21,7 +21,6 @@ const (
 	WaitMedium          = 3 * time.Minute
 	WaitLong            = 10 * time.Minute
 	RetryMedium         = 5 * time.Second
-
 	// DefaultMachineSetReplicas is the default number of replicas of a machineset
 	// if MachineSet.Spec.Replicas field is set to nil
 	DefaultMachineSetReplicas = 0

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/deloyment.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework/deloyment.go
@@ -1,0 +1,75 @@
+package framework
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/golang/glog"
+	kappsapi "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetDeployment gets deployment object by name
+func GetDeployment(client runtimeclient.Client, name string) (*kappsapi.Deployment, error) {
+	key := types.NamespacedName{
+		Namespace: TestContext.MachineApiNamespace,
+		Name:      name,
+	}
+	d := &kappsapi.Deployment{}
+
+	if err := wait.PollImmediate(1*time.Second, WaitShort, func() (bool, error) {
+		if err := client.Get(context.TODO(), key, d); err != nil {
+			glog.Errorf("Error querying api for Deployment object %q: %v, retrying...", name, err)
+			return false, nil
+		}
+		return true, nil
+	}); err != nil {
+		return nil, fmt.Errorf("error getting deployment %q: %v", name, err)
+	}
+	return d, nil
+}
+
+// DeleteDeployment deletes the specified deployment
+func DeleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployment) error {
+	return wait.PollImmediate(1*time.Second, WaitShort, func() (bool, error) {
+		if err := client.Delete(context.TODO(), deployment); err != nil {
+			glog.Errorf("error querying api for deployment object %q: %v, retrying...", deployment.Name, err)
+			return false, nil
+		}
+		return true, nil
+	})
+}
+
+// IsDeploymentAvailable returns true if the deployment has one or more availabe replicas
+func IsDeploymentAvailable(client runtimeclient.Client, name string) bool {
+	if err := wait.PollImmediate(1*time.Second, WaitLong, func() (bool, error) {
+		d, err := GetDeployment(client, name)
+		if err != nil {
+			glog.Errorf("Error getting deployment: %v", err)
+			return false, nil
+		}
+		if d.Status.AvailableReplicas < 1 {
+			glog.Errorf("Deployment %q is not available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
+			return false, nil
+		}
+		glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
+		return true, nil
+	}); err != nil {
+		glog.Errorf("Error checking isDeploymentAvailable: %v", err)
+		return false
+	}
+	return true
+}
+
+// DeploymentHasContainer returns true if the deployment has container with the specified name
+func DeploymentHasContainer(deployment *kappsapi.Deployment, containerName string) bool {
+	for _, container := range deployment.Spec.Template.Spec.Containers {
+		if container.Name == containerName {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck/machinehealthcheck.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/machinehealthcheck/machinehealthcheck.go
@@ -21,7 +21,12 @@ import (
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", func() {
+const (
+	machineAPIControllers       = "machine-api-controllers"
+	machineHealthCheckControler = "machine-healthcheck-controller"
+)
+
+var _ = Describe("[TechPreview:Feature:MachineHealthCheck] MachineHealthCheck controller", func() {
 	var client runtimeclient.Client
 	var numberOfReadyWorkers int
 	var workerNode *corev1.Node
@@ -48,6 +53,7 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 					return true
 				}
 			}
+			glog.V(2).Infof("machine deletion timestamp %s still exists", machine.DeletionTimestamp)
 			return false
 		}, timeout, 5*time.Second).Should(BeTrue())
 	}
@@ -57,9 +63,19 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 		client, err = e2e.LoadClient()
 		Expect(err).ToNot(HaveOccurred())
 
-		// TODO: enable once https://github.com/openshift/cluster-api-actuator-pkg/pull/61 is fixed
-		glog.V(2).Info("Skipping machine health checking test")
-		Skip("Skipping machine health checking test")
+		err = e2e.CreateOrUpdateTechPreviewFeatureGate()
+		Expect(err).ToNot(HaveOccurred())
+
+		// Wait until the deployment with machine-healthcheck controller will be ready
+		Eventually(func() bool {
+			d, err := e2e.GetDeployment(client, machineAPIControllers)
+			if err != nil {
+				return false
+			}
+			return e2e.DeploymentHasContainer(d, machineHealthCheckControler)
+		}, e2e.WaitLong, 10*time.Second).Should(BeTrue())
+
+		Expect(e2e.IsDeploymentAvailable(client, machineAPIControllers)).Should(BeTrue())
 
 		workerNodes, err := e2e.GetWorkerNodes(client)
 		Expect(err).ToNot(HaveOccurred())
@@ -112,10 +128,6 @@ var _ = Describe("[Feature:MachineHealthCheck] MachineHealthCheck controller", f
 	})
 
 	AfterEach(func() {
-		// TODO: enable once https://github.com/openshift/cluster-api-actuator-pkg/pull/61 is fixed
-		glog.V(2).Info("Skipping machine health checking test")
-		Skip("Skipping machine health checking test")
-
 		waitForWorkersToGetReady(numberOfReadyWorkers)
 		deleteMachineHealthCheck(e2e.MachineHealthCheckName)
 		deleteKubeletKillerPods()

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/cluster-autoscaler-operator.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/cluster-autoscaler-operator.go
@@ -13,7 +13,7 @@ var _ = g.Describe("[Feature:Operators] Cluster autoscaler operator deployment s
 		var err error
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(isDeploymentAvailable(client, "cluster-autoscaler-operator")).To(o.BeTrue())
+		o.Expect(e2e.IsDeploymentAvailable(client, "cluster-autoscaler-operator")).To(o.BeTrue())
 	})
 })
 

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/machine-api-operator.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/machine-api-operator.go
@@ -19,7 +19,7 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		var err error
 		client, err := e2e.LoadClient()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(isDeploymentAvailable(client, "machine-api-operator")).To(o.BeTrue())
+		o.Expect(e2e.IsDeploymentAvailable(client, "machine-api-operator")).To(o.BeTrue())
 	})
 
 	g.It("reconcile controllers deployment", func() {
@@ -28,22 +28,22 @@ var _ = g.Describe("[Feature:Operators] Machine API operator deployment should",
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		deploymentName := "machine-api-controllers"
-		initialDeployment, err := getDeployment(client, deploymentName)
+		initialDeployment, err := e2e.GetDeployment(client, deploymentName)
 		if err != nil {
-			initialDeployment, err = getDeployment(client, deploymentDeprecatedName)
+			initialDeployment, err = e2e.GetDeployment(client, deploymentDeprecatedName)
 			o.Expect(err).NotTo(o.HaveOccurred())
 			deploymentName = deploymentDeprecatedName
 		}
 
 		g.By(fmt.Sprintf("checking deployment %q is available", deploymentName))
-		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
+		o.Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 
 		g.By(fmt.Sprintf("deleting deployment %q", deploymentName))
-		err = deleteDeployment(client, initialDeployment)
+		err = e2e.DeleteDeployment(client, initialDeployment)
 		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By(fmt.Sprintf("checking deployment %q is available again", deploymentName))
-		o.Expect(isDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
+		o.Expect(e2e.IsDeploymentAvailable(client, deploymentName)).To(o.BeTrue())
 	})
 })
 

--- a/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
+++ b/vendor/github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/operators/utils.go
@@ -2,67 +2,16 @@ package operators
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	e2e "github.com/openshift/cluster-api-actuator-pkg/pkg/e2e/framework"
 	cov1helpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
-	kappsapi "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-func getDeployment(client runtimeclient.Client, name string) (*kappsapi.Deployment, error) {
-	key := types.NamespacedName{
-		Namespace: e2e.TestContext.MachineApiNamespace,
-		Name:      name,
-	}
-	d := &kappsapi.Deployment{}
-
-	if err := wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-		if err := client.Get(context.TODO(), key, d); err != nil {
-			glog.Errorf("Error querying api for Deployment object %q: %v, retrying...", name, err)
-			return false, nil
-		}
-		return true, nil
-	}); err != nil {
-		return nil, fmt.Errorf("error getting deployment %q: %v", name, err)
-	}
-	return d, nil
-}
-
-func deleteDeployment(client runtimeclient.Client, deployment *kappsapi.Deployment) error {
-	return wait.PollImmediate(1*time.Second, e2e.WaitShort, func() (bool, error) {
-		if err := client.Delete(context.TODO(), deployment); err != nil {
-			glog.Errorf("error querying api for deployment object %q: %v, retrying...", deployment.Name, err)
-			return false, nil
-		}
-		return true, nil
-	})
-}
-
-func isDeploymentAvailable(client runtimeclient.Client, name string) bool {
-	if err := wait.PollImmediate(1*time.Second, e2e.WaitLong, func() (bool, error) {
-		d, err := getDeployment(client, name)
-		if err != nil {
-			glog.Errorf("Error getting deployment: %v", err)
-			return false, nil
-		}
-		if d.Status.AvailableReplicas < 1 {
-			glog.Errorf("Deployment %q is not available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
-			return false, nil
-		}
-		glog.Infof("Deployment %q is available. Status: (replicas: %d, updated: %d, ready: %d, available: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.AvailableReplicas, d.Status.UnavailableReplicas)
-		return true, nil
-	}); err != nil {
-		glog.Errorf("Error checking isDeploymentAvailable: %v", err)
-		return false
-	}
-	return true
-}
 
 func isStatusAvailable(client runtimeclient.Client, name string) bool {
 	key := types.NamespacedName{


### PR DESCRIPTION
Bring https://github.com/openshift/cluster-api-actuator-pkg/pull/70 into mao so the mhc tests can be run through a different make target (out of `make test-e2e`).