### PR TITLE
changes apiversion of the deployment to apps/v1

### DIFF
--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: machine-api-operator


### PR DESCRIPTION
`apps/v1beta2` has been deprecated and might be removed in the future.