### PR TITLE
BUG 1807125: Add GCP roles/compute.loadBalancerAdmin role

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -88,6 +88,10 @@ spec:
     predefinedRoles:
     - "roles/compute.instanceAdmin.v1"
     - "roles/iam.serviceAccountUser"
+    - "roles/compute.loadBalancerAdmin"
+# includes compute.targetPools.* currently used to add masters to LB in DR scenarios.
+# https://cloud.google.com/compute/docs/access/iam#compute.loadBalancerAdmin
+
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
"roles/compute.networkAdmin" https://cloud.google.com/compute/docs/access/iam includes "compute.targetPools.*". This is currently used to add masters to LB in DR scenarios.
https://bugzilla.redhat.com/show_bug.cgi?id=1807125

/cherrypick release-4.4
/cherrypick release-4.3
/cherrypick release-4.2