### PR TITLE
Make qosClass of the bm pod Burstable

### DIFF
--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -4,6 +4,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/pointer"
 )
 
@@ -324,6 +325,11 @@ func createContainerMetal3IronicApi(config *OperatorConfig) corev1.Container {
 			Privileged: pointer.BoolPtr(true),
 		},
 		Command:      []string{"/bin/runironic-api"},
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
+			},
+		},
 		VolumeMounts: volumeMounts,
 		Env: []corev1.EnvVar{
 			setMariadbPassword(),


### PR DESCRIPTION
Set a Memory requirement on the most memory hungry
part of the baremetal pod.

Not having any resource requirements results in a
qosClass == best-effort. openshift-tests requires the pod
to be either Burstable or Guaranteed. Setting a single resource
will result in it being Burstable.

Fixes: #409

**Untested patch - will remove message once tested**