### PR TITLE
Monitoring for ironic-prometheus-exporter

### DIFF
--- a/install/0000_30_machine-api-operator_10_service-ironic-prometheus-exporter.yaml
+++ b/install/0000_30_machine-api-operator_10_service-ironic-prometheus-exporter.yaml
@@ -1,0 +1,22 @@
+{{if .usingBareMetal}}
+apiVersion: monitoring.coreos.com/v1
+kind: Service
+metadata:
+  name: metal3-baremetalhost-controller
+  namespace: openshift-machine-api
+  labels:
+    app: ironic-exporter
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9608
+      targetPort: 9608
+  selector:
+    app: ironic-exporter
+  clusterIP: None
+  type: ClusterIP
+  sessionAffinity: None
+status:
+  loadBalancer: {}
+{{- end}}

--- a/install/0000_90_machine-api-operator_04_servicemonitor-ironic-prometheus-exporter.yaml
+++ b/install/0000_90_machine-api-operator_04_servicemonitor-ironic-prometheus-exporter.yaml
@@ -1,0 +1,22 @@
+{{if .usingBareMetal}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: ironic-exporter
+  name: metal3-baremetalhost-controller
+  namespace: openshift-machine-api
+spec:
+  endpoints:
+  - port: "9608-tcp"
+    scheme: http
+    path: /metrics
+    targetPort: 9608
+  jobLabel: app
+  namespaceSelector:
+    matchNames:
+    - metal3-baremetalhost-controller
+  selector:
+    matchLabels:
+      app: ironic-exporter
+{{- end}}

--- a/install/0000_90_machine-api-operator_05_prometheusrules-ironic-prometheus-exporter.yaml
+++ b/install/0000_90_machine-api-operator_05_prometheusrules-ironic-prometheus-exporter.yaml
@@ -1,0 +1,27 @@
+{{if .usingBareMetal}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: metal3-baremetalhost-controller
+  namespace: openshift-machine-api
+spec:
+  groups:
+  - name: metal3-baremetalhost-controller
+    rules:
+    - alert: HighCPUTemperature
+      annotations:
+        summary: "The baremetal node {{ $labels.node_name }} CPU {{ $labels.entity_id }} is too high"
+        description: "The baremetal node {{ $labels.node_name }} CPU {{ $labels.entity_id }} was too high in the past 5 minutes. Last measurement {{ $value }}"
+      expr: baremetal_temp_celsius > 96
+      for: 5m
+      labels:
+        severity: warning
+    - alert: LowCPUTemperature
+      annotations:
+        summary: "The baremetal node {{ $labels.node_name }} CPU {{ $labels.entity_id }} is too low"
+        description: "The baremetal node {{ $labels.node_name }} CPU {{ $labels.entity_id }} was too low in the past 5 minutes. Last measurement {{ $value }}"
+      expr: baremetal_temp_celsius < 3
+      for: 5m
+      labels:
+        severity: warning
+{{- end}}

--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -290,6 +290,7 @@ func newMetal3Containers(config *OperatorConfig, baremetalProvisioningConfig Bar
 	containers = append(containers, createContainerMetal3IronicApi(config, baremetalProvisioningConfig))
 	containers = append(containers, createContainerMetal3IronicInspector(config, baremetalProvisioningConfig))
 	containers = append(containers, createContainerMetal3StaticIpManager(config, baremetalProvisioningConfig))
+	containers = append(containers, createContainerMetal3IronicExporter(config))
 	return containers
 }
 
@@ -421,6 +422,21 @@ func createContainerMetal3StaticIpManager(config *OperatorConfig, baremetalProvi
 			buildEnvVar("PROVISIONING_IP", "provisioning_ip", baremetalProvisioningConfig),
 			buildEnvVar("PROVISIONING_INTERFACE", "provisioning_interface", baremetalProvisioningConfig),
 		},
+	}
+	return container
+}
+
+func createContainerMetal3IronicExporter(config *OperatorConfig) corev1.Container {
+
+	container := corev1.Container{
+		Name:            "metal3-ironic-exporter",
+		Image:           config.BaremetalControllers.Ironic,
+		ImagePullPolicy: "Always",
+		SecurityContext: &corev1.SecurityContext{
+			Privileged: pointer.BoolPtr(true),
+		},
+		Command:      []string{"/bin/runironic-exporter"},
+		VolumeMounts: volumeMounts,
 	}
 	return container
 }


### PR DESCRIPTION
This PR depends on #302 and adds the changes to enable monitoring
in the machine-api-operator that will allow Prometheus
to collect data from the ironic-prometheus-exporter[1] that
runs in the ironic-image [2]. 

- Added monitoring label to namespace yaml
- Added monitoring information to the rbac yaml
- Added Service for the ironic-prometheus-exporter
- Added the ServiceMonitor for the ironic-prometheus-exporter
- Added PrometheusRule with alert for baremetal_temp_celsius
metric.

[1] https://github.com/metal3-io/ironic-prometheus-exporter
[2] https://github.com/metal3-io/ironic-image