### PR TITLE
Bug 1795037: Fix cloud-provider-config-reader role

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -384,7 +384,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - configmap
+      - configmaps
     resourceNames:
       - cloud-provider-config
     verbs:


### PR DESCRIPTION
Due to a typo, the `cloud-provider-config-reader` role introduced in
[1] to allow CAPO to read from the `openshift-config/cloud-provider-config` configmap didn't work.

This commit fixes the typo.

[1] https://github.com/openshift/machine-api-operator/pull/473/