### PR TITLE
Only reconcile owned deployments

### DIFF
--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -106,6 +106,9 @@ func newMetal3Deployment(config *OperatorConfig) *appsv1.Deployment {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "metal3",
 			Namespace: config.TargetNamespace,
+			Annotations: map[string]string{
+				maoOwnedAnnotation: "",
+			},
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "controller",

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -154,6 +154,9 @@ func newDeployment(config *OperatorConfig, features map[string]bool) *appsv1.Dep
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "machine-api-controllers",
 			Namespace: config.TargetNamespace,
+			Annotations: map[string]string{
+				maoOwnedAnnotation: "",
+			},
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "controller",


### PR DESCRIPTION
Only reconcile owned deployments for update/delete events.
This would prevent other deployments in the `openshift-machine-api` e.g autoscaler, mao deployment (owned by cvo) to trigger the reconciliation loop here.
Opted by annotation rather than ownerRefs pointing to mao deployment as this would increase complexity and skew to contemplate reconciliation when the mao is running remotely 