### PR TITLE
Remove default value from MachineHealthCheck CurrentHealthy

### DIFF
--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -83,8 +83,7 @@ type MachineHealthCheckStatus struct {
 	// +kubebuilder:validation:Minimum=0
 	ExpectedMachines *int `json:"expectedMachines"`
 
-	// total number of machines counted by this machine health check
-	// +kubebuilder:default=0
+	// total number of healthy machines counted by this machine health check
 	// +kubebuilder:validation:Minimum=0
 	CurrentHealthy *int `json:"currentHealthy" protobuf:"varint,4,opt,name=currentHealthy"`
 }


### PR DESCRIPTION
The `// +kubebuilder:default` marker is currently not observed by the CRD code generator because the version of controller-tools we use does not have this implemented. Were we to update the version of controller-tools this would then add a default value to the generated CRD OpenAPI Schema for the `.status.currentHealth` field.

However, in K8s 1.17 onwards, default values within OpenAPI Schema are forbidden and attempting to create a CRD with a default value will result in the API server returning a conflict response.

I concluded we should remove the default marker so that we don't break installation of MAO in the future