### PR TITLE
Bug 1811161: ROKS - remove machine related CRDs from cluster [4.4]

### DIFF
--- a/hack/gen-crd.sh
+++ b/hack/gen-crd.sh
@@ -2,6 +2,15 @@
 
 set -eu
 
+function annotate_crd() {
+  script='/^metadata:/a\
+\ \ annotations:\
+\ \ \ \ exclude.release.openshift.io/internal-openshift-hosted: "true"'
+  input="${1}"
+  output="${2}"
+  sed -e "${script}" "${input}" > "${output}"
+}
+
 echo "Building controller-gen tool..."
 go build -o bin/controller-gen github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 
@@ -23,9 +32,9 @@ GOPATH=$dir ${cwd}/bin/controller-gen crd \
 #${cwd}/bin/controller-gen crd paths=$dir/src/github.com/openshift/machine-api-operator/pkg/apis/... output:crd:dir=$dir/src/github.com/openshift/machine-api-operator/config/crds/
 popd
 
-echo "Coping generated CRDs"
-cp $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machinehealthchecks.yaml install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
-cp $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machinesets.yaml install/0000_30_machine-api-operator_03_machineset.crd.yaml
-cp $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machines.yaml install/0000_30_machine-api-operator_02_machine.crd.yaml
+echo "Copying and patching generated CRDs"
+annotate_crd $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machinehealthchecks.yaml install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+annotate_crd $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machinesets.yaml install/0000_30_machine-api-operator_03_machineset.crd.yaml
+annotate_crd $dir/src/github.com/openshift/machine-api-operator/config/crds/machine.openshift.io_machines.yaml install/0000_30_machine-api-operator_02_machine.crd.yaml
 
 rm -rf $dir

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   creationTimestamp: null
   name: machines.machine.openshift.io
 spec:

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   creationTimestamp: null
   name: machinesets.machine.openshift.io
 spec:

--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   creationTimestamp: null
   name: machinehealthchecks.machine.openshift.io
 spec:


### PR DESCRIPTION
In a ROKS cluster, the console UI should not show machine related views since
machine management is done outside the cluster. The UI will remove the
views as long as the CRDs are not present.