### PR TITLE
Bug 1704587: Reconcile nodes on MHC changes

### DIFF
--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -103,7 +103,7 @@ func NewNode(name string, ready bool) *corev1.Node {
 
 // NewMachine returns new machine object that can be used for testing
 func NewMachine(name string, nodeName string) *mapiv1.Machine {
-	return &mapiv1.Machine{
+	m := &mapiv1.Machine{
 		TypeMeta: metav1.TypeMeta{Kind: "Machine"},
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations:     make(map[string]string),
@@ -114,13 +114,16 @@ func NewMachine(name string, nodeName string) *mapiv1.Machine {
 			OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
 		},
 		Spec: mapiv1.MachineSpec{},
-		Status: mapiv1.MachineStatus{
+	}
+	if nodeName != "" {
+		m.Status = mapiv1.MachineStatus{
 			NodeRef: &corev1.ObjectReference{
 				Name:      nodeName,
 				Namespace: metav1.NamespaceNone,
 			},
-		},
+		}
 	}
+	return m
 }
 
 // NewMachineHealthCheck returns new MachineHealthCheck object that can be used for testing


### PR DESCRIPTION
Watch MachineHealthChecks and enqueue reconcile.Request for the backed nodes.
This is useful to trigger remediation when e.g a machineHealCheck is created against
a node which is already unhealthy and is not able to receive status updates which would otherwise be ignored by MHC
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1704587