### PR TITLE
credentials request: fix gcp roles

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -79,6 +79,6 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
     predefinedRoles:
-    - "compute.instanceAdmin.v1"
-    - "iam.serviceAccountUser"
+    - "roles/compute.instanceAdmin.v1"
+    - "roles/iam.serviceAccountUser"
 ---


### PR DESCRIPTION
The cloud credentials operator requires that roles be specified with a
prefix indicating their scope (roles/* for global roles,
roles/project/[project]/* for project-scoped roles, etc)