### PR TITLE
Add reboot annotation

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"runtime"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-operator/pkg/controller/disruption"
 	"github.com/openshift/machine-api-operator/pkg/controller/machinehealthcheck"
 
@@ -55,6 +56,9 @@ func main() {
 		glog.Fatal(err)
 	}
 	if err := mapiv1.AddToScheme(mgr.GetScheme()); err != nil {
+		glog.Fatal(err)
+	}
+	if err := configv1.AddToScheme(mgr.GetScheme()); err != nil {
 		glog.Fatal(err)
 	}
 

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -133,6 +133,14 @@ rules:
       - list
       - watch
 
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+      - infrastructures/status
+    verbs:
+      - get
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	configv1 "github.com/openshift/api/config/v1"
 	mapiv1 "github.com/openshift/cluster-api/pkg/apis/machine/v1beta1"
 	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 
@@ -152,6 +153,18 @@ func NewUnhealthyConditionsConfigMap(name string, data string) *corev1.ConfigMap
 		},
 		Data: map[string]string{
 			"conditions": data,
+		},
+	}
+}
+
+// NewInfrastructure returns new infrastructure object
+func NewInfrastructure(platform configv1.PlatformType) *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			Platform: platform,
 		},
 	}
 }


### PR DESCRIPTION
Instead of deleting the unhealthy machine under the bare metal provider
we want only to reboot it, the one who will responsible for the reboot will
be the machine-remediation controller and MHC will just set reboot annotation on
the node.