### PR TITLE
Adding a new CRD for configuration needed for Baremetal provisioning

### DIFF
--- a/install/0000_30_machine-api-operator_04_metal3provisioning.crd.yaml
+++ b/install/0000_30_machine-api-operator_04_metal3provisioning.crd.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: provisionings.metal3.io
+spec:
+  group: metal3.io
+  names:
+    kind: Provisioning
+    listKind: ProvisioningList
+    plural: provisionings
+    singular: provisioning
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: 'Provisioning contains configuration used by the Provisioning
+        service (Ironic) to provision baremetal hosts. \n Provisioning is created
+        by the Openshift installer using admin or user provided information about
+        the provisioning network and the NIC on the server that can be used to PXE
+        boot it. \n This CR is a singleton, created by the installer and currently
+        only consumed by the machine-api-operator to bring up and update containers
+        in a metal3 cluster.'
+      type: object
+      required:
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: Specification of provisioning configuration for Metal3.
+          type: object
+          properties:
+            provisioningInterface:
+              description: provisioningInterface is the name of the network interface
+                on a baremetal server to the provisioning network. It can have values
+                like eth1 or ens3.
+              type: string
+            provisioningIP:
+              description: provisioningIP is the IP address assigned to the provisioningInterface
+                of the baremetal server. This IP address should be within the provisioning
+                subnet, and outside of the DHCP range.
+              type: string
+            provisioningNetworkCIDR:
+              description: provisioningNetworkCIDR is the network on which the baremetal
+                nodes are provisioned. The provisioningIP and the IPs in the dhcpRange
+                all come from within this network.
+              type: string
+            provisioningDHCPExternal:
+              description: provisioningDHCPExternal indicates whether the DHCP server for IP
+                addresses in the provisioning DHCP range is present within the metal3 cluster
+                or external to it.
+              type: boolean
+            provisioningDHCPRange:
+              description: Needs to be interpreted along with provisioningDHCPExternal.
+                If the value of provisioningDHCPExternal is set to False, then
+                provisioningDHCPRange represents the range of IP addresses that the DHCP server
+                running within the metal3 cluster can use while provisioning baremetal servers.
+                If the value of provisioningDHCPExternal is set to True, then the value of
+                provisioningDHCPRange will be ignored. When the value of provisioningDHCPExternal
+                is set to False, indicating an internal DHCP server and the value of
+                provisioningDHCPRange is not set, then the DHCP range is taken to be the default
+                range which goes from .10 to .100 of the provisioningNetworkCIDR. This is the only
+                value in all of the provisioning configuration that can be changed after the
+                installer has created the CR. This value needs to be two comma sererated IP
+                addresses within the provisioningNetworkCIDR where the 1st address represents the
+                start of the range and the 2nd address represents the last usable address in the
+                range.
+              type: string
+        status:
+          description: status holds observed values from the cluster. They may not
+            be overridden.
+          type: object
+          properties:
+            conditions:
+              description: conditions is a list of conditions and their status
+              type: array
+              items:
+                description: OperatorCondition is just the standard condition fields.
+                type: object
+                properties:
+                  lastTransitionTime:
+                    type: string
+                    format: date-time
+                  message:
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+            generations:
+              description: generations are used to determine when an item needs to
+                be reconciled or has changed in a way that needs a reaction.
+              type: array
+              items:
+                description: GenerationStatus keeps track of the generation for a
+                  given resource so that decisions about forced updates can be made.
+                type: object
+                properties:
+                  group:
+                    description: group is the group of the thing you're tracking
+                    type: string
+                  hash:
+                    description: hash is an optional field set for resources without
+                      generation that are content sensitive like secrets and configmaps
+                    type: string
+                  lastGeneration:
+                    description: lastGeneration is the last generation of the workload
+                      controller involved
+                    type: integer
+                    format: int64
+                  name:
+                    description: name is the name of the thing you're tracking
+                    type: string
+                  namespace:
+                    description: namespace is where the thing you're tracking is
+                    type: string
+                  resource:
+                    description: resource is the resource type of the thing you're
+                      tracking
+                    type: string
+            observedGeneration:
+              description: observedGeneration is the last generation change you've
+                dealt with
+              type: integer
+              format: int64
+            readyReplicas:
+              description: readyReplicas indicates how many replicas are ready and
+                at the desired state
+              type: integer
+              format: int32
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
A new CRD is being added to metal3.io API group that contains config
necessary to provision baremetal hosts.