### PR TITLE
vsphere: Add support for passing ignition user-data

### DIFF
--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -1,17 +1,140 @@
 package vsphere
 
 import (
+	"bytes"
+	"context"
 	"testing"
 
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	apivsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
+	vsphereapi "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+const TestNamespace = "vsphere-test"
+
+func MachineWithSpec(spec *apivsphere.VSphereMachineProviderSpec) *machinev1.Machine {
+	rawSpec, err := vsphereapi.RawExtensionFromProviderSpec(spec)
+	if err != nil {
+		panic("Failed to encode raw extension from provider spec")
+	}
+
+	return &machinev1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vsphere-test",
+			Namespace: TestNamespace,
+		},
+		Spec: machinev1.MachineSpec{
+			ProviderSpec: machinev1.ProviderSpec{
+				Value: rawSpec,
+			},
+		},
+	}
+}
+
+func TestGetUserData(t *testing.T) {
+	userDataSecretName := "vsphere-ignition"
+
+	defaultProviderSpec := &apivsphere.VSphereMachineProviderSpec{
+		UserDataSecret: &corev1.LocalObjectReference{
+			Name: userDataSecretName,
+		},
+	}
+
+	testCases := []struct {
+		testCase         string
+		userDataSecret   *corev1.Secret
+		providerSpec     *apivsphere.VSphereMachineProviderSpec
+		expectedUserdata []byte
+		expectError      bool
+	}{
+		{
+			testCase: "all good",
+			userDataSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      userDataSecretName,
+					Namespace: TestNamespace,
+				},
+				Data: map[string][]byte{
+					userDataSecretKey: []byte("{}"),
+				},
+			},
+			providerSpec:     defaultProviderSpec,
+			expectedUserdata: []byte("{}"),
+			expectError:      false,
+		},
+		{
+			testCase:       "missing secret",
+			userDataSecret: nil,
+			providerSpec:   defaultProviderSpec,
+			expectError:    true,
+		},
+		{
+			testCase: "missing key in secret",
+			userDataSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      userDataSecretName,
+					Namespace: TestNamespace,
+				},
+				Data: map[string][]byte{
+					"badKey": []byte("{}"),
+				},
+			},
+			providerSpec: defaultProviderSpec,
+			expectError:  true,
+		},
+		{
+			testCase:         "no provider spec",
+			userDataSecret:   nil,
+			providerSpec:     nil,
+			expectError:      false,
+			expectedUserdata: nil,
+		},
+		{
+			testCase:         "no user-data in provider spec",
+			userDataSecret:   nil,
+			providerSpec:     &apivsphere.VSphereMachineProviderSpec{},
+			expectError:      false,
+			expectedUserdata: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.testCase, func(t *testing.T) {
+			clientObjs := []runtime.Object{}
+
+			if tc.userDataSecret != nil {
+				clientObjs = append(clientObjs, tc.userDataSecret)
+			}
+
+			client := fake.NewFakeClient(clientObjs...)
+
+			// Can't use newMachineScope because it tries to create an API
+			// session, and other things unrelated to these tests.
+			ms := &machineScope{
+				Context:      context.Background(),
+				client:       client,
+				machine:      MachineWithSpec(tc.providerSpec),
+				providerSpec: tc.providerSpec,
+			}
+
+			userData, err := ms.GetUserData()
+			if !tc.expectError && err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+
+			if bytes.Compare(userData, tc.expectedUserdata) != 0 {
+				t.Errorf("Got: %q, Want: %q", userData, tc.expectedUserdata)
+			}
+		})
+	}
+}
+
 func TestGetCredentialsSecret(t *testing.T) {
-	namespace := "test"
 	expectedUser := "user"
 	expectedPassword := "password"
 	testCases := []struct {
@@ -26,7 +149,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: namespace,
+					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
 					credentialsSecretUser:     []byte(expectedUser),
@@ -45,7 +168,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: namespace,
+					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
 					credentialsSecretUser:     []byte(expectedUser),
@@ -64,7 +187,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: namespace,
+					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
 					"badUserKey":              []byte(expectedUser),
@@ -83,7 +206,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: namespace,
+					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
 					credentialsSecretUser: []byte(expectedUser),
@@ -102,7 +225,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 			secret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
-					Namespace: namespace,
+					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
 					credentialsSecretUser:     []byte(expectedUser),
@@ -118,7 +241,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
 			client := fake.NewFakeClientWithScheme(scheme.Scheme, tc.secret)
-			gotUser, gotPassword, err := getCredentialsSecret(client, namespace, *tc.providerSpec)
+			gotUser, gotPassword, err := getCredentialsSecret(client, TestNamespace, *tc.providerSpec)
 			if (err != nil) != tc.expectError {
 				t.Errorf("Expected error: %v, got %v", tc.expectError, err)
 			}


### PR DESCRIPTION
This adds support for fetching the user-data secret referenced in the
ProviderSpec of a Machine using the vsphere provider, and passing that
data as ignition config via guestinfo variables.