### PR TITLE
Disable metrics to avoid pod collisions

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -37,7 +37,10 @@ func main() {
 		glog.Fatal(err)
 	}
 
-	opts := manager.Options{}
+	opts := manager.Options{
+		// Disable metrics serving
+		MetricsBindAddress: "0",
+	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		klog.Infof("Watching machine-api objects only in namespace %q for reconciliation.", opts.Namespace)

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -36,7 +36,10 @@ func main() {
 		klog.Fatal(err)
 	}
 
-	opts := manager.Options{}
+	opts := manager.Options{
+		// Disable metrics serving
+		MetricsBindAddress: "0",
+	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		klog.Infof("Watching machine-api objects only in namespace %q for reconciliation.", opts.Namespace)


### PR DESCRIPTION
Disable metrics to avoid pod collisions. This was enabled by default it https://github.com/kubernetes-sigs/controller-runtime/pull/510/files

See https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-api-provider-aws/261/pull-ci-openshift-cluster-api-provider-aws-master-e2e-aws-operator/727/artifacts/e2e-aws-operator/pods/openshift-machine-api_machine-api-controllers-6dd895f447-zglqq_nodelink-controller.log