### PR TITLE
Add Interruptible Instance label name

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -59,6 +59,9 @@ const (
 	// MachineInstanceTypeLabelName as annotation name for a machine instance type
 	MachineInstanceTypeLabelName = "machine.openshift.io/instance-type"
 
+	// MachineInterruptableInstanceLabelName as annotaiton name for interruptible instances
+	MachineInterruptableInstanceLabelName = "machine.openshift.io/interruptible-instance"
+
 	// https://github.com/openshift/enhancements/blob/master/enhancements/machine-instance-lifecycle.md
 	// This is not a transient error, but
 	// indicates a state that will likely need to be fixed before progress can be made


### PR DESCRIPTION
This will be used by AWS/GCP/Azure actuators to label Machines as either On-Demand or Spot depending on the provider and the appropriate terminology.

This will allow selectors for Machine's based on this label