### PR TITLE
Introduce gosec for security checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ build-integration: ## Build integration test binary
 test-e2e: ## Run openshift specific e2e test
 	$(MAKE) -C ./vendor/github.com/openshift/cluster-api-actuator-pkg $@
 
+.PHONY: test-sec
+test-sec:
+	@which gosec 2> /dev/null >&1 || { echo "gosec must be installed to lint code";  exit 1; }
+	gosec -severity medium --confidence medium -quiet ./...
+
 .PHONY: deploy-kubemark
 deploy-kubemark:
 	kustomize build config | kubectl apply -f -

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
 )
@@ -48,7 +49,7 @@ func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.Pla
 }
 
 func getImagesFromJSONFile(filePath string) (*Images, error) {
-	data, err := ioutil.ReadFile(filePath)
+	data, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
+	"path/filepath"
 	"strings"
 )
 
@@ -11,7 +12,7 @@ const ServiceAccountNamespaceFile = "/var/run/secrets/kubernetes.io/serviceaccou
 
 // GetNamespace returns the namespace of the pod where the code is running
 func GetNamespace(namespaceFile string) (string, error) {
-	data, err := ioutil.ReadFile(namespaceFile)
+	data, err := ioutil.ReadFile(filepath.Clean(namespaceFile))
 	if err != nil {
 		return "", fmt.Errorf("failed to determine namespace from %s: %v", namespaceFile, err)
 	}


### PR DESCRIPTION
gosec does static code analysis and checks for common security issues in golang codebases.

This PR introduces the tool, and sets it up as a test target in the Makefile; it also fixes a couple of warnings that were found (which were probably not very problematic).