### PR TITLE
MDB: Set minimum value constraint for MinAvailable and MaxUnavailable

### DIFF
--- a/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
@@ -53,6 +53,7 @@ spec:
                 one can prevent all voluntary deletions by specifying 0. This is a
                 mutually exclusive setting with "minAvailable".
               format: int32
+              minimum: 0
               type: integer
             minAvailable:
               description: An deletion of the machine is allowed if at least "minAvailable"
@@ -60,6 +61,7 @@ spec:
                 deletion. So for example you can prevent all voluntary deletions by
                 specifying all available nodes.
               format: int32
+              minimum: 0
               type: integer
             selector:
               description: Label query over machines whose deletions are managed by

--- a/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
+++ b/pkg/apis/healthchecking/v1alpha1/machinedisruptionbudget_types.go
@@ -10,6 +10,7 @@ type MachineDisruptionBudgetSpec struct {
 	// "selector" will still be available after the deletion.
 	// So for example you can prevent all voluntary deletions by specifying all available nodes.
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MinAvailable *int32 `json:"minAvailable,omitempty" protobuf:"bytes,1,opt,name=minAvailable"`
 
 	// Label query over machines whose deletions are managed by the disruption
@@ -22,6 +23,7 @@ type MachineDisruptionBudgetSpec struct {
 	// For example, one can prevent all voluntary deletions by specifying 0.
 	// This is a mutually exclusive setting with "minAvailable".
 	// +optional
+	// +kubebuilder:validation:Minimum=0
 	MaxUnavailable *int32 `json:"maxUnavailable,omitempty" protobuf:"bytes,3,opt,name=maxUnavailable"`
 }
 


### PR DESCRIPTION
After applying the change and applying:
```yaml
apiVersion: healthchecking.openshift.io/v1alpha1
kind: MachineDisruptionBudget
metadata:
  name: mdb-test
  namespace: kubemark-provider
spec:
  selector:
    matchLabels:
      machine.openshift.io/cluster-api-cluster: kubemark
      sigs.k8s.io/cluster-api-machineset: kubemark-scale-group-2a
  maxUnavailable: -2
```

I get:

```sh
The MachineDisruptionBudget "mdb-test" is invalid: []: Invalid value: map[string]interface {}{"apiVersion":"healthchecking.openshift.io/v1alpha1", "kind":"MachineDisruptionBudget", "metadata":map[string]interface {}{"annotations":map[string]interface {}{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"healthchecking.openshift.io/v1alpha1\",\"kind\":\"MachineDisruptionBudget\",\"metadata\":{\"annotations\":{},\"name\":\"mdb-test\",\"namespace\":\"kubemark-provider\"},\"spec\":{\"maxUnavailable\":-2,\"selector\":{\"matchLabels\":{\"machine.openshift.io/cluster-api-cluster\":\"kubemark\",\"sigs.k8s.io/cluster-api-machineset\":\"kubemark-scale-group-2a\"}}}}\n"}, "generation":1, "uid":"f2bab200-b1f5-11e9-9a34-bcf37e375394", "name":"mdb-test", "namespace":"kubemark-provider", "creationTimestamp":"2019-07-29T11:42:30Z"}, "spec":map[string]interface {}{"maxUnavailable":-2, "selector":map[string]interface {}{"matchLabels":map[string]interface {}{"machine.openshift.io/cluster-api-cluster":"kubemark", "sigs.k8s.io/cluster-api-machineset":"kubemark-scale-group-2a"}}}}: validation failure list:
spec.maxUnavailable in body should be greater than or equal to 0
```

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1733473