### PR TITLE
Expose metric endpoint on https

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -145,7 +145,7 @@ func startMetricsCollectionAndServer(ctx *ControllerContext) {
 		metricsPort = v
 	}
 	glog.V(4).Info("Starting server to serve prometheus metrics")
-	go startHTTPMetricServer(fmt.Sprintf(":%d", metricsPort))
+	go startHTTPMetricServer(fmt.Sprintf("localhost:%d", metricsPort))
 }
 
 func startHTTPMetricServer(metricsPort string) {

--- a/config/machine-api-operator-deployment.yaml
+++ b/config/machine-api-operator-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -23,8 +24,6 @@ spec:
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://localhost:8080/"
-        - "--tls-cert-file=/etc/tls/private/tls.crt"
-        - "--tls-private-key-file=/etc/tls/private/tls.key"
         - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
         - "--logtostderr=true"
         - "--v=10"
@@ -34,8 +33,6 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /etc/kube-rbac-proxy
-        - mountPath: /etc/tls/private
-          name: machine-api-operator-tls
       - name: machine-api-operator
         image: docker.io/openshift/origin-machine-api-operator:v4.0.0
         command:
@@ -85,7 +82,4 @@ spec:
           name: kube-rbac-proxy
       - name: images
         configMap:
-                name: machine-api-operator-images
-      - name: machine-api-operator-tls
-        secret:
-          secretName: machine-api-operator-tls
+          name: machine-api-operator-images

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -200,7 +200,14 @@ kind: ClusterRole
 metadata:
   name: machine-api-operator
 rules:
-
+  - apiGroups: ["authentication.k8s.io"]
+    resources:
+      - tokenreviews
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources:
+      - subjectaccessreviews
+    verbs: ["create"]
   - apiGroups:
       - config.openshift.io
     resources:
@@ -319,6 +326,12 @@ metadata:
   name: prometheus-k8s-machine-api-operator
   namespace: openshift-machine-api
 rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespace/metrics
+    verbs:
+      - get
   - apiGroups:
       - ""
     resources:

--- a/install/0000_30_machine-api-operator_10_kube-rbac-proxy-config.yaml
+++ b/install/0000_30_machine-api-operator_10_kube-rbac-proxy-config.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-machine-api
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-machine-api
+

--- a/install/0000_30_machine-api-operator_10_service.yaml
+++ b/install/0000_30_machine-api-operator_10_service.yaml
@@ -4,15 +4,16 @@ kind: Service
 metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: machine-api-operator-tls
   labels:
     k8s-app: machine-api-operator
 spec:
   type: ClusterIP
   ports:
-  - name: metrics
-    port: 8080
-    targetPort: metrics
-    protocol: TCP
+  - name: https
+    port: 8443
+    targetPort: https
   selector:
     k8s-app: machine-api-operator
   sessionAffinity: None

--- a/install/0000_90_machine-api-operator_03_servicemonitor.yaml
+++ b/install/0000_90_machine-api-operator_03_servicemonitor.yaml
@@ -9,8 +9,11 @@ spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 30s
-      port: metrics
-      scheme: http
+      port: https
+      scheme: https
+      tlsConfig:
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        serverName: machine-api-operator.openshift-machine-api.svc
   namespaceSelector:
     matchNames:
       - openshift-machine-api

--- a/install/image-references
+++ b/install/image-references
@@ -54,3 +54,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:4.2.0

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -26,8 +26,9 @@ resources:
 - install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
 - install/0000_30_machine-api-operator_08_machinedisruptionbudget.crd.yaml
 - install/0000_30_machine-api-operator_09_rbac.yaml
+- install/0000_30_machine-api-operator_10_kube-rbac-proxy-config.yaml
 - install/0000_30_machine-api-operator_10_service.yaml
-- install/0000_30_machine-api-operator_11_deployment.yaml
+- config/machine-api-operator-deployment.yaml
 - install/0000_30_machine-api-operator_12_clusteroperator.yaml
 
 


### PR DESCRIPTION
This PR is adding changes to expose metrics endpoint on https and also changes at other objects for integration with openshift-monitoring at https.
This PR is also restricting http port access only on loopback ip.

## Approach for https support:
[kube-rbac-proxy](https://github.com/openshift/kube-rbac-proxy/tree/master/examples/rewrites#rewriting-subjectaccessreviews-example) container is being run alongside operator container which runs metrics server in the same pod. kube-rbac -proxy validates authz and authn on behalf of the metrics server and if success, proxies the incoming https request to the metrics server(which is listening on 127.0.0.1 and http port 8080).
### How authn and authz is being validated by kube-rbac-proxy
It uses `TokenReviews()` and `SubjectAccessReviews()` apis internally for validation of token authentication and authorization respectively. These apis are used against a stub resource, `namespace/metrics` which is passed as config to the kube-rbac-proxy
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: kube-rbac-proxy
  namespace: openshift-machine-api
data:
  config-file.yaml: |+
    authorization:
      resourceAttributes:
        apiVersion: v1
        resource: namespace
        subresource: metrics
        namespace: openshift-machine-api
 ```
[RBAC permissions](https://github.com/openshift/machine-api-operator/pull/368/commits/cfacd9dc1d5666dd1958dcd3fa6f32c78fd7d7e1#diff-2043d8125934ffff48ca0cb4d630543bR329-R334) for this rule are defined same as that we expect for metrics endpoint.
So when a https request is received for metrics endpoint, token and rbac of the request user is validated against this stub resource. If it passes, proxied to the metrics endpoint.

 ### How I tested it locally
- launch a cluster using installer
- make cluster-version deployment replica to 0
- change mao image with the one with the PR changes
- change/create all the api objects(like clusterrole, rbac-config etc) that are part of this PR
- I had to make a curl command on the metrics service with service account, `prometheus-k8s`. I got this token using following command:
> kubectl -n openshift-monitoring get secret $(kubectl -n openshift-monitoring get sa prometheus-k8s -o 'jsonpath={.secrets[0].name}') -o 'jsonpath={.data.token}' | base64 -d

- Next, created a pod in the openshift-monitoring namespace to make curl call at service
- Then copy token obtained above in the curl container and make the curl call
> curl -v -s -k -H "Authorization: Bearer `cat ./token2`" https://machine-api-operator.openshift-machine-api.svc:8443/metrics

This should return metrics


