### PR TITLE
rbac: allow delete of secrets and baremetalhosts

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -57,6 +57,7 @@ rules:
       - create
       - update
       - patch
+      - delete
 
   - apiGroups:
       - ""
@@ -69,7 +70,7 @@ rules:
       - patch
 
   - apiGroups:
-      - metalkube.org
+      - metal3.io
     resources:
       - baremetalhosts
     verbs:
@@ -82,16 +83,10 @@ rules:
   - apiGroups:
       - metal3.io
     resources:
-      - baremetalhosts
       - baremetalhosts/status
       - baremetalhosts/finalizers
     verbs:
-      - get
-      - list
-      - watch
       - update
-      - patch
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
A follow-on change to openshift/machine-api-operator#384 and openshift/machine-api-operator#385, allowing baremetal-operator set an owner reference on the BMC secrets.

The main change needed is delete permissions on the secret are required to avoid:

> cannot set an ownerRef on a resource you can't delete

As in openshift/machine-api-operator#385 update permissions on baremetalhost finalizers are required to avoid:

> cannot set blockOwnerDeletion if an ownerReference refers to a
> resource you can't set finalizers on

and update permissions on baremetalhost status is required to avoid:

> cannot update resource "baremetalhosts/status"

Limit permissions on these latter two subresources to just update instead of the more broad permissions in openshift/machine-api-operator#385.

Finally, delete the metalkube.org resources since we now use metal3.io.