### PR TITLE
Precedence in Cloud Identification

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	configv1 "github.com/openshift/api/config/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
@@ -65,6 +66,34 @@ func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.Pla
 		return "", fmt.Errorf("no platform provider found on install config")
 	}
 	return infra.Status.Platform, nil
+}
+
+func getProviderFromConfigMap(configmap *corev1.ConfigMap) (configv1.PlatformType, error) {
+
+	provider := configmap.Data["cloud-api-provider"]
+
+	switch provider {
+	case string(configv1.AWSPlatformType):
+		return configv1.AWSPlatformType, nil
+	case string(configv1.LibvirtPlatformType):
+		return configv1.LibvirtPlatformType, nil
+	case string(configv1.OpenStackPlatformType):
+		return configv1.OpenStackPlatformType, nil
+	case string(configv1.AzurePlatformType):
+		return configv1.AzurePlatformType, nil
+	case string(configv1.GCPPlatformType):
+		return configv1.GCPPlatformType, nil
+	case string(configv1.BareMetalPlatformType):
+		return configv1.BareMetalPlatformType, nil
+	case string(configv1.OvirtPlatformType):
+		return configv1.OvirtPlatformType, nil
+	case string(configv1.VSpherePlatformType):
+		return configv1.BareMetalPlatformType, nil
+	case string(kubemarkPlatform):
+		return clusterAPIControllerKubemark, nil
+	default:
+		return clusterAPIControllerNoOp, fmt.Errorf("no platform provider found on install config")
+	}
 }
 
 func getImagesFromJSONFile(filePath string) (*Images, error) {

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -70,7 +70,7 @@ func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.Pla
 
 func getProviderFromConfigMap(configmap *corev1.ConfigMap) (configv1.PlatformType, error) {
 
-	provider := configmap.Data["cloud-api-provider"]
+	provider := configmap.Data["machine-api-provider"]
 
 	switch provider {
 	case string(configv1.AWSPlatformType):
@@ -92,7 +92,7 @@ func getProviderFromConfigMap(configmap *corev1.ConfigMap) (configv1.PlatformTyp
 	case string(kubemarkPlatform):
 		return clusterAPIControllerKubemark, nil
 	default:
-		return clusterAPIControllerNoOp, fmt.Errorf("no platform provider found on install config")
+		return clusterAPIControllerNoOp, fmt.Errorf("no platform provider found in config map")
 	}
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -260,11 +260,11 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		return nil, err
 	}
 
-	cloudapiconfig, err := optr.kubeClient.CoreV1().ConfigMaps(optr.namespace).Get("cluster-api-provider-config", metav1.GetOptions{})
+	machineapiconfig, err := optr.kubeClient.CoreV1().ConfigMaps(optr.namespace).Get("machine-api-controller-config", metav1.GetOptions{})
 	if err != nil {
-		glog.V(4).Infof("Error in reading config map cluster-api-provider-config, %v", err)
+		glog.V(4).Infof("Error in reading config map machine-api-controller-config, %v", err)
 	} else {
-		provider, err = getProviderFromConfigMap(cloudapiconfig)
+		provider, err = getProviderFromConfigMap(machineapiconfig)
 		if err != nil {
 			glog.V(4).Infof("Unable able to find cloud in configmap, %v", err)
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -260,6 +260,19 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		return nil, err
 	}
 
+	cloudapiconfig, err := optr.kubeClient.CoreV1().ConfigMaps(optr.namespace).Get("cluster-api-provider-config", metav1.GetOptions{})
+	if err != nil {
+		glog.Infoln("ConfigMap cluster-api-provider-config not found or error in reading it, continuing with infrastructure Object")
+	} else {
+		glog.Infoln("ConfigMap found, Trying to read cloud from ConfigMap")
+		provider, err = getProviderFromConfigMap(cloudapiconfig)
+		if err != nil {
+			glog.Infoln("Unable able to find cloud in cloud config")
+		} else {
+			glog.Infoln("Found cloud ", provider, "in configmap")
+		}
+	}
+
 	images, err := getImagesFromJSONFile(optr.imagesFile)
 	if err != nil {
 		return nil, err

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -262,14 +262,11 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 
 	cloudapiconfig, err := optr.kubeClient.CoreV1().ConfigMaps(optr.namespace).Get("cluster-api-provider-config", metav1.GetOptions{})
 	if err != nil {
-		glog.Infoln("ConfigMap cluster-api-provider-config not found or error in reading it, continuing with infrastructure Object")
+		glog.V(4).Infof("Error in reading config map cluster-api-provider-config, %v", err)
 	} else {
-		glog.Infoln("ConfigMap found, Trying to read cloud from ConfigMap")
 		provider, err = getProviderFromConfigMap(cloudapiconfig)
 		if err != nil {
-			glog.Infoln("Unable able to find cloud in cloud config")
-		} else {
-			glog.Infoln("Found cloud ", provider, "in configmap")
+			glog.V(4).Infof("Unable able to find cloud in configmap, %v", err)
 		}
 	}
 


### PR DESCRIPTION
The machine api now is getting the cloud it is running in infrastructure object.

The change is about setting a precedence for the with a config map to support for bare metal installation on any cloud.

When the operator finds the config map it will  load the cloud from the config map and default to infrastructure object when there is an error in reading the configmap or the configmap not configured properly.