### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -5,6 +5,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-aws
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: aws-cloud-credentials
@@ -38,6 +40,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-azure
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: azure-cloud-credentials
@@ -55,6 +59,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-openstack
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: openstack-cloud-credentials
@@ -70,6 +76,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-gcp
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: gcp-cloud-credentials

--- a/install/0000_30_machine-api-operator_10_service.yaml
+++ b/install/0000_30_machine-api-operator_10_service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: machine-api-operator-tls
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     k8s-app: machine-api-operator
 spec:

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: openshift-machine-api
   labels:
     k8s-app: machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1
   selector:

--- a/install/0000_30_machine-api-operator_12_clusteroperator.yaml
+++ b/install/0000_30_machine-api-operator_12_clusteroperator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:
   versions:

--- a/install/0000_90_machine-api-operator_03_servicemonitor.yaml
+++ b/install/0000_90_machine-api-operator_03_servicemonitor.yaml
@@ -5,6 +5,8 @@ metadata:
     k8s-app: machine-api-operator
   name: machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -6,6 +6,8 @@ metadata:
     role: alert-rules
   name: machine-api-operator-prometheus-rules
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
     - name: machine-without-valid-node-ref


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252