### PR TITLE
baremetal: set host networking to true

### DIFF
--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -117,6 +117,7 @@ func newMetal3PodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSpec {
 			Volumes:           volumes,
 			InitContainers:    initContainers,
 			Containers:        containers,
+			HostNetwork:       true,
 			PriorityClassName: "system-node-critical",
 			NodeSelector:      map[string]string{"node-role.kubernetes.io/master": ""},
 			SecurityContext: &corev1.PodSecurityContext{


### PR DESCRIPTION
static ip container fails to come up, as it can not see host network
interfaces:

```
[root@host dev-scripts]# oc logs -n openshift-machine-api pod/metal3-7557d6d788-cfdt6  --container=metal3-static-ip-set
+ '[' -z ens3 ']'
+ '[' -z 172.22.0.3/24 ']'
+ /usr/sbin/ip address flush dev ens3
Device "ens3" does not exist.
```