### PR TITLE
[OCPCLOUD-774] Add Node startup timeout API field

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -56,6 +56,10 @@ spec:
               - type: integer
               description: Any farther remediation is only allowed if at most "MaxUnhealthy"
                 machines selected by "selector" are not healthy.
+            nodeStartupTimeout:
+              description: Machines older than this duration without a node will be
+                considered to have failed and will be remediated.
+              type: string
             selector:
               description: Label selector to match machines whose health will be exercised
               properties:

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -55,6 +55,18 @@ type MachineHealthCheckSpec struct {
 	// "selector" are not healthy.
 	// +optional
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
+
+	// It would be preferable for nodeStartupTimeout to be a metav1.Duration, but
+	// there's no good way to validate the format here.  Invalid input would cause
+	// problems with marshaling, so it's better to just make it a string and
+	// handle the conversion in the controller.
+	//
+	// Intentional blank line to keep this out of the OpenAPI description...
+
+	// Machines older than this duration without a node will be considered to have
+	// failed and will be remediated.
+	// +optional
+	NodeStartupTimeout string `json:"nodeStartupTimeout,omitempty"`
 }
 
 // UnhealthyCondition represents a Node condition type and value with a timeout


### PR DESCRIPTION
This allows users to set the previously hard coded `timeoutForMachineToHaveNode` value in the machine health checking algorithm as part of the `MachineHealthCheckSpec`.

If the value is not set, we default to the original hard coded 10 minute timeout.

Ideally the field would be a `metav1.Duration` but I've put it as a string because of the same reasons as the `UnhealthyCondition.Timeout` field.

/cherry-pick release-4.4

/cc @enxebre 