### PR TITLE
[OCPCLOUD-803] Run Spot Termination Handler from Machine API Operator

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -121,6 +121,7 @@ func startControllers(ctx *ControllerContext) {
 		startOpts.imagesFile,
 		config,
 		ctx.KubeNamespacedInformerFactory.Apps().V1().Deployments(),
+		ctx.KubeNamespacedInformerFactory.Apps().V1().DaemonSets(),
 		ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.OpenshiftClientOrDie(componentName),

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -12,6 +12,13 @@ metadata:
   namespace: openshift-machine-api
 
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -181,6 +188,21 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+rules:
+  - apiGroups:
+      - machine.openshift.io
+    resources:
+      - machines
+    verbs:
+      - list
+      - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
 rules:
@@ -202,6 +224,7 @@ rules:
       - apps
     resources:
       - deployments
+      - daemonsets
     verbs:
       - get
       - list
@@ -327,6 +350,21 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
+    namespace: openshift-machine-api
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: machine-api-termination-handler
+subjects:
+  - kind: ServiceAccount
+    name: machine-api-termination-handler
     namespace: openshift-machine-api
 
 ---

--- a/pkg/operator/baremetal_test.go
+++ b/pkg/operator/baremetal_test.go
@@ -54,6 +54,7 @@ func newOperatorWithBaremetalConfig() *OperatorConfig {
 			"docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
 			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
 			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
+			"docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
 		},
 		BaremetalControllers{
 			"quay.io/openshift/origin-baremetal-operator:v4.2.0",

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -29,6 +29,7 @@ type Controllers struct {
 	Provider           string
 	NodeLink           string
 	MachineHealthCheck string
+	TerminationHandler string
 }
 
 type BaremetalControllers struct {
@@ -100,6 +101,18 @@ func getProviderControllerFromImages(platform configv1.PlatformType, images Imag
 		return images.ClusterAPIControllerVSphere, nil
 	case kubemarkPlatform:
 		return clusterAPIControllerKubemark, nil
+	default:
+		return clusterAPIControllerNoOp, nil
+	}
+}
+
+// getTerminationHandlerFromImages returns the image to use for the Termination Handler DaemonSet
+// based on the platform provided.
+// Defaults to NoOp if not supported by the platform.
+func getTerminationHandlerFromImages(platform configv1.PlatformType, images Images) (string, error) {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return images.ClusterAPIControllerAWS, nil
 	default:
 		return clusterAPIControllerNoOp, nil
 	}

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -206,6 +206,69 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 	}
 }
 
+func TestGetTerminationHandlerFromImages(t *testing.T) {
+	tests := []struct {
+		provider      configv1.PlatformType
+		expectedImage string
+	}{{
+		provider:      configv1.AWSPlatformType,
+		expectedImage: expectedAWSImage,
+	},
+		{
+			provider:      configv1.LibvirtPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.OpenStackPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.BareMetalPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.AzurePlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.GCPPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      kubemarkPlatform,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.VSpherePlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.NonePlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+		{
+			provider:      configv1.OvirtPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
+	}
+
+	imagesJSONFile := "fixtures/images.json"
+	img, err := getImagesFromJSONFile(imagesJSONFile)
+	if err != nil {
+		t.Errorf("failed getImagesFromJSONFile, %v", err)
+	}
+
+	for _, test := range tests {
+		res, err := getTerminationHandlerFromImages(test.provider, *img)
+		if err != nil {
+			t.Errorf("failed getTerminationHandlerFromImages: %v", err)
+		}
+		if test.expectedImage != res {
+			t.Errorf("failed getTerminationHandlerFromImages. Expected: %q, got: %q", test.expectedImage, res)
+		}
+	}
+}
+
 func TestGetMachineAPIOperatorFromImages(t *testing.T) {
 	imagesJSONFile := "fixtures/images.json"
 	img, err := getImagesFromJSONFile(imagesJSONFile)

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -50,6 +50,9 @@ type Operator struct {
 	deployLister       appslisterv1.DeploymentLister
 	deployListerSynced cache.InformerSynced
 
+	daemonsetLister       appslisterv1.DaemonSetLister
+	daemonsetListerSynced cache.InformerSynced
+
 	featureGateLister      configlistersv1.FeatureGateLister
 	featureGateCacheSynced cache.InformerSynced
 
@@ -66,6 +69,7 @@ func New(
 	config string,
 
 	deployInformer appsinformersv1.DeploymentInformer,
+	daemonsetInformer appsinformersv1.DaemonSetInformer,
 	featureGateInformer configinformersv1.FeatureGateInformer,
 
 	kubeClient kubernetes.Interface,
@@ -102,6 +106,9 @@ func New(
 	optr.deployLister = deployInformer.Lister()
 	optr.deployListerSynced = deployInformer.Informer().HasSynced
 
+	optr.daemonsetLister = daemonsetInformer.Lister()
+	optr.daemonsetListerSynced = daemonsetInformer.Informer().HasSynced
+
 	optr.featureGateLister = featureGateInformer.Lister()
 	optr.featureGateCacheSynced = featureGateInformer.Informer().HasSynced
 
@@ -118,6 +125,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 
 	if !cache.WaitForCacheSync(stopCh,
 		optr.deployListerSynced,
+		optr.daemonsetListerSynced,
 		optr.featureGateCacheSynced) {
 		glog.Error("Failed to sync caches")
 		return

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -270,6 +270,11 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		return nil, err
 	}
 
+	terminationHandlerImage, err := getTerminationHandlerFromImages(provider, *images)
+	if err != nil {
+		return nil, err
+	}
+
 	usingBareMetal := provider == osconfigv1.BareMetalPlatformType
 	baremetalControllers := newBaremetalControllers(*images, usingBareMetal)
 
@@ -284,6 +289,7 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 			Provider:           providerControllerImage,
 			NodeLink:           machineAPIOperatorImage,
 			MachineHealthCheck: machineAPIOperatorImage,
+			TerminationHandler: terminationHandlerImage,
 		},
 		BaremetalControllers: baremetalControllers,
 	}, nil

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -36,6 +36,7 @@ func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, s
 	configSharedInformer := configinformersv1.NewSharedInformerFactoryWithOptions(osClient, 2*time.Minute)
 	featureGateInformer := configSharedInformer.Config().V1().FeatureGates()
 	deployInformer := kubeNamespacedSharedInformer.Apps().V1().Deployments()
+	daemonsetInformer := kubeNamespacedSharedInformer.Apps().V1().DaemonSets()
 
 	optr := &Operator{
 		kubeClient:             kubeClient,
@@ -43,11 +44,13 @@ func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, s
 		dynamicClient:          dynamicClient,
 		featureGateLister:      featureGateInformer.Lister(),
 		deployLister:           deployInformer.Lister(),
+		daemonsetLister:        daemonsetInformer.Lister(),
 		imagesFile:             "fixtures/images.json",
 		namespace:              targetNamespace,
 		eventRecorder:          record.NewFakeRecorder(50),
 		queue:                  workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "machineapioperator"),
 		deployListerSynced:     deployInformer.Informer().HasSynced,
+		daemonsetListerSynced:  daemonsetInformer.Informer().HasSynced,
 		featureGateCacheSynced: featureGateInformer.Informer().HasSynced,
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -39,6 +39,10 @@ func (optr *Operator) syncAll(config *OperatorConfig) error {
 		glog.V(3).Info("Synced up all machine-api-controller components")
 	}
 
+	if config.Controllers.TerminationHandler != clusterAPIControllerNoOp {
+
+	}
+
 	// In addition, if the Provider is BareMetal, then bring up
 	// the baremetal-operator pod
 	if config.BaremetalControllers.BaremetalOperator != "" {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -20,6 +20,9 @@ import (
 const (
 	deploymentRolloutPollInterval = time.Second
 	deploymentRolloutTimeout      = 5 * time.Minute
+	daemonsetRolloutPollInterval  = time.Second
+	daemonsetRolloutTimeout       = 5 * time.Minute
+	machineAPITerminationHandler  = "machine-api-termination-handler"
 )
 
 func (optr *Operator) syncAll(config *OperatorConfig) error {
@@ -41,7 +44,16 @@ func (optr *Operator) syncAll(config *OperatorConfig) error {
 	}
 
 	if config.Controllers.TerminationHandler != clusterAPIControllerNoOp {
-
+		if err := optr.syncTerminationHandler(config); err != nil {
+			if err := optr.statusDegraded(err.Error()); err != nil {
+				// Just log the error here.  We still want to
+				// return the outer error.
+				glog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
+			}
+			glog.Errorf("Error syncing machine-api-termination-handler: %v", err)
+			return err
+		}
+		glog.V(3).Info("Synced up all machine-api-termination-handler components")
 	}
 
 	// In addition, if the Provider is BareMetal, then bring up
@@ -86,6 +98,30 @@ func (optr *Operator) syncClusterAPIController(config *OperatorConfig) error {
 	}
 	if updated {
 		return optr.waitForDeploymentRollout(controllersDeployment)
+	}
+	return nil
+}
+
+func (optr *Operator) syncTerminationHandler(config *OperatorConfig) error {
+	terminationDaemonSet := newTerminationDaemonSet(config)
+	ds, err := optr.daemonsetLister.DaemonSets(terminationDaemonSet.GetNamespace()).Get(terminationDaemonSet.GetName())
+	generation := int64(-1)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	}
+	if ds != nil {
+		generation = ds.Status.ObservedGeneration
+	}
+
+	_, updated, err := resourceapply.ApplyDaemonSet(optr.kubeClient.AppsV1(),
+		events.NewLoggingEventRecorder(optr.name), terminationDaemonSet, generation, false)
+	if err != nil {
+		return err
+	}
+	if updated {
+		return optr.waitForDaemonSetRollout(terminationDaemonSet)
 	}
 	return nil
 }
@@ -152,6 +188,40 @@ func (optr *Operator) waitForDeploymentRollout(resource *appsv1.Deployment) erro
 			return true, nil
 		}
 		lastError = fmt.Errorf("deployment %s is not ready. status: (replicas: %d, updated: %d, ready: %d, unavailable: %d)", d.Name, d.Status.Replicas, d.Status.UpdatedReplicas, d.Status.ReadyReplicas, d.Status.UnavailableReplicas)
+		glog.V(4).Info(lastError)
+		return false, nil
+	})
+	if lastError != nil {
+		return lastError
+	}
+	return err
+}
+
+func (optr *Operator) waitForDaemonSetRollout(resource *appsv1.DaemonSet) error {
+	var lastError error
+	err := wait.Poll(daemonsetRolloutPollInterval, daemonsetRolloutTimeout, func() (bool, error) {
+		d, err := optr.daemonsetLister.DaemonSets(resource.Namespace).Get(resource.Name)
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		if err != nil {
+			// Do not return error here, as we could be updating the API Server itself, in which case we
+			// want to continue waiting.
+			lastError = fmt.Errorf("getting DaemonSet %s during rollout: %v", resource.Name, err)
+			glog.Error(lastError)
+			return false, nil
+		}
+
+		if d.DeletionTimestamp != nil {
+			lastError = nil
+			return false, fmt.Errorf("daemonset %s is being deleted", resource.Name)
+		}
+
+		if d.Generation <= d.Status.ObservedGeneration && d.Status.UpdatedNumberScheduled == d.Status.DesiredNumberScheduled && d.Status.NumberUnavailable == 0 {
+			lastError = nil
+			return true, nil
+		}
+		lastError = fmt.Errorf("daemonset %s is not ready. status: (desired: %d, updated: %d, available: %d, unavailable: %d)", d.Name, d.Status.DesiredNumberScheduled, d.Status.UpdatedNumberScheduled, d.Status.NumberAvailable, d.Status.NumberUnavailable)
 		glog.V(4).Info(lastError)
 		return false, nil
 	})
@@ -293,7 +363,7 @@ func newTerminationDaemonSet(config *OperatorConfig) *appsv1.DaemonSet {
 
 	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "machine-api-termination-handler",
+			Name:      machineAPITerminationHandler,
 			Namespace: config.TargetNamespace,
 			Annotations: map[string]string{
 				maoOwnedAnnotation: "",
@@ -317,12 +387,6 @@ func newTerminationDaemonSet(config *OperatorConfig) *appsv1.DaemonSet {
 
 func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSpec {
 	containers := newTerminationContainers(config)
-	// Tolerate any taint, node selector will ensure the pod only runs where required
-	tolerations := []corev1.Toleration{
-		{
-			Operator: corev1.TolerationOpExists,
-		},
-	}
 
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
@@ -335,8 +399,7 @@ func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSp
 			Containers:         containers,
 			PriorityClassName:  "system-node-critical",
 			NodeSelector:       map[string]string{machinecontroller.MachineInterruptibleInstanceLabelName: ""},
-			ServiceAccountName: "machine-api-termination-handler",
-			Tolerations:        tolerations,
+			ServiceAccountName: machineAPITerminationHandler,
 			HostNetwork:        true,
 		},
 	}


### PR DESCRIPTION
This PR enables the Machine API Operator to run the Termination Handler added to the AWS cloud provider in https://github.com/openshift/cluster-api-provider-aws/pull/308 by running a DaemonSet on nodes labelled as interruptible

Need to test on a real cluster before this merges

/hold