### PR TITLE
rbac: Allow update and patch of secrets.

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -55,6 +55,8 @@ rules:
       - list
       - watch
       - create
+      - update
+      - patch
 
   - apiGroups:
       - ""


### PR DESCRIPTION
When using the baremetal infrastructure platform, the
baremetal-operator component within the metal3 deployment needs to be
able to set the owner reference on Secrets.

Secrets are used to hold credentials used to talk to the out-of-band
management controllers (BMCs) on bare metal servers.  These Secrets
are associated with a BareMetalHost resource.  The BareMetalHost
controller will set the owner on the Secret.