### PR TITLE
Marking a couple of fields in the BaremetalHost CRD optional

### DIFF
--- a/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
@@ -368,8 +368,6 @@ spec:
           - operationalStatus
           - hardwareProfile
           - provisioning
-          - goodCredentials
-          - triedCredentials
           - errorMessage
           - poweredOn
           type: object


### PR DESCRIPTION
A couple of fields in the BaremetalHost CRD are being marked as
optional as part of https://github.com/metal3-io/baremetal-operator/pull/322.
Keeping the BaremetalHost CRD in the MAO current with those changes.