### PR TITLE
vsphere: Rename UserDataSecret to IgnitionSecret

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,6 +21,10 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
+# The provider types don't need all the extra bits that generate-groups.sh
+# creates.  A simple `go generate` is enough for these.
+go generate ./pkg/apis/vsphereprovider/...
+
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -34,7 +34,7 @@ cleanup
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
-"${SCRIPT_ROOT}/hack/update-codegen.sh"
+NO_DOCKER=1 make --directory="${SCRIPT_ROOT}" update-codegen
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
@@ -43,6 +43,6 @@ if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run `make generate`"
+  echo "${DIFFROOT} is out of date. Please run: make generate"
   exit 1
 fi

--- a/pkg/apis/vsphereprovider/v1alpha1/register.go
+++ b/pkg/apis/vsphereprovider/v1alpha1/register.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "vsphereprovider.openshift.io", Version: "v1beta1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "vsphereprovider.openshift.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}

--- a/pkg/apis/vsphereprovider/v1alpha1/vsphereproviderconfig_types.go
+++ b/pkg/apis/vsphereprovider/v1alpha1/vsphereproviderconfig_types.go
@@ -15,9 +15,9 @@ type VSphereMachineProviderSpec struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// UserDataSecret contains a local reference to a secret that contains the
-	// UserData to apply to the instance
-	UserDataSecret *corev1.LocalObjectReference `json:"userDataSecret,omitempty"`
+	// IgnitionSecret is a reference to a secret with Ignition data for the
+	// instance.  The secret should have a single key called "ignition".
+	IgnitionSecret *corev1.LocalObjectReference `json:"ignitionSecret,omitempty"`
 
 	// CredentialsSecret is a reference to the secret with vSphere credentials.
 	CredentialsSecret *corev1.LocalObjectReference `json:"credentialsSecret,omitempty"`
@@ -67,8 +67,7 @@ type NetworkDeviceSpec struct {
 	NetworkName string `json:"networkName"`
 }
 
-// WorkspaceConfig defines a workspace configuration for the vSphere cloud
-// provider.
+// Workspace defines a workspace configuration for the vSphere cloud provider.
 type Workspace struct {
 	// Server is the IP address or FQDN of the vSphere endpoint.
 	// +optional

--- a/pkg/apis/vsphereprovider/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/vsphereprovider/v1alpha1/zz_generated.deepcopy.go
@@ -66,8 +66,8 @@ func (in *VSphereMachineProviderSpec) DeepCopyInto(out *VSphereMachineProviderSp
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
-	if in.UserDataSecret != nil {
-		in, out := &in.UserDataSecret, &out.UserDataSecret
+	if in.IgnitionSecret != nil {
+		in, out := &in.IgnitionSecret, &out.IgnitionSecret
 		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	userDataSecretKey         = "userData"
+	ignitionSecretKey         = "ignition"
 	credentialsSecretUser     = "user"
 	credentialsSecretPassword = "password"
 )
@@ -99,30 +99,30 @@ func (s *machineScope) GetSession() *session.Session {
 	return s.session
 }
 
-// GetUserData fetches the user-data from the secret referenced in the Machine's
-// provider spec, if one is set.
-func (s *machineScope) GetUserData() ([]byte, error) {
-	if s.providerSpec == nil || s.providerSpec.UserDataSecret == nil {
+// GetIgnitionData fetches the Ignition configuration from the secret referenced
+// in the Machine's provider spec, if one is set.
+func (s *machineScope) GetIgnitionData() ([]byte, error) {
+	if s.providerSpec == nil || s.providerSpec.IgnitionSecret == nil {
 		return nil, nil
 	}
 
-	userDataSecret := &apicorev1.Secret{}
+	ignitionSecret := &apicorev1.Secret{}
 
 	objKey := runtimeclient.ObjectKey{
 		Namespace: s.machine.Namespace,
-		Name:      s.providerSpec.UserDataSecret.Name,
+		Name:      s.providerSpec.IgnitionSecret.Name,
 	}
 
-	if err := s.client.Get(context.Background(), objKey, userDataSecret); err != nil {
+	if err := s.client.Get(context.Background(), objKey, ignitionSecret); err != nil {
 		return nil, err
 	}
 
-	userData, exists := userDataSecret.Data[userDataSecretKey]
+	ignition, exists := ignitionSecret.Data[ignitionSecretKey]
 	if !exists {
-		return nil, fmt.Errorf("secret %s missing %s key", objKey, userDataSecretKey)
+		return nil, fmt.Errorf("secret %s missing %s key", objKey, ignitionSecretKey)
 	}
 
-	return userData, nil
+	return ignition, nil
 }
 
 // This is a temporary assumption to expose credentials as a secret

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -37,47 +37,47 @@ func MachineWithSpec(spec *apivsphere.VSphereMachineProviderSpec) *machinev1.Mac
 }
 
 func TestGetUserData(t *testing.T) {
-	userDataSecretName := "vsphere-ignition"
+	ignitionSecretName := "vsphere-ignition"
 
 	defaultProviderSpec := &apivsphere.VSphereMachineProviderSpec{
-		UserDataSecret: &corev1.LocalObjectReference{
-			Name: userDataSecretName,
+		IgnitionSecret: &corev1.LocalObjectReference{
+			Name: ignitionSecretName,
 		},
 	}
 
 	testCases := []struct {
 		testCase         string
-		userDataSecret   *corev1.Secret
+		ignitionSecret   *corev1.Secret
 		providerSpec     *apivsphere.VSphereMachineProviderSpec
-		expectedUserdata []byte
+		expectedIgnition []byte
 		expectError      bool
 	}{
 		{
 			testCase: "all good",
-			userDataSecret: &corev1.Secret{
+			ignitionSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      userDataSecretName,
+					Name:      ignitionSecretName,
 					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
-					userDataSecretKey: []byte("{}"),
+					ignitionSecretKey: []byte("{}"),
 				},
 			},
 			providerSpec:     defaultProviderSpec,
-			expectedUserdata: []byte("{}"),
+			expectedIgnition: []byte("{}"),
 			expectError:      false,
 		},
 		{
 			testCase:       "missing secret",
-			userDataSecret: nil,
+			ignitionSecret: nil,
 			providerSpec:   defaultProviderSpec,
 			expectError:    true,
 		},
 		{
 			testCase: "missing key in secret",
-			userDataSecret: &corev1.Secret{
+			ignitionSecret: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      userDataSecretName,
+					Name:      ignitionSecretName,
 					Namespace: TestNamespace,
 				},
 				Data: map[string][]byte{
@@ -89,17 +89,17 @@ func TestGetUserData(t *testing.T) {
 		},
 		{
 			testCase:         "no provider spec",
-			userDataSecret:   nil,
+			ignitionSecret:   nil,
 			providerSpec:     nil,
 			expectError:      false,
-			expectedUserdata: nil,
+			expectedIgnition: nil,
 		},
 		{
 			testCase:         "no user-data in provider spec",
-			userDataSecret:   nil,
+			ignitionSecret:   nil,
 			providerSpec:     &apivsphere.VSphereMachineProviderSpec{},
 			expectError:      false,
-			expectedUserdata: nil,
+			expectedIgnition: nil,
 		},
 	}
 
@@ -107,8 +107,8 @@ func TestGetUserData(t *testing.T) {
 		t.Run(tc.testCase, func(t *testing.T) {
 			clientObjs := []runtime.Object{}
 
-			if tc.userDataSecret != nil {
-				clientObjs = append(clientObjs, tc.userDataSecret)
+			if tc.ignitionSecret != nil {
+				clientObjs = append(clientObjs, tc.ignitionSecret)
 			}
 
 			client := fake.NewFakeClient(clientObjs...)
@@ -122,13 +122,13 @@ func TestGetUserData(t *testing.T) {
 				providerSpec: tc.providerSpec,
 			}
 
-			userData, err := ms.GetUserData()
+			ignition, err := ms.GetIgnitionData()
 			if !tc.expectError && err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			if bytes.Compare(userData, tc.expectedUserdata) != 0 {
-				t.Errorf("Got: %q, Want: %q", userData, tc.expectedUserdata)
+			if bytes.Compare(ignition, tc.expectedIgnition) != 0 {
+				t.Errorf("Got: %q, Want: %q", ignition, tc.expectedIgnition)
 			}
 		})
 	}

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -224,7 +224,7 @@ func isRetrieveMONotFound(taskRef string, err error) bool {
 }
 
 func clone(s *machineScope) error {
-	userData, err := s.GetUserData()
+	ignitionData, err := s.GetIgnitionData()
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func clone(s *machineScope) error {
 			// the VM's UUID.
 			InstanceUuid: string(s.machine.UID),
 			Flags:        newVMFlagInfo(),
-			ExtraConfig:  IgnitionConfig(userData),
+			ExtraConfig:  IgnitionConfig(ignitionData),
 			// TODO: set disk devices
 			DeviceChange:      deviceSpecs,
 			NumCPUs:           numCPUs,


### PR DESCRIPTION
This renames the UserDataSecret field in VSphereMachineProviderSpec to
IgnitionSecret as the provider only supports passing Ignition data
currently and not other types of configuration.
