### PR TITLE
add exclusion annotations to all resources

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     openshift.io/node-selector: ""
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   name: openshift-machine-api
   labels:
     name: openshift-machine-api

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: machine-api-operator-images
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   images.json: >
     {

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -5,6 +5,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: machines.machine.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.phase

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -5,6 +5,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: machinesets.machine.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .spec.replicas

--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -5,6 +5,8 @@ kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
   name: machinehealthchecks.machine.openshift.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   group: machine.openshift.io
   names:

--- a/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: baremetalhosts.metal3.io
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.operationalStatus

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -3,20 +3,24 @@ kind: ServiceAccount
 metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
-
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: machine-api-controllers
   namespace: openshift-machine-api
-
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: machine-api-controllers
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 
   - apiGroups:
@@ -92,6 +96,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-api-controllers
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 
   - apiGroups:
@@ -157,6 +163,8 @@ kind: Role
 metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 
   - apiGroups:
@@ -205,6 +213,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups: ["authentication.k8s.io"]
     resources:
@@ -256,10 +266,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-api-controllers
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: machine-api-controllers
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
@@ -271,10 +285,14 @@ kind: RoleBinding
 metadata:
   name: machine-api-controllers
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: machine-api-controllers
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
@@ -285,10 +303,14 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
   - kind: ServiceAccount
     name: machine-api-operator
@@ -300,10 +322,14 @@ kind: RoleBinding
 metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
   - kind: ServiceAccount
     name: machine-api-operator
@@ -315,10 +341,14 @@ kind: RoleBinding
 metadata:
   name: prometheus-k8s-machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: prometheus-k8s-machine-api-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 subjects:
   - kind: ServiceAccount
     name: prometheus-k8s
@@ -331,6 +361,8 @@ kind: Role
 metadata:
   name: prometheus-k8s-machine-api-operator
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - ""

--- a/install/0000_30_machine-api-operator_10_kube-rbac-proxy-config.yaml
+++ b/install/0000_30_machine-api-operator_10_kube-rbac-proxy-config.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: kube-rbac-proxy
   namespace: openshift-machine-api
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   config-file.yaml: |+
     authorization:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "Fixes: #xxxx", or
"Closes: #xxxx"

Please provide the following information:
-->

**- What I did**
Added exclusion annotation so the 4.3 CVO will ignore these operators to stay consistent with 4.2 CVO. As seen here, the 4.3 CVO looks at the value when looking at exclusions https://github.com/openshift/hypershift-toolkit/blob/release-4.3/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L76-L77

The 4.2 CVO excluded the following operators and resources with those operators https://github.com/openshift/hypershift-toolkit/blob/release-4.2/assets/cluster-version-operator/cluster-version-operator-deployment.yaml#L60-L72
 
**- How to verify it**
Deploy the hypershift toolkit https://github.com/openshift/hypershift-toolkit/tree/release-4.2 and verify that all the resources with this exclusion (exclude.release.openshift.io/internal-openshift-hosted: "true") are not overwriting the ones being deployed into the cluster. 
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
added exclusion to the rest of the resources that the operator manages.