### PR TITLE
Machine controller fixes

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -44,6 +44,7 @@ import (
 
 const (
 	NodeNameEnvVar = "NODE_NAME"
+	requeueAfter   = 30 * time.Second
 
 	// ExcludeNodeDrainingAnnotation annotation explicitly skips node draining if set
 	ExcludeNodeDrainingAnnotation = "machine.openshift.io/exclude-node-draining"
@@ -262,8 +263,8 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 		}
 
 		if !machineIsProvisioned(m) {
-			klog.Errorf(`Instance for Machine "%s/%s exists but providerID or addresses has not been given to the machine yet"`, m.Namespace, name)
-			return reconcile.Result{}, err
+			klog.Errorf("%v: instance exists but providerID or addresses has not been given to the machine yet, requeuing", m.GetName())
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 		if machineHasNode(m) {
 			if err := r.setPhase(m, phaseRunning, ""); err != nil {

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -304,7 +304,8 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 		return delayIfRequeueAfterError(err)
 	}
 
-	return reconcile.Result{}, nil
+	klog.Infof("%v: created instance, requeuing", m.GetName())
+	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
 func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -191,7 +191,7 @@ func TestReconcileRequest(t *testing.T) {
 				existCallCount:  1,
 				updateCallCount: 0,
 				deleteCallCount: 0,
-				result:          reconcile.Result{},
+				result:          reconcile.Result{RequeueAfter: requeueAfter},
 				error:           false,
 				phase:           phaseProvisioning,
 			},

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -204,7 +204,7 @@ func TestReconcileRequest(t *testing.T) {
 				existCallCount:  1,
 				updateCallCount: 1,
 				deleteCallCount: 0,
-				result:          reconcile.Result{},
+				result:          reconcile.Result{RequeueAfter: requeueAfter},
 				error:           false,
 				phase:           phaseProvisioned,
 			},


### PR DESCRIPTION
Enforce Requeue when machine is not provisioned yet
Enforce Requeue when machine has no node yet
Enforce Requeue right after creating an instance
Prepend machine name to logging consistently