### PR TITLE
vsphere ipi: add extra config key with guestinfo hostname

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -36,6 +36,7 @@ const (
 const (
 	GuestInfoIgnitionData     = "guestinfo.ignition.config.data"
 	GuestInfoIgnitionEncoding = "guestinfo.ignition.config.data.encoding"
+	GuestInfoHostname         = "guestinfo.hostname"
 )
 
 // Reconciler runs the logic to reconciles a machine resource towards its desired state
@@ -389,6 +390,14 @@ func clone(s *machineScope) error {
 	var deviceSpecs []types.BaseVirtualDeviceConfigSpec
 	deviceSpecs = append(deviceSpecs, networkDevices...)
 
+	extraConfig := []types.BaseOptionValue{}
+
+	extraConfig = append(extraConfig, IgnitionConfig(userData)...)
+	extraConfig = append(extraConfig, &types.OptionValue{
+		Key:   GuestInfoHostname,
+		Value: s.machine.GetName(),
+	})
+
 	spec := types.VirtualMachineCloneSpec{
 		Config: &types.VirtualMachineConfigSpec{
 			Annotation: s.machine.GetName(),
@@ -397,7 +406,7 @@ func clone(s *machineScope) error {
 			// the VM's UUID.
 			InstanceUuid: string(s.machine.UID),
 			Flags:        newVMFlagInfo(),
-			ExtraConfig:  IgnitionConfig(userData),
+			ExtraConfig:  extraConfig,
 			// TODO: set disk devices
 			DeviceChange:      deviceSpecs,
 			NumCPUs:           numCPUs,


### PR DESCRIPTION
To support setting the hostname of the RHCOS guest
add a extra config key/value `guestinfo.hostname`.