### PR TITLE
Pass config values read from Baremetal Provisioning CR to Metal3

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -77,7 +77,8 @@ func (optr *Operator) syncBaremetalControllers(config *OperatorConfig) error {
 	// Try to get baremetal provisioning config from a CR
 	baremetalProvisioningConfig, err := getBaremetalProvisioningConfig(optr.dynamicClient, baremetalProvisioningCR)
 	if err != nil {
-		glog.Infof("Unable to read Baremetal Provisioning config from CR %s.", baremetalProvisioningCR)
+		glog.Errorf("Unable to read Baremetal Provisioning config from CR %s.", baremetalProvisioningCR)
+		glog.Infof("Will try to read Baremetal Provisioning config from ConfigMap %s instead", baremetalConfigmap)
 	}
 	// Create a Secret needed for the Metal3 deployment
 	if err := createMariadbPasswordSecret(optr.kubeClient.CoreV1(), config); err != nil {


### PR DESCRIPTION
Provide configuration values read from Baremetal Provisioning CR to
Metal3 containers via env vars. When the CR is not available, fall
back to reading the config map for configuration values.