### PR TITLE
Bug 1802179: use generic image placeholders for install

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -6,19 +6,19 @@ metadata:
 data:
   images.json: >
     {
-      "machineAPIOperator": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
-      "clusterAPIControllerAWS": "docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
-      "clusterAPIControllerOpenStack": "docker.io/openshift/origin-openstack-machine-controllers:v4.0.0",
-      "clusterAPIControllerLibvirt": "docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0",
-      "clusterAPIControllerBareMetal": "quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0",
-      "clusterAPIControllerAzure": "quay.io/openshift/origin-azure-machine-controllers:v4.0.0",
-      "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0",
-      "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
-      "clusterAPIControllerVSphere": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
-      "baremetalOperator": "quay.io/openshift/origin-baremetal-operator:v4.2.0",
-      "baremetalIronic": "quay.io/openshift/origin-ironic:v4.2.0",
-      "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",
-      "baremetalIpaDownloader": "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0",
-      "baremetalMachineOsDownloader": "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0",
-      "baremetalStaticIpManager": "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
+      "machineAPIOperator": "registry.svc.ci.openshift.org/openshift:machine-api-operator",
+      "clusterAPIControllerAWS": "registry.svc.ci.openshift.org/openshift:aws-machine-controllers",
+      "clusterAPIControllerOpenStack": "registry.svc.ci.openshift.org/openshift:openstack-machine-controllers",
+      "clusterAPIControllerLibvirt": "registry.svc.ci.openshift.org/openshift:libvirt-machine-controllers",
+      "clusterAPIControllerBareMetal": "registry.svc.ci.openshift.org/openshift:baremetal-machine-controllers",
+      "clusterAPIControllerAzure": "registry.svc.ci.openshift.org/openshift:azure-machine-controllers",
+      "clusterAPIControllerGCP": "registry.svc.ci.openshift.org/openshift:gcp-machine-controllers",
+      "clusterAPIControllerOvirt": "registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers",
+      "clusterAPIControllerVSphere": "registry.svc.ci.openshift.org/openshift:machine-api-operator",
+      "baremetalOperator": "registry.svc.ci.openshift.org/openshift:baremetal-operator",
+      "baremetalIronic": "registry.svc.ci.openshift.org/openshift:ironic",
+      "baremetalIronicInspector": "registry.svc.ci.openshift.org/openshift:ironic-inspector",
+      "baremetalIpaDownloader": "registry.svc.ci.openshift.org/openshift:ironic-ipa-downloader",
+      "baremetalMachineOsDownloader": "registry.svc.ci.openshift.org/openshift:ironic-machine-os-downloader",
+      "baremetalStaticIpManager": "registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager"
     }

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: machine-api-operator
       containers:
       - name: kube-rbac-proxy
-        image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
+        image: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://localhost:8080/"
@@ -44,7 +44,7 @@ spec:
         - mountPath: /etc/tls/private
           name: machine-api-operator-tls
       - name: machine-api-operator
-        image: docker.io/openshift/origin-machine-api-operator:v4.0.0
+        image: registry.svc.ci.openshift.org/openshift:machine-api-operator
         command:
         - "/machine-api-operator"
         args:

--- a/install/image-references
+++ b/install/image-references
@@ -5,60 +5,60 @@ spec:
   - name: machine-api-operator
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-machine-api-operator:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:machine-api-operator
   - name: aws-machine-controllers
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-aws-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:aws-machine-controllers
   - name: openstack-machine-controllers
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-openstack-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:openstack-machine-controllers
   - name: libvirt-machine-controllers
     from:
       kind: DockerImage
-      name: docker.io/openshift/origin-libvirt-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:libvirt-machine-controllers
   - name: baremetal-machine-controllers
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-baremetal-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:baremetal-machine-controllers
   - name: azure-machine-controllers
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-azure-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:azure-machine-controllers
   - name: gcp-machine-controllers
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-gcp-machine-controllers:v4.0.0
+      name: registry.svc.ci.openshift.org/openshift:gcp-machine-controllers
   - name: baremetal-operator
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-baremetal-operator:v4.2.0
+      name: registry.svc.ci.openshift.org/openshift:baremetal-operator
   - name: ironic
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic:v4.2.0
+      name: registry.svc.ci.openshift.org/openshift:ironic
   - name: ironic-inspector
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic-inspector:v4.2.0
+      name: registry.svc.ci.openshift.org/openshift:ironic-inspector
   - name: ironic-ipa-downloader
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0
+      name: registry.svc.ci.openshift.org/openshift:ironic-ipa-downloader
   - name: ironic-machine-os-downloader
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0
+      name: registry.svc.ci.openshift.org/openshift:ironic-machine-os-downloader
   - name: ironic-static-ip-manager
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0
+      name: registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
+      name: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
   - name: ovirt-machine-controllers
     from:
       kind: DockerImage
-      name: quay.io/openshift/origin-ovirt-machine-controllers
+      name: registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers


### PR DESCRIPTION
these placeholders will get replaced by the release-creation tooling[0].
this change is inspired by a previous commit[1] to the
machine-config-operator.

[0]: https://github.com/openshift/cluster-version-operator/blob/33079c7732b99394f78c4fecb8d7d277c87ef02c/docs/dev/operators.md#how-do-i-ensure-the-right-images-get-used-by-my-manifests
[1]: https://github.com/openshift/machine-config-operator/pull/750