### PR TITLE
Bug 1815680: Allow MachineHealthCheck to have an empty selector

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -63,7 +63,8 @@ spec:
                 considered to have failed and will be remediated.
               type: string
             selector:
-              description: Label selector to match machines whose health will be exercised
+              description: 'Label selector to match machines whose health will be
+                exercised. Note: An empty selector will match all machines.'
               properties:
                 matchExpressions:
                   description: matchExpressions is a list of label selector requirements.

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -41,7 +41,8 @@ type MachineHealthCheckList struct {
 
 // MachineHealthCheckSpec defines the desired state of MachineHealthCheck
 type MachineHealthCheckSpec struct {
-	// Label selector to match machines whose health will be exercised
+	// Label selector to match machines whose health will be exercised.
+	// Note: An empty selector will match all machines.
 	Selector metav1.LabelSelector `json:"selector"`
 
 	// UnhealthyConditions contains a list of the conditions that determine

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -661,10 +661,9 @@ func hasMatchingLabels(machineHealthCheck *mapiv1.MachineHealthCheck, machine *m
 		glog.Warningf("unable to convert selector: %v", err)
 		return false
 	}
-	// If a deployment with a nil or empty selector creeps in, it should match nothing, not everything.
+	// If the selector is empty, all machines are considered to match
 	if selector.Empty() {
-		glog.V(3).Infof("%q machineHealthCheck has empty selector", machineHealthCheck.GetName())
-		return false
+		return true
 	}
 	if !selector.Matches(labels.Set(machine.Labels)) {
 		glog.V(4).Infof("%q machine has mismatched labels for MHC %q", machine.GetName(), machineHealthCheck.GetName())

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -68,6 +68,38 @@ func TestHasMatchingLabels(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			machine: machine,
+			machineHealthCheck: &mapiv1beta1.MachineHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "EmptySelector",
+					Namespace: namespace,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineHealthCheck",
+				},
+				Spec: mapiv1beta1.MachineHealthCheckSpec{
+					Selector: metav1.LabelSelector{},
+				},
+				Status: mapiv1beta1.MachineHealthCheckStatus{},
+			},
+			expected: true,
+		},
+		{
+			machine: machine,
+			machineHealthCheck: &mapiv1beta1.MachineHealthCheck{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "NilSelector", // Note this shouldn't happen, API schema validation requires the selector be non-nil
+					Namespace: namespace,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind: "MachineHealthCheck",
+				},
+				Spec:   mapiv1beta1.MachineHealthCheckSpec{},
+				Status: mapiv1beta1.MachineHealthCheckStatus{},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tc := range testsCases {


### PR DESCRIPTION
This allows MachineHealthChecks to be created with an empty selector (`selector: {}`) which will match all machines.

This currently works, but the watch maps for watching Nodes and Machines currently assume no Nodes or Machines should match when the selector is empty, this change ensures all Nodes/Machines match when the selector is empty as per the behaviour of an empty selector normally