### PR TITLE
Use unhealty conditions config map under the MDB

### DIFF
--- a/pkg/controller/disruption/disruption_test.go
+++ b/pkg/controller/disruption/disruption_test.go
@@ -410,7 +410,7 @@ func TestCountHealthyMachines(t *testing.T) {
 	disruptedMachineAfterTimeout := maotesting.NewMachine("disruptedMachineAfterTimeout", healthyNode.Name)
 
 	r := newFakeReconciler(nil, healthyNode, unhealthyNode)
-	healthyMachinesCount := r.countHealthyMachines(
+	healthyMachinesCount, err := r.countHealthyMachines(
 		[]mapiv1.Machine{
 			*healthyMachine,
 			*deletedMachine,
@@ -424,6 +424,9 @@ func TestCountHealthyMachines(t *testing.T) {
 		},
 		currentTime.Time,
 	)
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+	}
 
 	expectedHealthyMachinesCount := int32(2)
 	if healthyMachinesCount != expectedHealthyMachinesCount {

--- a/pkg/util/conditions/conditions.go
+++ b/pkg/util/conditions/conditions.go
@@ -1,12 +1,18 @@
 package conditions
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
+	healthcheckingv1alpha1 "github.com/openshift/machine-api-operator/pkg/apis/healthchecking/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetNodeCondition returns node condition by type
@@ -29,6 +35,29 @@ type UnhealthyCondition struct {
 	Name    corev1.NodeConditionType `json:"name"`
 	Status  corev1.ConditionStatus   `json:"status"`
 	Timeout string                   `json:"timeout"`
+}
+
+// CreateDummyUnhealthyConditionsConfigMap creates dummy config map with default unhealthy conditions
+func createDummyUnhealthyConditionsConfigMap() (*corev1.ConfigMap, error) {
+	unhealthyConditions := &UnhealthyConditions{
+		Items: []UnhealthyCondition{
+			{
+				Name:    "Ready",
+				Status:  "Unknown",
+				Timeout: "300s",
+			},
+			{
+				Name:    "Ready",
+				Status:  "False",
+				Timeout: "300s",
+			},
+		},
+	}
+	conditionsData, err := yaml.Marshal(unhealthyConditions)
+	if err != nil {
+		return nil, err
+	}
+	return &corev1.ConfigMap{Data: map[string]string{"conditions": string(conditionsData)}}, nil
 }
 
 // GetNodeUnhealthyConditions returns node unhealthy conditions
@@ -55,25 +84,32 @@ func GetNodeUnhealthyConditions(node *corev1.Node, cmUnealthyConditions *corev1.
 	return conditions, nil
 }
 
-// CreateDummyUnhealthyConditionsConfigMap creates dummy config map with default unhealthy conditions
-func CreateDummyUnhealthyConditionsConfigMap() (*corev1.ConfigMap, error) {
-	unhealthyConditions := &UnhealthyConditions{
-		Items: []UnhealthyCondition{
-			{
-				Name:    "Ready",
-				Status:  "Unknown",
-				Timeout: "300s",
-			},
-			{
-				Name:    "Ready",
-				Status:  "False",
-				Timeout: "300s",
-			},
-		},
+// GetUnhealthyConditionsConfigMap get config map with unhealthy node conditions, when the config map
+// does not exist, returns dummy config map with default unhealthy conditions
+func GetUnhealthyConditionsConfigMap(c client.Client, namespace string) (*corev1.ConfigMap, error) {
+	cmUnhealtyConditions := &corev1.ConfigMap{}
+	cmKey := types.NamespacedName{
+		Name:      healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+		Namespace: namespace,
 	}
-	conditionsData, err := yaml.Marshal(unhealthyConditions)
+	err := c.Get(context.TODO(), cmKey, cmUnhealtyConditions)
 	if err != nil {
-		return nil, err
+		// Error reading the object - requeue the request
+		if !errors.IsNotFound(err) {
+			return nil, err
+		}
+
+		// creates dummy config map with default values if it does not exist
+		cmUnhealtyConditions, err = createDummyUnhealthyConditionsConfigMap()
+		if err != nil {
+			return nil, err
+		}
+		glog.Infof(
+			"ConfigMap %s not found under the namespace %s, fallback to default values: %s",
+			healthcheckingv1alpha1.ConfigMapNodeUnhealthyConditions,
+			namespace,
+			cmUnhealtyConditions.Data["conditions"],
+		)
 	}
-	return &corev1.ConfigMap{Data: map[string]string{"conditions": string(conditionsData)}}, nil
+	return cmUnhealtyConditions, nil
 }


### PR DESCRIPTION
Now the MDB will check the health of the machine by equal
node conditions to the conditions under the unhealthy node conditions
config map and if the node referenced by machine has conditions from the
config map, MDB will mark it as unhealthy.