### PR TITLE
Bug 1800423: Apply the reboot annotation to the machine

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -473,17 +473,17 @@ func (t *target) remediate(r *ReconcileMachineHealthCheck) error {
 
 func (t *target) remediationStrategyReboot(r *ReconcileMachineHealthCheck) error {
 	// we already have reboot annotation on the node, stop reconcile
-	if _, ok := t.Node.Annotations[machineRebootAnnotationKey]; ok {
+	if _, ok := t.Machine.Annotations[machineRebootAnnotationKey]; ok {
 		return nil
 	}
 
-	if t.Node.Annotations == nil {
-		t.Node.Annotations = map[string]string{}
+	if t.Machine.Annotations == nil {
+		t.Machine.Annotations = map[string]string{}
 	}
 
 	glog.Infof("Machine %s has been unhealthy for too long, adding reboot annotation", t.Machine.Name)
-	t.Node.Annotations[machineRebootAnnotationKey] = ""
-	if err := r.client.Update(context.TODO(), t.Node); err != nil {
+	t.Machine.Annotations[machineRebootAnnotationKey] = ""
+	if err := r.client.Update(context.TODO(), &t.Machine); err != nil {
 		r.recorder.Eventf(
 			&t.Machine,
 			corev1.EventTypeWarning,

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -370,8 +370,8 @@ func TestApplyRemediationReboot(t *testing.T) {
 	machineHealthCheck := maotesting.NewMachineHealthCheck("machineHealthCheck")
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
-			Namespace: "",
-			Name:      nodeUnhealthyForTooLong.Name,
+			Namespace: namespace,
+			Name:      machineUnhealthyForTooLong.Name,
 		},
 	}
 	recorder := record.NewFakeRecorder(2)
@@ -391,13 +391,13 @@ func TestApplyRemediationReboot(t *testing.T) {
 		recorder.Events,
 	)
 
-	node := &corev1.Node{}
-	if err := r.client.Get(context.TODO(), request.NamespacedName, node); err != nil {
+	machine := &mapiv1beta1.Machine{}
+	if err := r.client.Get(context.TODO(), request.NamespacedName, machine); err != nil {
 		t.Errorf("Expected: no error, got: %v", err)
 	}
 
-	if _, ok := node.Annotations[machineRebootAnnotationKey]; !ok {
-		t.Errorf("Expected: node to have reboot annotion %s, got: %v", machineRebootAnnotationKey, node.Annotations)
+	if _, ok := machine.Annotations[machineRebootAnnotationKey]; !ok {
+		t.Errorf("Expected: node to have reboot annotion %s, got: %v", machineRebootAnnotationKey, machine.Annotations)
 	}
 }
 


### PR DESCRIPTION
Discussing with the metal3 folks, we’d like to watch the machine for the annotation instead if the node. This avoids the creation of a controller that just relays the annotation from the node to the machine.