### PR TITLE
Expose a dynamic client in the Operator struct

### DIFF
--- a/cmd/machine-api-operator/client_builder.go
+++ b/cmd/machine-api-operator/client_builder.go
@@ -4,6 +4,7 @@ import (
 	"github.com/golang/glog"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	mapiclientset "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -18,6 +19,11 @@ type ClientBuilder struct {
 // KubeClientOrDie returns the kubernetes client interface for general kubernetes objects.
 func (cb *ClientBuilder) KubeClientOrDie(name string) kubernetes.Interface {
 	return kubernetes.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
+}
+
+// NewForConfigOrDie returns the kubernetes client interface for dynamic objects.
+func (cb *ClientBuilder) dynamicClientOrDie(name string) dynamic.Interface {
+	return dynamic.NewForConfigOrDie(rest.AddUserAgent(cb.config, name))
 }
 
 // OpenshiftClientOrDie returns the kubernetes client interface for Openshift objects.

--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -124,6 +124,7 @@ func startControllers(ctx *ControllerContext) {
 		ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.OpenshiftClientOrDie(componentName),
+		ctx.ClientBuilder.dynamicClientOrDie(componentName),
 		recorder,
 	).Run(1, ctx.Stop)
 }

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -251,6 +251,14 @@ rules:
       - watch
       - list
       - patch
+
+  - apiGroups:
+      - metal3.io
+    resources:
+      - provisionings
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	appsinformersv1 "k8s.io/client-go/informers/apps/v1"
 	"k8s.io/client-go/kubernetes"
 	appslisterv1 "k8s.io/client-go/listers/apps/v1"
@@ -41,6 +42,7 @@ type Operator struct {
 
 	kubeClient    kubernetes.Interface
 	osClient      osclientset.Interface
+	dynamicClient dynamic.Interface
 	eventRecorder record.EventRecorder
 
 	syncHandler func(ic string) error
@@ -68,6 +70,7 @@ func New(
 
 	kubeClient kubernetes.Interface,
 	osClient osclientset.Interface,
+	dynamicClient dynamic.Interface,
 
 	recorder record.EventRecorder,
 ) *Operator {
@@ -84,6 +87,7 @@ func New(
 		imagesFile:      imagesFile,
 		kubeClient:      kubeClient,
 		osClient:        osClient,
+		dynamicClient:   dynamicClient,
 		eventRecorder:   recorder,
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineapioperator"),
 		operandVersions: operandVersions,


### PR DESCRIPTION
This is so baremetal can fetch the `provisioning.metal3.io` object and parameterize their deployment. Related openshift/api#540 and #460