### PR TITLE
Bug 1803736: Revert "Vsphere provider"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,4 @@ COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install ma
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-healthcheck .
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./manager
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/vsphere ./machine-controller-manager
-
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,7 +8,4 @@ COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install ma
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-healthcheck .
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./manager
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/vsphere ./machine-controller-manager
-
 LABEL io.openshift.release.operator true

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check-pkg:
 	./hack/verify-actuator-pkg.sh
 
 .PHONY: build
-build: machine-api-operator nodelink-controller machine-healthcheck machineset vsphere ## Build binaries
+build: machine-api-operator nodelink-controller machine-healthcheck ## Build binaries
 
 .PHONY: machine-api-operator
 machine-api-operator:
@@ -55,14 +55,6 @@ nodelink-controller:
 .PHONY: machine-healthcheck
 machine-healthcheck:
 	$(DOCKER_CMD) ./hack/go-build.sh machine-healthcheck
-
-.PHONY: vsphere
-vsphere:
-	$(DOCKER_CMD) ./hack/go-build.sh vsphere
-
-.PHONY: machineset
-machineset:
-	$(DOCKER_CMD) ./hack/go-build.sh machineset
 
 .PHONY: generate
 generate: gen-crd update-codegen

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -14,7 +14,6 @@ data:
       "clusterAPIControllerAzure": "registry.svc.ci.openshift.org/openshift:azure-machine-controllers",
       "clusterAPIControllerGCP": "registry.svc.ci.openshift.org/openshift:gcp-machine-controllers",
       "clusterAPIControllerOvirt": "registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers",
-      "clusterAPIControllerVSphere": "registry.svc.ci.openshift.org/openshift:machine-api-operator",
       "baremetalOperator": "registry.svc.ci.openshift.org/openshift:baremetal-operator",
       "baremetalIronic": "registry.svc.ci.openshift.org/openshift:ironic",
       "baremetalIronicInspector": "registry.svc.ci.openshift.org/openshift:ironic-inspector",

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -50,7 +50,6 @@ type Images struct {
 	ClusterAPIControllerAzure     string `json:"clusterAPIControllerAzure"`
 	ClusterAPIControllerGCP       string `json:"clusterAPIControllerGCP"`
 	ClusterAPIControllerOvirt     string `json:"clusterAPIControllerOvirt"`
-	ClusterAPIControllerVSphere   string `json:"clusterAPIControllerVSphere"`
 	// Images required for the metal3 pod
 	BaremetalOperator            string `json:"baremetalOperator"`
 	BaremetalIronic              string `json:"baremetalIronic"`
@@ -96,8 +95,6 @@ func getProviderControllerFromImages(platform configv1.PlatformType, images Imag
 		return images.ClusterAPIControllerBareMetal, nil
 	case configv1.OvirtPlatformType:
 		return images.ClusterAPIControllerOvirt, nil
-	case configv1.VSpherePlatformType:
-		return images.ClusterAPIControllerVSphere, nil
 	case kubemarkPlatform:
 		return clusterAPIControllerKubemark, nil
 	default:

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -22,7 +22,6 @@ var (
 	expectedIronicMachineOsDownloader = "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0"
 	expectedIronicStaticIpManager     = "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
 	expectedOvirtImage                = "quay.io/openshift/origin-ovirt-machine-controllers"
-	expectedVSphereImage              = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
 )
 
 func TestGetProviderFromInfrastructure(t *testing.T) {
@@ -138,9 +137,6 @@ func TestGetImagesFromJSONFile(t *testing.T) {
 	if img.ClusterAPIControllerOvirt != expectedOvirtImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedOvirtImage, img.ClusterAPIControllerOvirt)
 	}
-	if img.ClusterAPIControllerVSphere != expectedVSphereImage {
-		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedVSphereImage, img.ClusterAPIControllerVSphere)
-	}
 }
 
 func TestGetProviderControllerFromImages(t *testing.T) {
@@ -177,7 +173,7 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 		},
 		{
 			provider:      configv1.VSpherePlatformType,
-			expectedImage: expectedVSphereImage,
+			expectedImage: clusterAPIControllerNoOp,
 		},
 		{
 			provider:      configv1.NonePlatformType,

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -7,7 +7,6 @@
   "clusterAPIControllerAzure": "quay.io/openshift/origin-azure-machine-controllers:v4.0.0",
   "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0",
   "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
-  "clusterAPIControllerVSphere": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
   "baremetalOperator": "quay.io/openshift/origin-baremetal-operator:v4.2.0",
   "baremetalIronic": "quay.io/openshift/origin-ironic:v4.2.0",
   "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -110,11 +110,7 @@ func TestOperatorSync_NoOp(t *testing.T) {
 		},
 		{
 			platform:     openshiftv1.VSpherePlatformType,
-			expectedNoop: false,
-		},
-		{
-			platform:     openshiftv1.OvirtPlatformType,
-			expectedNoop: false,
+			expectedNoop: true,
 		},
 		{
 			platform:     openshiftv1.NonePlatformType,


### PR DESCRIPTION
Reverts openshift/machine-api-operator#474

vSphere IPI was dropped from 4.4, therefore we don't want the controller to run in this release. We'll enable it back once master opens for 4.5