### PR TITLE
[OCPCLOUD-700] Add customer printer columns for MachineHealthCheck CRDs

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -6,6 +6,19 @@ metadata:
   creationTimestamp: null
   name: machinehealthchecks.machine.openshift.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.maxUnhealthy
+    description: Maximum number of unhealthy machines allowed
+    name: MaxUnhealthy
+    type: string
+  - JSONPath: .status.expectedMachines
+    description: Number of machines currently monitored
+    name: ExpectedMachines
+    type: integer
+  - JSONPath: .status.currentHealthy
+    description: Current observed healthy machines
+    name: CurrentHealthy
+    type: integer
   group: machine.openshift.io
   names:
     kind: MachineHealthCheck

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -16,6 +16,9 @@ type RemediationStrategyType string
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=mhc;mhcs
 // +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="MaxUnhealthy",type="string",JSONPath=".spec.maxUnhealthy",description="Maximum number of unhealthy machines allowed"
+// +kubebuilder:printcolumn:name="ExpectedMachines",type="integer",JSONPath=".status.expectedMachines",description="Number of machines currently monitored"
+// +kubebuilder:printcolumn:name="CurrentHealthy",type="integer",JSONPath=".status.currentHealthy",description="Current observed healthy machines"
 type MachineHealthCheck struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
This adds three printer columns (`MaxUnhealthy`, `ExpectedMachines`, `CurrentHealthy`) to the `MachineHealthCheck` CRD.

The description of each I've come up with from my understanding of MHCs, these will need confirming. Not sure if there is a pattern to be followed for that

I have not tested this on a cluster yet, will do so before marking ready