### PR TITLE
Remove unusued code and cleanup

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openshift/machine-api-operator/pkg/controller/machinehealthcheck"
 
 	"github.com/golang/glog"
-	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -51,7 +50,7 @@ func main() {
 	glog.Infof("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := v1beta1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := mapiv1.AddToScheme(mgr.GetScheme()); err != nil {
 		glog.Fatal(err)
 	}
 	if err := mapiv1.AddToScheme(mgr.GetScheme()); err != nil {

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	commonerrors "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -406,7 +405,7 @@ func delayIfRequeueAfterError(err error) (reconcile.Result, error) {
 func isInvalidMachineConfigurationError(err error) bool {
 	switch t := err.(type) {
 	case *MachineError:
-		if t.Reason == commonerrors.InvalidConfigurationMachineError {
+		if t.Reason == machinev1.InvalidConfigurationMachineError {
 			klog.Infof("Actuator returned invalid configuration error: %v", err)
 			return true
 		}

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -441,10 +441,7 @@ func machineHasNode(machine *machinev1.Machine) bool {
 }
 
 func machineIsFailed(machine *machinev1.Machine) bool {
-	if stringPointerDeref(machine.Status.Phase) == phaseFailed {
-		return true
-	}
-	return false
+	return stringPointerDeref(machine.Status.Phase) == phaseFailed
 }
 
 func nodeIsUnreachable(node *corev1.Node) bool {

--- a/pkg/controller/machine/machine_controller_suite_test.go
+++ b/pkg/controller/machine/machine_controller_suite_test.go
@@ -61,14 +61,15 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 }
 
 // StartTestManager adds recFn
-func StartTestManager(mgr manager.Manager, t *testing.T) chan struct{} {
+func StartTestManager(mgr manager.Manager, t *testing.T) (chan struct{}, chan error) {
 	t.Helper()
 
 	stop := make(chan struct{})
+	errs := make(chan error, 1)
+
 	go func() {
-		if err := mgr.Start(stop); err != nil {
-			t.Fatalf("error starting test manager: %v", err)
-		}
+		errs <- mgr.Start(stop)
 	}()
-	return stop
+
+	return stop, errs
 }

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -53,7 +53,14 @@ func TestReconcile(t *testing.T) {
 	if err := add(mgr, recFn); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}
-	defer close(StartTestManager(mgr, t))
+
+	stop, errChan := StartTestManager(mgr, t)
+	defer func() {
+		close(stop)
+		if err := <-errChan; err != nil {
+			t.Fatalf("error starting test manager: %v", err)
+		}
+	}()
 
 	// Create the Machine object and expect Reconcile and the actuator to be called
 	if err := c.Create(context.TODO(), instance); err != nil {

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -634,13 +634,6 @@ func derefStringPointer(stringPointer *string) string {
 	return ""
 }
 
-func derefStringInt(intPointer *int) int {
-	if intPointer != nil {
-		return 0
-	}
-	return *intPointer
-}
-
 func minDuration(durations []time.Duration) time.Duration {
 	if len(durations) == 0 {
 		return time.Duration(0)

--- a/pkg/controller/machineset/machineset_controller_suite_test.go
+++ b/pkg/controller/machineset/machineset_controller_suite_test.go
@@ -61,14 +61,15 @@ func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan 
 }
 
 // StartTestManager adds recFn
-func StartTestManager(mgr manager.Manager, t *testing.T) chan struct{} {
+func StartTestManager(mgr manager.Manager, t *testing.T) (chan struct{}, chan error) {
 	t.Helper()
 
 	stop := make(chan struct{})
+	errs := make(chan error, 1)
+
 	go func() {
-		if err := mgr.Start(stop); err != nil {
-			t.Fatalf("error starting test manager: %v", err)
-		}
+		errs <- mgr.Start(stop)
 	}()
-	return stop
+
+	return stop, errs
 }

--- a/pkg/controller/machineset/machineset_controller_test.go
+++ b/pkg/controller/machineset/machineset_controller_test.go
@@ -49,7 +49,14 @@ func TestReconcile(t *testing.T) {
 	if err := add(mgr, recFn, r.MachineToMachineSets); err != nil {
 		t.Errorf("error adding controller to manager: %v", err)
 	}
-	defer close(StartTestManager(mgr, t))
+
+	stop, errChan := StartTestManager(mgr, t)
+	defer func() {
+		close(stop)
+		if err := <-errChan; err != nil {
+			t.Fatalf("error starting test manager: %v", err)
+		}
+	}()
 
 	replicas := int32(2)
 	labels := map[string]string{"foo": "bar"}

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -22,10 +22,9 @@ const (
 // machineScopeParams defines the input parameters used to create a new MachineScope.
 type machineScopeParams struct {
 	context.Context
-	client        runtimeclient.Client
-	apiReader     runtimeclient.Reader
-	machine       *machinev1.Machine
-	vSphereConfig *vSphereConfig
+	client    runtimeclient.Client
+	apiReader runtimeclient.Reader
+	machine   *machinev1.Machine
 }
 
 // machineScope defines a scope defined around a machine and its cluster.

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -7,8 +7,7 @@ import (
 	"testing"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	apivsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
-	vsphereapi "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
+	vspherev1 "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,8 +19,8 @@ import (
 
 const TestNamespace = "vsphere-test"
 
-func MachineWithSpec(spec *apivsphere.VSphereMachineProviderSpec) *machinev1.Machine {
-	rawSpec, err := vsphereapi.RawExtensionFromProviderSpec(spec)
+func MachineWithSpec(spec *vspherev1.VSphereMachineProviderSpec) *machinev1.Machine {
+	rawSpec, err := vspherev1.RawExtensionFromProviderSpec(spec)
 	if err != nil {
 		panic("Failed to encode raw extension from provider spec")
 	}
@@ -42,7 +41,7 @@ func MachineWithSpec(spec *apivsphere.VSphereMachineProviderSpec) *machinev1.Mac
 func TestGetUserData(t *testing.T) {
 	userDataSecretName := "vsphere-ignition"
 
-	defaultProviderSpec := &apivsphere.VSphereMachineProviderSpec{
+	defaultProviderSpec := &vspherev1.VSphereMachineProviderSpec{
 		UserDataSecret: &corev1.LocalObjectReference{
 			Name: userDataSecretName,
 		},
@@ -51,7 +50,7 @@ func TestGetUserData(t *testing.T) {
 	testCases := []struct {
 		testCase         string
 		userDataSecret   *corev1.Secret
-		providerSpec     *apivsphere.VSphereMachineProviderSpec
+		providerSpec     *vspherev1.VSphereMachineProviderSpec
 		expectedUserdata []byte
 		expectError      bool
 	}{
@@ -100,7 +99,7 @@ func TestGetUserData(t *testing.T) {
 		{
 			testCase:         "no user-data in provider spec",
 			userDataSecret:   nil,
-			providerSpec:     &apivsphere.VSphereMachineProviderSpec{},
+			providerSpec:     &vspherev1.VSphereMachineProviderSpec{},
 			expectError:      false,
 			expectedUserdata: nil,
 		},
@@ -146,7 +145,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 	testCases := []struct {
 		testCase          string
 		secret            *corev1.Secret
-		providerSpec      *apivsphere.VSphereMachineProviderSpec
+		providerSpec      *vspherev1.VSphereMachineProviderSpec
 		expectError       bool
 		expectCredentials bool
 	}{
@@ -162,11 +161,11 @@ func TestGetCredentialsSecret(t *testing.T) {
 					expectedCredentialsSecretPassword: []byte(expectedPassword),
 				},
 			},
-			providerSpec: &apivsphere.VSphereMachineProviderSpec{
+			providerSpec: &vspherev1.VSphereMachineProviderSpec{
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: "test",
 				},
-				Workspace: &apivsphere.Workspace{
+				Workspace: &vspherev1.Workspace{
 					Server: expectedServer,
 				},
 			},
@@ -184,11 +183,11 @@ func TestGetCredentialsSecret(t *testing.T) {
 					expectedCredentialsSecretPassword: []byte(expectedPassword),
 				},
 			},
-			providerSpec: &apivsphere.VSphereMachineProviderSpec{
+			providerSpec: &vspherev1.VSphereMachineProviderSpec{
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: "secret-does-not-exist",
 				},
-				Workspace: &apivsphere.Workspace{
+				Workspace: &vspherev1.Workspace{
 					Server: expectedServer,
 				},
 			},
@@ -206,11 +205,11 @@ func TestGetCredentialsSecret(t *testing.T) {
 					expectedCredentialsSecretPassword: []byte(expectedPassword),
 				},
 			},
-			providerSpec: &apivsphere.VSphereMachineProviderSpec{
+			providerSpec: &vspherev1.VSphereMachineProviderSpec{
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: "test",
 				},
-				Workspace: &apivsphere.Workspace{
+				Workspace: &vspherev1.Workspace{
 					Server: expectedServer,
 				},
 			},
@@ -228,11 +227,11 @@ func TestGetCredentialsSecret(t *testing.T) {
 					"badPasswordKey":                  []byte(expectedPassword),
 				},
 			},
-			providerSpec: &apivsphere.VSphereMachineProviderSpec{
+			providerSpec: &vspherev1.VSphereMachineProviderSpec{
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: "test",
 				},
-				Workspace: &apivsphere.Workspace{
+				Workspace: &vspherev1.Workspace{
 					Server: expectedServer,
 				},
 			},
@@ -250,7 +249,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 					expectedCredentialsSecretPassword: []byte(expectedPassword),
 				},
 			},
-			providerSpec:      &apivsphere.VSphereMachineProviderSpec{},
+			providerSpec:      &vspherev1.VSphereMachineProviderSpec{},
 			expectError:       false,
 			expectCredentials: false,
 		},
@@ -298,25 +297,25 @@ func TestPatchMachine(t *testing.T) {
 	}
 
 	// original objects
-	originalProviderSpec := apivsphere.VSphereMachineProviderSpec{
+	originalProviderSpec := vspherev1.VSphereMachineProviderSpec{
 		CredentialsSecret: &corev1.LocalObjectReference{
 			Name: "test",
 		},
 
-		Workspace: &apivsphere.Workspace{
+		Workspace: &vspherev1.Workspace{
 			Server: server.URL.Host,
 			Folder: "test",
 		},
 	}
-	rawProviderSpec, err := apivsphere.RawExtensionFromProviderSpec(&originalProviderSpec)
+	rawProviderSpec, err := vspherev1.RawExtensionFromProviderSpec(&originalProviderSpec)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	originalProviderStatus := &apivsphere.VSphereMachineProviderStatus{
+	originalProviderStatus := &vspherev1.VSphereMachineProviderStatus{
 		TaskRef: "test",
 	}
-	rawProviderStatus, err := apivsphere.RawExtensionFromProviderStatus(originalProviderStatus)
+	rawProviderStatus, err := vspherev1.RawExtensionFromProviderStatus(originalProviderStatus)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -349,10 +348,10 @@ func TestPatchMachine(t *testing.T) {
 			Address: "127.0.0.1",
 		},
 	}
-	expectedProviderStatus := &apivsphere.VSphereMachineProviderStatus{
+	expectedProviderStatus := &vspherev1.VSphereMachineProviderStatus{
 		TaskRef: "mutated",
 	}
-	rawProviderStatus, err = apivsphere.RawExtensionFromProviderStatus(expectedProviderStatus)
+	rawProviderStatus, err = vspherev1.RawExtensionFromProviderStatus(expectedProviderStatus)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -129,7 +129,7 @@ func TestGetUserData(t *testing.T) {
 				t.Errorf("Unexpected error: %v", err)
 			}
 
-			if bytes.Compare(userData, tc.expectedUserdata) != 0 {
+			if !bytes.Equal(userData, tc.expectedUserdata) {
 				t.Errorf("Got: %q, Want: %q", userData, tc.expectedUserdata)
 			}
 		})

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -27,20 +27,6 @@ const (
 	releaseVersion   = "0.0.0.test-unit"
 )
 
-func newOperatorConfig() *OperatorConfig {
-	baremetalControllers := BaremetalControllers{}
-
-	return &OperatorConfig{
-		targetNamespace,
-		Controllers{
-			"docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
-			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
-			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
-		},
-		baremetalControllers,
-	}
-}
-
 func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, stopCh <-chan struct{}) *Operator {
 	kubeClient := fakekube.NewSimpleClientset(kubeObjects...)
 	osClient := fakeos.NewSimpleClientset(osObjects...)

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	openshiftv1 "github.com/openshift/api/config/v1"
-	osconfigv1 "github.com/openshift/api/config/v1"
 	fakeos "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
 	"github.com/stretchr/testify/assert"
@@ -72,7 +71,7 @@ func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, s
 	deployInformer.Informer().AddEventHandler(optr.eventHandlerDeployments())
 	featureGateInformer.Informer().AddEventHandler(optr.eventHandler())
 
-	optr.operandVersions = []osconfigv1.OperandVersion{
+	optr.operandVersions = []openshiftv1.OperandVersion{
 		{Name: "operator", Version: releaseVersion},
 	}
 

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -35,10 +35,9 @@ func TestPrintOperandVersions(t *testing.T) {
 
 func TestOperatorStatusProgressing(t *testing.T) {
 	type tCase struct {
-		currentVersion        []osconfigv1.OperandVersion
-		desiredVersion        []osconfigv1.OperandVersion
-		expectedConditions    []osconfigv1.ClusterOperatorStatusCondition
-		transitionTimeUpdated bool
+		currentVersion     []osconfigv1.OperandVersion
+		desiredVersion     []osconfigv1.OperandVersion
+		expectedConditions []osconfigv1.ClusterOperatorStatusCondition
 	}
 	tCases := []tCase{
 		{


### PR DESCRIPTION
This PR:
1. Removes unused code
2. Replaces unreasonable structures
3. Removes duplicate imports
4. Fixes `t.Fatalf` call from separate go routine