### PR TITLE
Add baremetalhosts.metal3.io to related objects.

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -197,6 +197,12 @@ func (optr *Operator) getOrCreateClusterOperator() (*osconfigv1.ClusterOperator,
 			Name:      "",
 			Namespace: optr.namespace,
 		},
+		{
+			Group:     "metal3.io",
+			Resource:  "baremetalhosts",
+			Name:      "",
+			Namespace: optr.namespace,
+		},
 	}
 	if !equality.Semantic.DeepEqual(co.Status.RelatedObjects, relatedObjects) {
 		co.Status.RelatedObjects = relatedObjects

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -177,6 +177,12 @@ func TestGetOrCreateClusterOperator(t *testing.T) {
 							Name:      "",
 							Namespace: namespace,
 						},
+						{
+							Group:     "metal3.io",
+							Resource:  "baremetalhosts",
+							Name:      "",
+							Namespace: namespace,
+						},
 					},
 				},
 			},
@@ -210,6 +216,12 @@ func TestGetOrCreateClusterOperator(t *testing.T) {
 						{
 							Group:     "machine.openshift.io",
 							Resource:  "machinesets",
+							Name:      "",
+							Namespace: namespace,
+						},
+						{
+							Group:     "metal3.io",
+							Resource:  "baremetalhosts",
 							Name:      "",
 							Namespace: namespace,
 						},


### PR DESCRIPTION
This patch is similar to PR #391, which added machines and
machinesets to the related objects list for the cluster operator.
This will ensure that BareMetalHosts are collected by must-gather, as
well.

This is only applicable when the "baremetal" infrastructure platform
is in use, but is harmless otherwise as the CRD is always defined.