### PR TITLE
Fixes to codegen for vsphere provider

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,6 +21,10 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
+# The provider types don't need all the extra bits that generate-groups.sh
+# creates.  A simple `go generate` is enough for these.
+go generate ./pkg/apis/vsphereprovider/...
+
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -34,7 +34,7 @@ cleanup
 mkdir -p "${TMP_DIFFROOT}"
 cp -a "${DIFFROOT}"/* "${TMP_DIFFROOT}"
 
-"${SCRIPT_ROOT}/hack/update-codegen.sh"
+NO_DOCKER=1 make --directory="${SCRIPT_ROOT}" update-codegen
 echo "diffing ${DIFFROOT} against freshly generated codegen"
 ret=0
 diff -Naupr "${DIFFROOT}" "${TMP_DIFFROOT}" || ret=$?
@@ -43,6 +43,6 @@ if [[ $ret -eq 0 ]]
 then
   echo "${DIFFROOT} up to date."
 else
-  echo "${DIFFROOT} is out of date. Please run `make generate`"
+  echo "${DIFFROOT} is out of date. Please run: make generate"
   exit 1
 fi

--- a/pkg/apis/vsphereprovider/v1alpha1/register.go
+++ b/pkg/apis/vsphereprovider/v1alpha1/register.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// SchemeGroupVersion is group version used to register these objects
-	SchemeGroupVersion = schema.GroupVersion{Group: "vsphereprovider.openshift.io", Version: "v1beta1"}
+	SchemeGroupVersion = schema.GroupVersion{Group: "vsphereprovider.openshift.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: SchemeGroupVersion}


### PR DESCRIPTION
This fixes a few small things so that `make generate` works for the types in the vsphere provider code.