### PR TITLE
vSphere: Add InternalDNS with virtual machine name to Status addresses

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -278,6 +278,11 @@ func (r *Reconciler) reconcileNetwork(vm *virtualMachine) error {
 		}
 	}
 
+	ipAddrs = append(ipAddrs, corev1.NodeAddress{
+		Type:    corev1.NodeInternalDNS,
+		Address: vm.Obj.Name(),
+	})
+
 	klog.V(3).Infof("%v: reconciling network: IP addresses: %v", r.machine.GetName(), ipAddrs)
 	r.machine.Status.Addresses = ipAddrs
 	return nil

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -526,6 +526,10 @@ func TestReconcileNetwork(t *testing.T) {
 			Type:    corev1.NodeInternalIP,
 			Address: "127.0.0.1",
 		},
+		{
+			Type:    corev1.NodeInternalDNS,
+			Address: vm.Obj.Name(),
+		},
 	}
 	r := &Reconciler{
 		machineScope: &machineScope{


### PR DESCRIPTION
The CSR that is created uses the name of the virtual machine.
There are no other SAN(s) within the CSR for the cluster-machine-approver
to use.
Adding an item to status addresses to include InternalDNS with
VM name.