### PR TITLE
BUG 1806438: Drop run-level

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -6,7 +6,6 @@ metadata:
   name: openshift-machine-api
   labels:
     name: openshift-machine-api
-    openshift.io/run-level: "1"
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true"
 


### PR DESCRIPTION
mao should follow normal admission control rules for a cluster.