### PR TITLE
Rename part of disruption variables and methods

### DIFF
--- a/docs/proposals/machine-disruption-budget-kpe.md
+++ b/docs/proposals/machine-disruption-budget-kpe.md
@@ -72,7 +72,7 @@ spec:
 ```yaml
 status:
   # total number of machines with the labels that correspond to the label selector
-  ExpectedMachines: 5
+  total: 5
   # currently number of healthy machines
   currentHealthy: 3
   # desired number of healthy machines

--- a/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
@@ -11,7 +11,7 @@ spec:
     description: The number of healthy machines
     name: Healthy
     type: integer
-  - JSONPath: .status.expectedMachines
+  - JSONPath: .status.total
     description: The total number of machines
     name: Total
     type: integer
@@ -93,21 +93,21 @@ spec:
               description: Number of machines disruptions that are currently allowed.
               format: int32
               type: integer
-            expectedMachines:
-              description: total number of machines counted by this disruption budget
-              format: int32
-              type: integer
             observedGeneration:
               description: Most recent generation observed when updating this MDB
                 status. MachineDisruptionsAllowed and other status information is
                 valid only if observedGeneration equals to MDB's object generation.
               format: int64
               type: integer
+            total:
+              description: total number of machines counted by this disruption budget
+              format: int32
+              type: integer
           required:
           - disruptionsAllowed
           - currentHealthy
           - desiredHealthy
-          - expectedMachines
+          - total
           type: object
   version: v1alpha1
 status:

--- a/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
@@ -56,7 +56,7 @@ type MachineDisruptionBudgetStatus struct {
 	DesiredHealthy int32 `json:"desiredHealthy" protobuf:"varint,5,opt,name=desiredHealthy"`
 
 	// total number of machines counted by this disruption budget
-	ExpectedMachines int32 `json:"expectedMachines" protobuf:"varint,6,opt,name=expectedMachines"`
+	Total int32 `json:"total" protobuf:"varint,6,opt,name=total"`
 }
 
 // +genclient
@@ -66,7 +66,7 @@ type MachineDisruptionBudgetStatus struct {
 // kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mdb;mdbs
 // +kubebuilder:printcolumn:name="Healthy",type="integer",JSONPath=".status.currentHealthy",description="The number of healthy machines"
-// +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.expectedMachines",description="The total number of machines"
+// +kubebuilder:printcolumn:name="Total",type="integer",JSONPath=".status.total",description="The total number of machines"
 // +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".status.desiredHealthy",description="The desired number of healthy machines"
 type MachineDisruptionBudget struct {
 	metav1.TypeMeta `json:",inline"`

--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -96,11 +96,11 @@ func newMachineDeployment(name string, size int32) *mapiv1.MachineDeployment {
 }
 
 type expectedMachineCount struct {
-	count   int32
+	total   int32
 	healthy int32
 }
 
-func TestGetExpectedMachineCount(t *testing.T) {
+func TestGetTotalMachineCount(t *testing.T) {
 	mdbMinAvailable := maotesting.NewMinAvailableMachineDisruptionBudget(1)
 	mdbMaxUnavailable := maotesting.NewMaxUnavailableMachineDisruptionBudget(1)
 
@@ -132,7 +132,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMinAvailable,
 			machines: []mapiv1.Machine{*machine},
 			expected: &expectedMachineCount{
-				count:   1,
+				total:   1,
 				healthy: 1,
 			},
 		},
@@ -141,7 +141,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMinAvailable,
 			machines: []mapiv1.Machine{*machineControlledByMachineSet},
 			expected: &expectedMachineCount{
-				count:   1,
+				total:   1,
 				healthy: 1,
 			},
 		},
@@ -150,7 +150,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMinAvailable,
 			machines: []mapiv1.Machine{*machineControlledByMachineDeployment},
 			expected: &expectedMachineCount{
-				count:   1,
+				total:   1,
 				healthy: 1,
 			},
 		},
@@ -162,7 +162,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 				*machineControlledByMachineDeployment,
 			},
 			expected: &expectedMachineCount{
-				count:   2,
+				total:   2,
 				healthy: 1,
 			},
 		},
@@ -171,7 +171,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMaxUnavailable,
 			machines: []mapiv1.Machine{*machine},
 			expected: &expectedMachineCount{
-				count:   1,
+				total:   1,
 				healthy: 0,
 			},
 		},
@@ -180,7 +180,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMaxUnavailable,
 			machines: []mapiv1.Machine{*machineControlledByMachineSet},
 			expected: &expectedMachineCount{
-				count:   3,
+				total:   3,
 				healthy: 2,
 			},
 		},
@@ -189,7 +189,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 			mdb:      mdbMaxUnavailable,
 			machines: []mapiv1.Machine{*machineControlledByMachineDeployment},
 			expected: &expectedMachineCount{
-				count:   4,
+				total:   4,
 				healthy: 3,
 			},
 		},
@@ -201,7 +201,7 @@ func TestGetExpectedMachineCount(t *testing.T) {
 				*machineControlledByMachineDeployment,
 			},
 			expected: &expectedMachineCount{
-				count:   7,
+				total:   7,
 				healthy: 6,
 			},
 		},
@@ -214,9 +214,9 @@ func TestGetExpectedMachineCount(t *testing.T) {
 		machineDeployment,
 	)
 	for _, tc := range testsCases {
-		expectedCount, desiredHealthy := r.getExpectedMachineCount(tc.mdb, tc.machines)
-		if expectedCount != tc.expected.count {
-			t.Errorf("Test case: %v. Expected count: %v, got: %v", tc.testName, tc.expected.count, expectedCount)
+		total, desiredHealthy := r.getTotalAndDesiredMachinesCount(tc.mdb, tc.machines)
+		if total != tc.expected.total {
+			t.Errorf("Test case: %v. Expected count: %v, got: %v", tc.testName, tc.expected.total, total)
 		}
 
 		if desiredHealthy != tc.expected.healthy {


### PR DESCRIPTION
New names better reflect the purpose of variable and methods.

- rename `expectedMachines` to `Total` under MDB types
- rename `getExpectedMachineCount` to `getTotalAndDesiredMachinesCount`
- rename `getExpectedScale` to `getTotalMachinesCount`
- rename all occurences of `expectedCount` to `total`