### PR TITLE
fix the master ci config link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ More information about those files can be found in [ci-operator onboarding file]
 [1]: https://github.com/openshift/machine-api-operator
 [2]: https://github.com/openshift/release
 [3]: https://github.com/openshift/release/blob/master/cluster/ci/config/prow/plugins.yaml
-[4]: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/machine-api-operator/master.yaml
+[4]: https://github.com/openshift/release/blob/master/ci-operator/config/openshift/machine-api-operator/openshift-machine-api-operator-master.yaml
 [5]: https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/machine-api-operator/openshift-machine-api-operator-master-presubmits.yaml
 [6]: https://github.com/openshift/release/blob/master/ci-operator/jobs/openshift/machine-api-operator/openshift-machine-api-operator-master-postsubmits.yaml
 [7]: https://github.com/openshift/ci-operator/blob/master/ONBOARD.md


### PR DESCRIPTION
the ci section contains a link to the master configuration for the
machine api operator component registry, this change fixes the link to
the current location.