### PR TITLE
Bug 1784505: Update the image name for ironic-rhcos-downloader

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -17,6 +17,6 @@ data:
       "baremetalIronic": "quay.io/openshift/origin-ironic:v4.2.0",
       "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",
       "baremetalIpaDownloader": "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0",
-      "baremetalRhcosDownloader": "quay.io/openshift/origin-ironic-rhcos-downloader:v4.2.0",
+      "baremetalMachineOsDownloader": "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0",
       "baremetalStaticIpManager": "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -46,10 +46,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0
-  - name: ironic-rhcos-downloader
+  - name: ironic-machine-os-downloader
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic-rhcos-downloader:v4.2.0
+      name: quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0
   - name: ironic-static-ip-manager
     from:
       kind: DockerImage

--- a/pkg/operator/baremetal_pod.go
+++ b/pkg/operator/baremetal_pod.go
@@ -145,15 +145,15 @@ func newMetal3InitContainers(config *OperatorConfig) []corev1.Container {
 			},
 		},
 	}
-	initContainers = append(initContainers, createInitContainerRhcosDownloader(config))
+	initContainers = append(initContainers, createInitContainerMachineOsDownloader(config))
 	initContainers = append(initContainers, createInitContainerStaticIpSet(config))
 	return initContainers
 }
 
-func createInitContainerRhcosDownloader(config *OperatorConfig) corev1.Container {
+func createInitContainerMachineOsDownloader(config *OperatorConfig) corev1.Container {
 	initContainer := corev1.Container{
-		Name:            "metal3-rhcos-downloader",
-		Image:           config.BaremetalControllers.IronicRhcosDownloader,
+		Name:            "metal3-machine-os-downloader",
+		Image:           config.BaremetalControllers.IronicMachineOsDownloader,
 		Command:         []string{"/usr/local/bin/get-resource.sh"},
 		ImagePullPolicy: "Always",
 		SecurityContext: &corev1.SecurityContext{

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -32,12 +32,12 @@ type Controllers struct {
 }
 
 type BaremetalControllers struct {
-	BaremetalOperator     string
-	Ironic                string
-	IronicInspector       string
-	IronicIpaDownloader   string
-	IronicRhcosDownloader string
-	IronicStaticIpManager string
+	BaremetalOperator         string
+	Ironic                    string
+	IronicInspector           string
+	IronicIpaDownloader       string
+	IronicMachineOsDownloader string
+	IronicStaticIpManager     string
 }
 
 // Images allows build systems to inject images for MAO components
@@ -50,12 +50,12 @@ type Images struct {
 	ClusterAPIControllerAzure     string `json:"clusterAPIControllerAzure"`
 	ClusterAPIControllerGCP       string `json:"clusterAPIControllerGCP"`
 	// Images required for the metal3 pod
-	BaremetalOperator        string `json:"baremetalOperator"`
-	BaremetalIronic          string `json:"baremetalIronic"`
-	BaremetalIronicInspector string `json:"baremetalIronicInspector"`
-	BaremetalIpaDownloader   string `json:"baremetalIpaDownloader"`
-	BaremetalRhcosDownloader string `json:"baremetalRhcosDownloader"`
-	BaremetalStaticIpManager string `json:"baremetalStaticIpManager"`
+	BaremetalOperator            string `json:"baremetalOperator"`
+	BaremetalIronic              string `json:"baremetalIronic"`
+	BaremetalIronicInspector     string `json:"baremetalIronicInspector"`
+	BaremetalIpaDownloader       string `json:"baremetalIpaDownloader"`
+	BaremetalMachineOsDownloader string `json:"baremetalMachineOsDownloader"`
+	BaremetalStaticIpManager     string `json:"baremetalStaticIpManager"`
 }
 
 func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.PlatformType, error) {
@@ -105,12 +105,12 @@ func newBaremetalControllers(images Images, usingBareMetal bool) BaremetalContro
 		return BaremetalControllers{}
 	}
 	return BaremetalControllers{
-		BaremetalOperator:     images.BaremetalOperator,
-		Ironic:                images.BaremetalIronic,
-		IronicInspector:       images.BaremetalIronicInspector,
-		IronicIpaDownloader:   images.BaremetalIpaDownloader,
-		IronicRhcosDownloader: images.BaremetalRhcosDownloader,
-		IronicStaticIpManager: images.BaremetalStaticIpManager,
+		BaremetalOperator:         images.BaremetalOperator,
+		Ironic:                    images.BaremetalIronic,
+		IronicInspector:           images.BaremetalIronicInspector,
+		IronicIpaDownloader:       images.BaremetalIpaDownloader,
+		IronicMachineOsDownloader: images.BaremetalMachineOsDownloader,
+		IronicStaticIpManager:     images.BaremetalStaticIpManager,
 	}
 }
 

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -7,20 +7,20 @@ import (
 )
 
 var (
-	imagesJSONFile                  = "fixtures/images.json"
-	expectedAWSImage                = "docker.io/openshift/origin-aws-machine-controllers:v4.0.0"
-	expectedLibvirtImage            = "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
-	expectedOpenstackImage          = "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0"
-	expectedMachineAPIOperatorImage = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
-	expectedBareMetalImage          = "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0"
-	expectedAzureImage              = "quay.io/openshift/origin-azure-machine-controllers:v4.0.0"
-	expectedGCPImage                = "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0"
-	expectedBaremetalOperator       = "quay.io/openshift/origin-baremetal-operator:v4.2.0"
-	expectedIronic                  = "quay.io/openshift/origin-ironic:v4.2.0"
-	expectedIronicInspector         = "quay.io/openshift/origin-ironic-inspector:v4.2.0"
-	expectedIronicIpaDownloader     = "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0"
-	expectedIronicRhcosDownloader   = "quay.io/openshift/origin-ironic-rhcos-downloader:v4.2.0"
-	expectedIronicStaticIpManager   = "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
+	imagesJSONFile                    = "fixtures/images.json"
+	expectedAWSImage                  = "docker.io/openshift/origin-aws-machine-controllers:v4.0.0"
+	expectedLibvirtImage              = "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0"
+	expectedOpenstackImage            = "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0"
+	expectedMachineAPIOperatorImage   = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
+	expectedBareMetalImage            = "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0"
+	expectedAzureImage                = "quay.io/openshift/origin-azure-machine-controllers:v4.0.0"
+	expectedGCPImage                  = "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0"
+	expectedBaremetalOperator         = "quay.io/openshift/origin-baremetal-operator:v4.2.0"
+	expectedIronic                    = "quay.io/openshift/origin-ironic:v4.2.0"
+	expectedIronicInspector           = "quay.io/openshift/origin-ironic-inspector:v4.2.0"
+	expectedIronicIpaDownloader       = "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0"
+	expectedIronicMachineOsDownloader = "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0"
+	expectedIronicStaticIpManager     = "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
 )
 
 func TestGetProviderFromInfrastructure(t *testing.T) {
@@ -216,7 +216,7 @@ func TestGetBaremetalControllers(t *testing.T) {
 		baremetalControllers.Ironic != expectedIronic ||
 		baremetalControllers.IronicInspector != expectedIronicInspector ||
 		baremetalControllers.IronicIpaDownloader != expectedIronicIpaDownloader ||
-		baremetalControllers.IronicRhcosDownloader != expectedIronicRhcosDownloader ||
+		baremetalControllers.IronicMachineOsDownloader != expectedIronicMachineOsDownloader ||
 		baremetalControllers.IronicStaticIpManager != expectedIronicStaticIpManager {
 		t.Errorf("failed getAdditionalProviderImages. One or more BaremetalController images do not match the expected images.")
 	}

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -10,6 +10,6 @@
   "baremetalIronic": "quay.io/openshift/origin-ironic:v4.2.0",
   "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",
   "baremetalIpaDownloader": "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0",
-  "baremetalRhcosDownloader": "quay.io/openshift/origin-ironic-rhcos-downloader:v4.2.0",
+  "baremetalMachineOsDownloader": "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0",
   "baremetalStaticIpManager": "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
 }


### PR DESCRIPTION
The new image name is ironic-machine-os-downloader.
Fixes : https://github.com/openshift/machine-api-operator/issues/451

Manual cherry-pick of:
https://github.com/openshift/machine-api-operator/pull/452
https://github.com/openshift/machine-api-operator/pull/454
