### PR TITLE
Add image reference to GCP machine controllers

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -26,3 +26,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-azure-machine-controllers:v4.0.0
+  - name: gcp-machine-controllers
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-gcp-machine-controllers:v4.0.0


### PR DESCRIPTION
Get the right reference rendered in the images configmap