### PR TITLE
bug 1747246: nodelink_controller: fix SEGV in findNodeFromMachine()

### DIFF
--- a/pkg/controller/nodelink/nodelink_controller.go
+++ b/pkg/controller/nodelink/nodelink_controller.go
@@ -417,7 +417,7 @@ func (r *ReconcileNodeLink) findMachineFromNode(node *corev1.Node) (*mapiv1beta1
 
 	machine, err = r.findMachineFromNodeByIP(node)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find node from machine %q by internal IP: %v", machine.GetName(), err)
+		return nil, fmt.Errorf("failed to find machine from node %q by internal IP: %v", node.GetName(), err)
 	}
 	return machine, nil
 }


### PR DESCRIPTION
If an error occurs looking up the machine we went on to log the
machine name using `machine.GetName()` as part of the error message.
That triggered a nil pointer dereference given that machine is nil
when lookup fails.

Add explicit unit test so that we don't regress.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1747246