### PR TITLE
Bug 1763293: pkg/operator/sync: Track lastError in waitForDeploymentRollout

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -113,7 +113,8 @@ func (optr *Operator) syncBaremetalControllers(config *OperatorConfig) error {
 }
 
 func (optr *Operator) waitForDeploymentRollout(resource *appsv1.Deployment) error {
-	return wait.Poll(deploymentRolloutPollInterval, deploymentRolloutTimeout, func() (bool, error) {
+	var lastError error
+	err := wait.Poll(deploymentRolloutPollInterval, deploymentRolloutTimeout, func() (bool, error) {
 		d, err := optr.deployLister.Deployments(resource.Namespace).Get(resource.Name)
 		if apierrors.IsNotFound(err) {
 			return false, nil
@@ -121,20 +122,28 @@ func (optr *Operator) waitForDeploymentRollout(resource *appsv1.Deployment) erro
 		if err != nil {
 			// Do not return error here, as we could be updating the API Server itself, in which case we
 			// want to continue waiting.
-			glog.Errorf("Error getting Deployment %q during rollout: %v", resource.Name, err)
+			lastError = fmt.Errorf("getting Deployment %s during rollout: %v", resource.Name, err)
+			glog.Error(lastError)
 			return false, nil
 		}
 
 		if d.DeletionTimestamp != nil {
-			return false, fmt.Errorf("deployment %q is being deleted", resource.Name)
+			lastError = nil
+			return false, fmt.Errorf("deployment %s is being deleted", resource.Name)
 		}
 
 		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedReplicas == d.Status.Replicas && d.Status.UnavailableReplicas == 0 {
+			lastError = nil
 			return true, nil
 		}
-		glog.V(4).Infof("Deployment %q is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
+		lastError = fmt.Errorf("deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
+		glog.V(4).Info(lastError)
 		return false, nil
 	})
+	if lastError != nil {
+		return lastError
+	}
+	return err
 }
 
 func newDeployment(config *OperatorConfig, features map[string]bool) *appsv1.Deployment {


### PR DESCRIPTION
Because otherwise stuck deployments will result in the not-very-useful `timed out waiting for the condition` errors [like][1]:

```
Oct 17 18:41:52.205 E clusteroperator/machine-api changed Degraded to True: SyncingFailed: Failed when progressing towards operator: 4.3.0-0.ci-2019-10-17-173803 because timed out waiting for the condition
```

Also use `%s` instead of `%q` for formatting the deployment name, because we control the names being monitored and they don't contain whitespace or other potentially-confusing characters.

[1]: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade/8809