### PR TITLE
reduce reconciling events

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -125,7 +125,7 @@ func startControllers(ctx *ControllerContext) {
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.OpenshiftClientOrDie(componentName),
 		recorder,
-	).Run(2, ctx.Stop)
+	).Run(1, ctx.Stop)
 }
 
 func startMetricsCollectionAndServer(ctx *ControllerContext) {

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: machine-api-operator
@@ -31,6 +31,7 @@ spec:
         ports:
         - containerPort: 8443
           name: https
+          protocol: TCP
         volumeMounts:
         - name: config
           mountPath: /etc/kube-rbac-proxy
@@ -51,6 +52,7 @@ spec:
         - name: COMPONENT_NAMESPACE
           valueFrom:
             fieldRef:
+              apiVersion: v1
               fieldPath: metadata.namespace
         - name: METRICS_PORT
           value: "8080"
@@ -83,9 +85,12 @@ spec:
       - name: config
         configMap:
           name: kube-rbac-proxy
+          defaultMode: 420
       - name: images
         configMap:
-                name: machine-api-operator-images
+          defaultMode: 420
+          name: machine-api-operator-images
       - name: machine-api-operator-tls
         secret:
+          defaultMode: 420
           secretName: machine-api-operator-tls


### PR DESCRIPTION
MAO is going through reconciles about every three minutes consistently. This is because the mao deployment receives update events which I can only think are coming from the CVO.
e.g
- https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/417/pull-ci-openshift-machine-api-operator-master-e2e-aws-operator/1411/artifacts/e2e-aws-operator/pods/openshift-machine-api_machine-api-operator-6b74c4f5d6-zcd26_machine-api-operator.log
- https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_machine-api-operator/422/pull-ci-openshift-machine-api-operator-master-e2e-aws/1534/artifacts/e2e-aws/pods/openshift-machine-api_machine-api-operator-7bf945646d-vc2pk_machine-api-operator.log

When CVO calls ensureDeployment it might wrongly return `modified=true` and do an api server update extra call when comparing the raw spec (without defaulted values) against the version fetch from the API server. See also https://github.com/openshift/cluster-version-operator/pull/256
This is one of a series of PRs to simplify mao reconciling loop and avoid unnecessary reconciling loops.
Follow up:
- Stop mao logic from watching mao/cao deployment and only watch "owned" deployments
