### PR TITLE
Bug 1804635: Fix timeout formatting

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -347,7 +347,7 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	if nodeIsUnreachable(node) {
-		klog.Infof("%q: Node %q is unreachable, draining will wait %q seconds after pod is signalled for deletion and skip after it",
+		klog.Infof("%q: Node %q is unreachable, draining will wait %d seconds after pod is signalled for deletion and skip after it",
 			machine.Name, node.Name, skipWaitForDeleteTimeoutSeconds)
 		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
 	}


### PR DESCRIPTION
Fix `skipWaitForDeleteTimeoutSeconds` format in log message