### PR TITLE
WIP: Add new DaemonSet for Baremetal HW Inventory management

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -20,5 +20,6 @@ data:
       "baremetalIronicInspector": "registry.svc.ci.openshift.org/openshift:ironic-inspector",
       "baremetalIpaDownloader": "registry.svc.ci.openshift.org/openshift:ironic-ipa-downloader",
       "baremetalMachineOsDownloader": "registry.svc.ci.openshift.org/openshift:ironic-machine-os-downloader",
-      "baremetalStaticIpManager": "registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager"
+      "baremetalStaticIpManager": "registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager",
+      "baremetalHwInventoryRecorder": "quay.io/openshift/origin-ironic-hardware-inventory-recorder"
     }

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -164,6 +164,10 @@ rules:
       - get
       - list
       - watch
+      - create
+      - update
+      - patch
+      - delete
 
   - apiGroups:
     - config.openshift.io
@@ -173,6 +177,11 @@ rules:
     - get
     - list
     - watch
+    - create
+    - update
+    - patch
+    - delete
+
 
 # the baremetal pod deployment uses hostNetwork, hostPort, and privileged
   - apiGroups:

--- a/install/image-references
+++ b/install/image-references
@@ -62,3 +62,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers
+  - name: ironic-hardware-inventory-recorder
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-ironic-hardware-inventory-recorder

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -526,7 +526,7 @@ func TestNodeIsUnreachable(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
-						corev1.NodeCondition{
+						{
 							Type:   corev1.NodeReady,
 							Status: corev1.ConditionUnknown,
 						},
@@ -544,7 +544,7 @@ func TestNodeIsUnreachable(t *testing.T) {
 				},
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
-						corev1.NodeCondition{
+						{
 							Type:   corev1.NodeReady,
 							Status: corev1.ConditionTrue,
 						},

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1072,7 +1072,7 @@ func TestUpdate(t *testing.T) {
 				Template: vm.Name,
 				Network: vsphereapi.NetworkSpec{
 					Devices: []vsphereapi.NetworkDeviceSpec{
-						vsphereapi.NetworkDeviceSpec{
+						{
 							NetworkName: "test",
 						},
 					},
@@ -1088,7 +1088,7 @@ func TestUpdate(t *testing.T) {
 				Template: vm.Name,
 				Network: vsphereapi.NetworkSpec{
 					Devices: []vsphereapi.NetworkDeviceSpec{
-						vsphereapi.NetworkDeviceSpec{
+						{
 							NetworkName: "test",
 						},
 					},
@@ -1261,7 +1261,7 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 			Template: vm.Name,
 			Network: vsphereapi.NetworkSpec{
 				Devices: []vsphereapi.NetworkDeviceSpec{
-					vsphereapi.NetworkDeviceSpec{
+					{
 						NetworkName: "test",
 					},
 				},

--- a/pkg/operator/baremetal_config.go
+++ b/pkg/operator/baremetal_config.go
@@ -174,6 +174,9 @@ func getMetal3DeploymentConfig(name string, baremetalConfig BaremetalProvisionin
 		return getProvisioningDHCPRange(baremetalConfig)
 	case "RHCOS_IMAGE_URL":
 		return getProvisioningOSDownloadURL(baremetalConfig)
+	case "IRONIC_INSPECTOR_PORT":
+		configValue = baremetalIronicInspectorPort
+		return &configValue
 	}
 	return nil
 }

--- a/pkg/operator/baremetal_test.go
+++ b/pkg/operator/baremetal_test.go
@@ -63,6 +63,7 @@ func newOperatorWithBaremetalConfig() *OperatorConfig {
 			"quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0",
 			"quay.io/openshift/origin-ironic-machine-os-downloader:v4.2.0",
 			"quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0",
+			"quay.io/openshift/origin-ironic-hardware-inventory-recorder:v4.4.0",
 		},
 	}
 }

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -39,6 +39,7 @@ type BaremetalControllers struct {
 	IronicIpaDownloader       string
 	IronicMachineOsDownloader string
 	IronicStaticIpManager     string
+	IronicHwInventoryRecorder string
 }
 
 // Images allows build systems to inject images for MAO components
@@ -59,6 +60,7 @@ type Images struct {
 	BaremetalIpaDownloader       string `json:"baremetalIpaDownloader"`
 	BaremetalMachineOsDownloader string `json:"baremetalMachineOsDownloader"`
 	BaremetalStaticIpManager     string `json:"baremetalStaticIpManager"`
+	BaremetalHwInventoryRecorder string `json:"baremetalHwInventoryRecorder"`
 }
 
 func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.PlatformType, error) {
@@ -130,6 +132,7 @@ func newBaremetalControllers(images Images, usingBareMetal bool) BaremetalContro
 		IronicIpaDownloader:       images.BaremetalIpaDownloader,
 		IronicMachineOsDownloader: images.BaremetalMachineOsDownloader,
 		IronicStaticIpManager:     images.BaremetalStaticIpManager,
+		IronicHwInventoryRecorder: images.BaremetalHwInventoryRecorder,
 	}
 }
 

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -23,6 +23,7 @@ var (
 	expectedIronicStaticIpManager     = "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
 	expectedOvirtImage                = "quay.io/openshift/origin-ovirt-machine-controllers"
 	expectedVSphereImage              = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
+	expectedHwInventoryRecorder       = "quay.io/openshift/origin-ironic-hardware-inventory-recorder:v4.4.0"
 )
 
 func TestGetProviderFromInfrastructure(t *testing.T) {
@@ -293,13 +294,13 @@ func TestGetBaremetalControllers(t *testing.T) {
 	}
 
 	baremetalControllers := newBaremetalControllers(*img, true)
-
 	if baremetalControllers.BaremetalOperator != expectedBaremetalOperator ||
 		baremetalControllers.Ironic != expectedIronic ||
 		baremetalControllers.IronicInspector != expectedIronicInspector ||
 		baremetalControllers.IronicIpaDownloader != expectedIronicIpaDownloader ||
 		baremetalControllers.IronicMachineOsDownloader != expectedIronicMachineOsDownloader ||
-		baremetalControllers.IronicStaticIpManager != expectedIronicStaticIpManager {
+		baremetalControllers.IronicStaticIpManager != expectedIronicStaticIpManager ||
+		baremetalControllers.IronicHwInventoryRecorder != expectedHwInventoryRecorder {
 		t.Errorf("failed getAdditionalProviderImages. One or more BaremetalController images do not match the expected images.")
 	}
 }

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -13,5 +13,6 @@
   "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",
   "baremetalIpaDownloader": "quay.io/openshift/origin-ironic-ipa-downloader:v4.2.0",
   "baremetalMachineOsDownloader": "quay.io/openshift/origin-ironic-machine-os-downloader:v4.3.0",
-  "baremetalStaticIpManager": "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
+  "baremetalStaticIpManager": "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0",
+  "baremetalHwInventoryRecorder": "quay.io/openshift/origin-ironic-hardware-inventory-recorder:v4.4.0"
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -102,6 +102,8 @@ func New(
 
 	deployInformer.Informer().AddEventHandler(optr.eventHandlerDeployments())
 	featureGateInformer.Informer().AddEventHandler(optr.eventHandler())
+	// TODO not sure if this is required
+	//daemonSetInformer.Informer().AddEventHandler(optr.eventHandlerDaemonSets())
 
 	optr.config = config
 	optr.syncHandler = optr.sync


### PR DESCRIPTION
Adding a DaemonSet that a service runs on master and worker nodes in a Baremetal IPI deployment. This service perfoms continuous hardware introspection on all baremetal nodes.

Based on proposal : https://github.com/openshift/enhancements/pull/229