### PR TITLE
RBAC: Add additional metal3.io resource access

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -83,6 +83,8 @@ rules:
       - metal3.io
     resources:
       - baremetalhosts
+      - baremetalhosts/status
+      - baremetalhosts/finalizers
     verbs:
       - get
       - list


### PR DESCRIPTION
When utilising the baremetal infrastructure platform the baremetal
operator component needs to be able to update additional resources
for baremetal hosts, namely the status and the finalizer. This patch
ensures that it can do so, and will now allow hosts to be registered
with OpenShift as `BareMetalHosts` and as a result inside of Ironic.