### PR TITLE
Bug 1800314: Check if instance exists before proceeding with deletion

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -226,6 +226,17 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 			}
 		}
 
+		instanceExists, err := r.actuator.Exists(ctx, m)
+		if err != nil {
+			klog.Errorf("%v: failed to check if machine exists: %v", machineName, err)
+			return reconcile.Result{}, err
+		}
+
+		if instanceExists {
+			klog.V(3).Infof("%v: can't proceed deleting machine while cloud instance is being terminated, requeuing", machineName)
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
+		}
+
 		if m.Status.NodeRef != nil {
 			klog.Infof("%v: deleting node %q for machine", m.Status.NodeRef.Name, machineName)
 			if err := r.deleteNode(ctx, m.Status.NodeRef.Name); err != nil {

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -211,13 +211,26 @@ func TestReconcileRequest(t *testing.T) {
 		},
 		{
 			request:     reconcile.Request{NamespacedName: types.NamespacedName{Name: machineDeleting.Name, Namespace: machineDeleting.Namespace}},
-			existsValue: true,
+			existsValue: false,
 			expected: expected{
 				createCallCount: 0,
-				existCallCount:  0,
+				existCallCount:  1,
 				updateCallCount: 0,
 				deleteCallCount: 1,
 				result:          reconcile.Result{},
+				error:           false,
+				phase:           phaseDeleting,
+			},
+		},
+		{
+			request:     reconcile.Request{NamespacedName: types.NamespacedName{Name: machineDeleting.Name, Namespace: machineDeleting.Namespace}},
+			existsValue: true,
+			expected: expected{
+				createCallCount: 0,
+				existCallCount:  1,
+				updateCallCount: 0,
+				deleteCallCount: 1,
+				result:          reconcile.Result{RequeueAfter: requeueAfter},
 				error:           false,
 				phase:           phaseDeleting,
 			},


### PR DESCRIPTION
From BZ description:
Deleting the Node object in Kubernetes signals to the cluster that no pod on that node is running and that it is safe to release any storage or process locks that ensure two processes can't be running on different nodes with the same name or volumes.  The machine controller was deleting the node before the machine was fully terminated, which means that a stateful set controller would be able to launch two pods with the same name running on the cluster at the same time, which violates our cluster safety guarantees.

Fix is to wait for machine is confirmed shut down by cloud provider before deleting the Node object.