### PR TITLE
Set default role for minted credentials to Contributor

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -46,8 +46,7 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     roleBindings:
-    - role: passthrough
-      scope: resourcegroup
+    - role: Contributor
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
After cloud credential operator starts supporting resource group
scoped credential minting for Azure, all CCO will be required to set
at least one role in role bindings. If a CCO failed to do so,
no secret with azure credential will be minted.

Contributor role permissions should be sufficient. If not, please extend the list of role bindings with additional roles.

PR adding the support for resource group scoped credentials: https://github.com/openshift/cloud-credential-operator/pull/95