### PR TITLE
Remediaton strategies

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -32,10 +32,15 @@ spec:
         spec:
           description: Specification of machine health check policy
           properties:
+            remediationStrategy:
+              description: RemediationStrategy to use in case of problem detection
+                default is machine deletion
+              type: string
             selector:
               description: Label selector to match machines whose health will be exercised
               type: object
           required:
+          - remediationStrategy
           - selector
           type: object
         status:

--- a/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinehealthcheck_types.go
@@ -7,6 +7,8 @@ import (
 // ConfigMapNodeUnhealthyConditions contains the name of the unhealthy conditions config map
 const ConfigMapNodeUnhealthyConditions = "node-unhealthy-conditions"
 
+type RemediationStrategyType string
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -36,6 +38,9 @@ type MachineHealthCheckList struct {
 
 // MachineHealthCheckSpec defines the desired state of MachineHealthCheck
 type MachineHealthCheckSpec struct {
+	// RemediationStrategy to use in case of problem detection
+	// default is machine deletion
+	RemediationStrategy RemediationStrategyType `json:"remediationStrategy"`
 	// Label selector to match machines whose health will be exercised
 	Selector metav1.LabelSelector `json:"selector"`
 }

--- a/pkg/generated/clientset/versioned/clientset.go
+++ b/pkg/generated/clientset/versioned/clientset.go
@@ -28,8 +28,6 @@ import (
 type Interface interface {
 	Discovery() discovery.DiscoveryInterface
 	HealthcheckingV1alpha1() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface
-	// Deprecated: please explicitly pick a version if possible.
-	Healthchecking() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface
 }
 
 // Clientset contains the clients for groups. Each group has exactly one
@@ -41,12 +39,6 @@ type Clientset struct {
 
 // HealthcheckingV1alpha1 retrieves the HealthcheckingV1alpha1Client
 func (c *Clientset) HealthcheckingV1alpha1() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface {
-	return c.healthcheckingV1alpha1
-}
-
-// Deprecated: Healthchecking retrieves the default version of HealthcheckingClient.
-// Please explicitly pick a version.
-func (c *Clientset) Healthchecking() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface {
 	return c.healthcheckingV1alpha1
 }
 

--- a/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -75,8 +75,3 @@ var _ clientset.Interface = &Clientset{}
 func (c *Clientset) HealthcheckingV1alpha1() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface {
 	return &fakehealthcheckingv1alpha1.FakeHealthcheckingV1alpha1{Fake: &c.Fake}
 }
-
-// Healthchecking retrieves the HealthcheckingV1alpha1Client
-func (c *Clientset) Healthchecking() healthcheckingv1alpha1.HealthcheckingV1alpha1Interface {
-	return &fakehealthcheckingv1alpha1.FakeHealthcheckingV1alpha1{Fake: &c.Fake}
-}


### PR DESCRIPTION
Add `Remediation` field to spec
Defaults to simplest deletion behaviour
Support `remediationReboot` which sets an annotation that consumer remediation systems can react upon
Supersedes https://github.com/openshift/machine-api-operator/pull/346 This allows separation at the right level so consumers can architect their solution by choosing and implementing its strategy, no need for getting infrastructure specifics in the MHC