### PR TITLE
BUG 1806438: Remove explicit securityContext and add granular securitycontextconstraints "use" permissions in machine-api-controllers clusterRole

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -167,6 +167,16 @@ rules:
     - list
     - watch
 
+# the baremetal pod deployment uses hostNetwork, hostPort, and privileged
+  - apiGroups:
+      - security.openshift.io
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+    resourceNames:
+      - privileged
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -72,9 +72,6 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 65534
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -194,13 +194,9 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers:        containers,
-			PriorityClassName: "system-node-critical",
-			NodeSelector:      map[string]string{"node-role.kubernetes.io/master": ""},
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsNonRoot: pointer.BoolPtr(true),
-				RunAsUser:    pointer.Int64Ptr(65534),
-			},
+			Containers:         containers,
+			PriorityClassName:  "system-node-critical",
+			NodeSelector:       map[string]string{"node-role.kubernetes.io/master": ""},
 			ServiceAccountName: "machine-api-controllers",
 			Tolerations:        tolerations,
 		},


### PR DESCRIPTION
Without the runlabel https://github.com/openshift/machine-api-operator/pull/496, we’ll run as a high user by default, no need to say run me as non root.

Otherwise when removing the runlevel completely for the `openshift-machine-api` namespace https://github.com/openshift/cluster-autoscaler-operator/pull/133 the kube controller manager complains with ```Error creating: pods "machine-api-operator-75c887884f-" is forbidden: unable to validate against any security context constraint: [spec.containers[0].securityContext.securityContext.runAsUser: Invalid value: 65534: must be in the ranges: [1000340000, 1000349999] spec.containers[1].securityContext.securityContext.runAsUser: Invalid value: 65534: must be in the ranges: [1000340000, 1000349999]]``` https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-autoscaler-operator/133/pull-ci-openshift-cluster-autoscaler-operator-master-e2e-aws/496/artifacts/e2e-aws/pods/openshift-kube-controller-manager_kube-controller-manager-ip-10-0-133-251.us-east-2.compute.internal_kube-controller-manager.log"

Only after this PR makes it to payload then https://github.com/openshift/cluster-autoscaler-operator/pull/133/files should go green as no pods within the `openshift-machine-api` namespace will set an invalid user.