### PR TITLE
Bug 1733474: Add log message when draining the unreachable node

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -347,6 +347,8 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	if nodeIsUnreachable(node) {
+		klog.Infof("%q: Node %q is unreachable, draining will wait %q seconds after pod is signalled for deletion and skip after it",
+			machine.Name, node.Name, skipWaitForDeleteTimeoutSeconds)
 		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
 	}
 


### PR DESCRIPTION
Add log message when draining the unreachable node.