### PR TITLE
baremetal: Fix service account name.

### DIFF
--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -122,7 +122,7 @@ func newMetal3PodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSpec {
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsNonRoot: pointer.BoolPtr(false),
 			},
-			ServiceAccountName: "metal3-controller",
+			ServiceAccountName: "machine-api-controllers",
 			Tolerations:        tolerations,
 		},
 	}


### PR DESCRIPTION
The "metal3-controller" service account does not exist.  Instead, use
the "machine-api-controllers" service account.