### PR TITLE
Get values for CRD's additionalPrinterColumns from annotations and labels instead of machine provider config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -384,7 +384,7 @@
 
 [[projects]]
   branch = "openshift-4.2-cluster-api-0.1.0"
-  digest = "1:1fd0478928373af6be747a9191b2f60179ded98f612d33200fbd7521aea5f4df"
+  digest = "1:2ccd67b04d2483877ff0c4bdf59a3e7124de72dde98a7391bdfea314f420316f"
   name = "github.com/openshift/cluster-api"
   packages = [
     "pkg/apis/cluster/common",
@@ -405,7 +405,7 @@
     "pkg/client/listers_generated/machine/v1beta1",
   ]
   pruneopts = "NUT"
-  revision = "e911af77e9a33cfb45f82ba9778876d715cdb4ea"
+  revision = "f8de78af80fcecf1fd69e35005b591dc9e1df61a"
 
 [[projects]]
   branch = "master"
@@ -1266,6 +1266,7 @@
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/record",
     "k8s.io/client-go/util/flowcontrol",
+    "k8s.io/client-go/util/retry",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/code-generator/cmd/client-gen",
     "k8s.io/code-generator/cmd/conversion-gen",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,6 +14,10 @@ required = [
 ]
 
 [[override]]
+  name = "github.com/openshift/cluster-api"
+  branch = "openshift-4.2-cluster-api-0.1.0"
+
+[[override]]
   name = "k8s.io/utils"
 
 [[constraint]]

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -7,23 +7,19 @@ metadata:
   name: machines.machine.openshift.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.providerStatus.instanceId
-    description: Instance ID of machine created in AWS
-    name: Instance
-    type: string
-  - JSONPath: .status.providerStatus.instanceState
-    description: State of the AWS instance
+  - JSONPath: .metadata.annotations['machine\.openshift\.io/instance-state']
+    description: State of instance
     name: State
     type: string
-  - JSONPath: .spec.providerSpec.value.instanceType
+  - JSONPath: .metadata.labels['machine\.openshift\.io/instance-type']
     description: Type of instance
     name: Type
     type: string
-  - JSONPath: .spec.providerSpec.value.placement.region
+  - JSONPath: .metadata.labels['machine\.openshift\.io/region']
     description: Region associated with machine
     name: Region
     type: string
-  - JSONPath: .spec.providerSpec.value.placement.availabilityZone
+  - JSONPath: .metadata.labels['machine\.openshift\.io/zone']
     description: Zone associated with machine
     name: Zone
     type: string
@@ -31,6 +27,16 @@ spec:
     description: Machine age
     name: Age
     type: date
+  - JSONPath: .status.nodeRef.name
+    description: Node associated with machine
+    name: Node
+    priority: 1
+    type: string
+  - JSONPath: .spec.providerID
+    description: Provider ID of machine created in cloud provider
+    name: ProviderID
+    priority: 1
+    type: string
   group: machine.openshift.io
   names:
     kind: Machine

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machine_types.go
@@ -46,6 +46,13 @@ const (
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".metadata.annotations['machine\.openshift\.io/instance-state']",description="State of instance"
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/instance-type']",description="Type of instance"
+// +kubebuilder:printcolumn:name="Region",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/region']",description="Region associated with machine"
+// +kubebuilder:printcolumn:name="Zone",type="string",JSONPath=".metadata.labels['machine\.openshift\.io/zone']",description="Zone associated with machine"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machine age"
+// +kubebuilder:printcolumn:name="Node",type="string",JSONPath=".status.nodeRef.name",description="Node associated with machine",priority=1
+// +kubebuilder:printcolumn:name="ProviderID",type="string",JSONPath=".spec.providerID",description="Provider ID of machine created in cloud provider",priority=1
 type Machine struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/vendor/github.com/openshift/cluster-api/pkg/apis/machine/v1beta1/machineset_types.go
@@ -35,6 +35,11 @@ import (
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"
+// +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Current Replicas"
+// +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Ready Replicas"
+// +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.availableReplicas",description="Observed number of available replicas"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Machineset age"
 type MachineSet struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
Given we already support AWS, Azure and GCP instalations of OpenShift,
reading values from machine provider config is no longer an option.
Instead, let's read all needed values from machine annotations and labels.
Each actuator will be then responsible for making sure every machine
has all the annotations and labels that are needed to properly display
additional machine columns set.

- [x] Azure: https://github.com/openshift/cluster-api-provider-azure/pull/59
- [x] AWS: https://github.com/openshift/cluster-api-provider-aws/pull/242
- [ ] GCP: TBD
- [ ] OpenStack: TBD