### PR TITLE
[OCPCLOUD-818] Tag vms with cluster id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/prometheus/procfs v0.0.5 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/vmware/govmomi v0.21.0
+	github.com/vmware/govmomi v0.22.2
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	google.golang.org/appengine v1.6.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -397,8 +397,8 @@ github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijb
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
-github.com/vmware/govmomi v0.21.0 h1:jc8uMuxpcV2xMAA/cnEDlnsIjvqcMra5Y8onh/U3VuY=
-github.com/vmware/govmomi v0.21.0/go.mod h1:zbnFoBQ9GIjs2RVETy8CNEpb+L+Lwkjs3XZUL0B3/m0=
+github.com/vmware/govmomi v0.22.2 h1:hmLv4f+RMTTseqtJRijjOWzwELiaLMIoHv2D6H3bF4I=
+github.com/vmware/govmomi v0.22.2/go.mod h1:Y+Wq4lst78L85Ge/F8+ORXIWiKYqaro1vhAulACy9Lc=
 github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728/go.mod h1:x9oS4Wk2s2u4tS29nEaDLdzvuHdB19CvSGJjPgkZJNk=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=

--- a/vendor/github.com/vmware/govmomi/.mailmap
+++ b/vendor/github.com/vmware/govmomi/.mailmap
@@ -27,3 +27,4 @@ Zee Yang <zeey@vmware.com> <zee.yang@gmail.com>
 Jiatong Wang <wjiatong@vmware.com> jiatongw <wjiatong@vmware.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <u.bessle.extern@eos-ts.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de> Uwe Bessle <uwe.bessle@web.de>
+Lintong Jiang <lintongj@vmware.com> lintongj <55512168+lintongj@users.noreply.github.com>

--- a/vendor/github.com/vmware/govmomi/.travis.yml
+++ b/vendor/github.com/vmware/govmomi/.travis.yml
@@ -12,7 +12,7 @@ services:       false
 
 # Set the version of Go.
 language:       go
-go:             1.12
+go:             1.13
 
 # Always set the project's Go import path to ensure that forked
 # builds get cloned to the correct location.
@@ -35,7 +35,7 @@ jobs:
     - <<:            *lint-stage
       env:           LINTER=goimports
 
-    # The "build" stage verifies the program can be built against the 
+    # The "build" stage verifies the program can be built against the
     # various GOOS and GOARCH combinations found in the Go releaser
     # config file, ".goreleaser.yml".
     - &build-stage

--- a/vendor/github.com/vmware/govmomi/CHANGELOG.md
+++ b/vendor/github.com/vmware/govmomi/CHANGELOG.md
@@ -1,5 +1,57 @@
 # changelog
 
+### 0.22.1 (2020-01-13)
+
+* Fix SAML token auth using Holder-of-Key with delegated Bearer identity against 6.7 U3b+
+
+### 0.22.0 (2020-01-10)
+
+* Add OVF properties to library.Deploy method
+
+* Add retry support for HTTP status codes
+
+* Use cs.identity service type for sts endpoint lookups
+
+* Add Content Library VM template APIs
+
+* Add SearchIndex FindAllByDnsName and FindAllByIp methods
+
+* Fix HostSystem.ManagementIPs to use SelectedVnic
+
+* Change generated ResourceReductionToToleratePercent to pointer type
+
+* Add DistributedVirtualSwitch.ReconfigureDVPort method
+
+* Add VirtualMachine.IsTemplate method
+
+* Add GetInventoryPath to NetworkReference interface
+
+* Support HoK tokens with Interactive Users
+
+* Replace mo.LoadRetrievePropertiesResponse with mo.LoadObjectContent
+
+* Add VirtualHardwareSection.StorageItem
+
+* Add ResourcePool.Owner method
+
+* Add VirtualMachine.QueryChangedDiskAreas method
+
+* Update generated code to vSphere 6.7u3
+
+* Add option to propagate MissingSet faults in property.WaitForUpdates
+
+* Add content library subscription support
+
+* Fix deadlock for keep alive handlers that attempt log in
+
+* Add CNS API bindings
+
+* Add FetchCapabilityMetadata method to Pbm client
+
+* Add v4 option to VirtualMachine.WaitForIP
+
+* Add VirtualHardwareSection.StorageItem
+
 ### 0.21.0 (2019-07-24)
 
 * Add vsan package

--- a/vendor/github.com/vmware/govmomi/CONTRIBUTORS
+++ b/vendor/github.com/vmware/govmomi/CONTRIBUTORS
@@ -22,10 +22,12 @@ Anfernee Yongkun Gui <agui@vmware.com>
 angystardust <angystardust@users.noreply.github.com>
 aniketGslab <aniket.shinde@gslab.com>
 Arran Walker <arran.walker@zopa.com>
+Artem Anisimov <aanisimov@inbox.ru>
 Aryeh Weinreb <aryehweinreb@gmail.com>
 Austin Parker <aparker@apprenda.com>
 Balu Dontu <bdontu@vmware.com>
 bastienbc <bastien.barbe.creuly@gmail.com>
+Ben Corrie <bcorrie@vmware.com>
 Benjamin Peterson <benjamin@python.org>
 Bob Killen <killen.bob@gmail.com>
 Brad Fitzpatrick <bradfitz@golang.org>
@@ -35,15 +37,21 @@ Chris Marchesi <chrism@vancluevertech.com>
 Christian Höltje <docwhat@gerf.org>
 Clint Greenwood <cgreenwood@vmware.com>
 CuiHaozhi <cuihaozhi@chinacloud.com.cn>
+Daniel Mueller <deso@posteo.net>
 Danny Lockard <danny.lockard@banno.com>
+Dave Gress <gressd@vmware.com>
 Dave Smith-Uchida <dsmithuchida@vmware.com>
 Dave Tucker <dave@dtucker.co.uk>
 Davide Agnello <dagnello@hp.com>
 David Stark <dave@davidstark.name>
 Davinder Kumar <davinderk@vmware.com>
+dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
 Deric Crago <deric.crago@gmail.com>
+Divyen Patel <divyenp@vmware.com>
 Doug MacEachern <dougm@vmware.com>
 Eloy Coto <eloy.coto@gmail.com>
+Eric Edens <ericedens@google.com>
+Eric Graham <16710890+Pheric@users.noreply.github.com>
 Eric Gray <egray@vmware.com>
 Eric Yutao <eric.yutao@gmail.com>
 Erik Hollensbe <github@hollensbe.org>
@@ -51,6 +59,7 @@ Ethan Kaley <ethan.kaley@emc.com>
 Fabio Rapposelli <fabio@vmware.com>
 Faiyaz Ahmed <ahmedf@vmware.com>
 forkbomber <forkbomber@users.noreply.github.com>
+François Rigault <rigault.francois@gmail.com>
 freebsdly <qinhuajun@outlook.com>
 Gavin Gray <gavin@infinio.com>
 Gavrie Philipson <gavrie.philipson@elastifile.com>
@@ -59,23 +68,29 @@ Gerrit Renker <Gerrit.Renker@ctl.io>
 gthombare <gthombare@vmware.com>
 Hasan Mahmood <mahmoodh@vmware.com>
 Henrik Hodne <henrik@travis-ci.com>
+hkumar <hkumar@vmware.com>
 hui luo <luoh@vmware.com>
 Isaac Rodman <isaac@eyz.us>
+Ivan Mikushin <imikushin@vmware.com>
 Ivan Porto Carrero <icarrero@vmware.com>
 James King <james.king@emc.com>
 Jason Kincl <jkincl@gmail.com>
 Jeremy Canady <jcanady@jackhenry.com>
 jeremy-clerc <jeremy@clerc.io>
 Jiatong Wang <wjiatong@vmware.com>
+jingyizPensando <jingyiz@pensando.io>
 João Pereira <joaodrp@gmail.com>
 Jonas Ausevicius <jonas.ausevicius@virtustream.com>
 Jorge Sevilla <jorge.sevilla@rstor.io>
 kayrus <kay.diam@gmail.com>
 Kevin George <georgek@vmware.com>
 leslie-qiwa <leslie.qiwa@gmail.com>
+Lintong Jiang <lintongj@vmware.com>
 Louie Jiang <jiangl@vmware.com>
+Luther Monson <luther.monson@gmail.com>
 maplain <fangyuanl@vmware.com>
 Marc Carmier <mcarmier@gmail.com>
+Marcus Tan <marcus.tan@rubrik.com>
 Maria Ntalla <maria.ntalla@gmail.com>
 Marin Atanasov Nikolov <mnikolov@vmware.com>
 Mario Trangoni <mjtrangoni@gmail.com>
@@ -97,6 +112,9 @@ Rowan Jacobs <rojacobs@pivotal.io>
 runner.mei <runner.mei@gmail.com>
 S.Çağlar Onur <conur@vmware.com>
 Sergey Ignatov <sergey.ignatov@jetbrains.com>
+serokles <timbo.alexander@gmail.com>
+Shawn Neal <sneal@sneal.net>
+sky-joker <sky.jokerxx@gmail.com>
 Sten Feldman <exile@chamber.ee>
 Stepan Mazurov <smazurov@gmail.com>
 Steve Purcell <steve@sanityinc.com>
@@ -104,9 +122,11 @@ Takaaki Furukawa <takaaki.frkw@gmail.com>
 Tamas Eger <tamas.eger@bitrise.io>
 tanishi <tanishi503@gmail.com>
 Ted Zlatanov <tzz@lifelogs.com>
+Thad Craft <tcraft@pivotal.io>
 Thibaut Ackermann <thibaut.ackermann@alcatel-lucent.com>
 Tim McNamara <tim.mcnamara@canonical.com>
 Tjeu Kayim <15987676+TjeuKayim@users.noreply.github.com>
+Toomas Pelberg <toomas.pelberg@playtech.com>
 Trevor Dawe <trevor.dawe@gmail.com>
 Uwe Bessle <Uwe.Bessle@iteratec.de>
 Vadim Egorov <vegorov@vmware.com>

--- a/vendor/github.com/vmware/govmomi/README.md
+++ b/vendor/github.com/vmware/govmomi/README.md
@@ -28,7 +28,7 @@ The code in the `govmomi` package is a wrapper for the code that is generated fr
 It primarily provides convenience functions for working with the vSphere API.
 See [godoc.org][godoc] for documentation.
 
-[apiref]:http://pubs.vmware.com/vsphere-6-5/index.jsp#com.vmware.wssdk.apiref.doc/right-pane.html
+[apiref]:https://code.vmware.com/apis/196/vsphere
 [godoc]:http://godoc.org/github.com/vmware/govmomi
 
 ## Installation

--- a/vendor/github.com/vmware/govmomi/go.mod
+++ b/vendor/github.com/vmware/govmomi/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/kr/text v0.1.0 // indirect
 	github.com/vmware/vmw-guestinfo v0.0.0-20170707015358-25eff159a728
 )
+
+go 1.13

--- a/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
+++ b/vendor/github.com/vmware/govmomi/object/cluster_compute_resource.go
@@ -87,3 +87,17 @@ func (c ClusterComputeResource) MoveInto(ctx context.Context, hosts ...*HostSyst
 
 	return NewTask(c.c, res.Returnval), nil
 }
+
+func (c ClusterComputeResource) PlaceVm(ctx context.Context, spec types.PlacementSpec) (*types.PlacementResult, error) {
+	req := types.PlaceVm{
+		This:          c.Reference(),
+		PlacementSpec: spec,
+	}
+
+	res, err := methods.PlaceVm(ctx, c.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res.Returnval, nil
+}

--- a/vendor/github.com/vmware/govmomi/object/customization_spec_manager.go
+++ b/vendor/github.com/vmware/govmomi/object/customization_spec_manager.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -34,6 +35,12 @@ func NewCustomizationSpecManager(c *vim25.Client) *CustomizationSpecManager {
 	}
 
 	return &cs
+}
+
+func (cs CustomizationSpecManager) Info(ctx context.Context) ([]types.CustomizationSpecInfo, error) {
+	var m mo.CustomizationSpecManager
+	err := cs.Properties(ctx, cs.Reference(), []string{"info"}, &m)
+	return m.Info, err
 }
 
 func (cs CustomizationSpecManager) DoesCustomizationSpecExist(ctx context.Context, name string) (bool, error) {

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_portgroup.go
@@ -36,6 +36,10 @@ func NewDistributedVirtualPortgroup(c *vim25.Client, ref types.ManagedObjectRefe
 	}
 }
 
+func (p DistributedVirtualPortgroup) GetInventoryPath() string {
+	return p.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this DistributedVirtualPortgroup
 func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var dvp mo.DistributedVirtualPortgroup
@@ -46,9 +50,15 @@ func (p DistributedVirtualPortgroup) EthernetCardBackingInfo(ctx context.Context
 		return nil, err
 	}
 
+	// From the docs at https://code.vmware.com/apis/196/vsphere/doc/vim.dvs.DistributedVirtualPortgroup.ConfigInfo.html:
 	// "This property should always be set unless the user's setting does not have System.Read privilege on the object referred to by this property."
+	// Note that "the object" refers to the Switch, not the PortGroup.
 	if dvp.Config.DistributedVirtualSwitch == nil {
-		return nil, fmt.Errorf("no System.Read privilege on: %s.%s", p.Reference(), prop)
+		name := p.InventoryPath
+		if name == "" {
+			name = p.Reference().String()
+		}
+		return nil, fmt.Errorf("failed to create EthernetCardBackingInfo for %s: System.Read privilege required for %s", name, prop)
 	}
 
 	if err := p.Properties(ctx, *dvp.Config.DistributedVirtualSwitch, []string{"uuid"}, &dvs); err != nil {

--- a/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
+++ b/vendor/github.com/vmware/govmomi/object/distributed_virtual_switch.go
@@ -18,6 +18,7 @@ package object
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -34,8 +35,17 @@ func NewDistributedVirtualSwitch(c *vim25.Client, ref types.ManagedObjectReferen
 	}
 }
 
+func (s DistributedVirtualSwitch) GetInventoryPath() string {
+	return s.InventoryPath
+}
+
 func (s DistributedVirtualSwitch) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
-	return nil, ErrNotSupported // TODO: just to satisfy NetworkReference interface for the finder
+	ref := s.Reference()
+	name := s.InventoryPath
+	if name == "" {
+		name = ref.String()
+	}
+	return nil, fmt.Errorf("type %s (%s) cannot be used for EthernetCardBackingInfo", ref.Type, name)
 }
 
 func (s DistributedVirtualSwitch) Reconfigure(ctx context.Context, spec types.BaseDVSConfigSpec) (*Task, error) {
@@ -77,4 +87,18 @@ func (s DistributedVirtualSwitch) FetchDVPorts(ctx context.Context, criteria *ty
 		return nil, err
 	}
 	return res.Returnval, nil
+}
+
+func (s DistributedVirtualSwitch) ReconfigureDVPort(ctx context.Context, spec []types.DVPortConfigSpec) (*Task, error) {
+	req := types.ReconfigureDVPort_Task{
+		This: s.Reference(),
+		Port: spec,
+	}
+
+	res, err := methods.ReconfigureDVPort_Task(ctx, s.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewTask(s.Client(), res.Returnval), nil
 }

--- a/vendor/github.com/vmware/govmomi/object/host_system.go
+++ b/vendor/github.com/vmware/govmomi/object/host_system.go
@@ -83,14 +83,21 @@ func (h HostSystem) ManagementIPs(ctx context.Context) ([]net.IP, error) {
 
 	var ips []net.IP
 	for _, nc := range mh.Config.VirtualNicManagerInfo.NetConfig {
-		if nc.NicType == "management" && len(nc.CandidateVnic) > 0 {
-			ip := net.ParseIP(nc.CandidateVnic[0].Spec.Ip.IpAddress)
-			if ip != nil {
-				ips = append(ips, ip)
+		if nc.NicType != string(types.HostVirtualNicManagerNicTypeManagement) {
+			continue
+		}
+		for ix := range nc.CandidateVnic {
+			for _, selectedVnicKey := range nc.SelectedVnic {
+				if nc.CandidateVnic[ix].Key != selectedVnicKey {
+					continue
+				}
+				ip := net.ParseIP(nc.CandidateVnic[ix].Spec.Ip.IpAddress)
+				if ip != nil {
+					ips = append(ips, ip)
+				}
 			}
 		}
 	}
-
 	return ips, nil
 }
 

--- a/vendor/github.com/vmware/govmomi/object/network.go
+++ b/vendor/github.com/vmware/govmomi/object/network.go
@@ -34,6 +34,10 @@ func NewNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Network {
 	}
 }
 
+func (n Network) GetInventoryPath() string {
+	return n.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n Network) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var e mo.Network

--- a/vendor/github.com/vmware/govmomi/object/network_reference.go
+++ b/vendor/github.com/vmware/govmomi/object/network_reference.go
@@ -26,6 +26,6 @@ import (
 // which can be used as the backing for a VirtualEthernetCard.
 type NetworkReference interface {
 	Reference
-
+	GetInventoryPath() string
 	EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error)
 }

--- a/vendor/github.com/vmware/govmomi/object/opaque_network.go
+++ b/vendor/github.com/vmware/govmomi/object/opaque_network.go
@@ -35,6 +35,10 @@ func NewOpaqueNetwork(c *vim25.Client, ref types.ManagedObjectReference) *Opaque
 	}
 }
 
+func (n OpaqueNetwork) GetInventoryPath() string {
+	return n.InventoryPath
+}
+
 // EthernetCardBackingInfo returns the VirtualDeviceBackingInfo for this Network
 func (n OpaqueNetwork) EthernetCardBackingInfo(ctx context.Context) (types.BaseVirtualDeviceBackingInfo, error) {
 	var net mo.OpaqueNetwork

--- a/vendor/github.com/vmware/govmomi/object/resource_pool.go
+++ b/vendor/github.com/vmware/govmomi/object/resource_pool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/vmware/govmomi/nfc"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
@@ -33,6 +34,18 @@ func NewResourcePool(c *vim25.Client, ref types.ManagedObjectReference) *Resourc
 	return &ResourcePool{
 		Common: NewCommon(c, ref),
 	}
+}
+
+// Owner returns the ResourcePool owner as a ClusterComputeResource or ComputeResource.
+func (p ResourcePool) Owner(ctx context.Context) (Reference, error) {
+	var pool mo.ResourcePool
+
+	err := p.Properties(ctx, p.Reference(), []string{"owner"}, &pool)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewReference(p.Client(), pool.Owner), nil
 }
 
 func (p ResourcePool) ImportVApp(ctx context.Context, spec types.BaseImportSpec, folder *Folder, host *HostSystem) (*nfc.Lease, error) {

--- a/vendor/github.com/vmware/govmomi/object/search_index.go
+++ b/vendor/github.com/vmware/govmomi/object/search_index.go
@@ -161,3 +161,88 @@ func (s SearchIndex) FindChild(ctx context.Context, entity Reference, name strin
 	}
 	return NewReference(s.c, *res.Returnval), nil
 }
+
+// FindAllByDnsName finds all virtual machines or hosts by DNS name.
+func (s SearchIndex) FindAllByDnsName(ctx context.Context, dc *Datacenter, dnsName string, vmSearch bool) ([]Reference, error) {
+	req := types.FindAllByDnsName{
+		This:     s.Reference(),
+		DnsName:  dnsName,
+		VmSearch: vmSearch,
+	}
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	res, err := methods.FindAllByDnsName(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Returnval) == 0 {
+		return nil, nil
+	}
+
+	var references []Reference
+	for _, returnval := range res.Returnval {
+		references = append(references, NewReference(s.c, returnval))
+	}
+	return references, nil
+}
+
+// FindAllByIp finds all virtual machines or hosts by IP address.
+func (s SearchIndex) FindAllByIp(ctx context.Context, dc *Datacenter, ip string, vmSearch bool) ([]Reference, error) {
+	req := types.FindAllByIp{
+		This:     s.Reference(),
+		Ip:       ip,
+		VmSearch: vmSearch,
+	}
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	res, err := methods.FindAllByIp(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Returnval) == 0 {
+		return nil, nil
+	}
+
+	var references []Reference
+	for _, returnval := range res.Returnval {
+		references = append(references, NewReference(s.c, returnval))
+	}
+	return references, nil
+}
+
+// FindAllByUuid finds all virtual machines or hosts by UUID.
+func (s SearchIndex) FindAllByUuid(ctx context.Context, dc *Datacenter, uuid string, vmSearch bool, instanceUuid *bool) ([]Reference, error) {
+	req := types.FindAllByUuid{
+		This:         s.Reference(),
+		Uuid:         uuid,
+		VmSearch:     vmSearch,
+		InstanceUuid: instanceUuid,
+	}
+	if dc != nil {
+		ref := dc.Reference()
+		req.Datacenter = &ref
+	}
+
+	res, err := methods.FindAllByUuid(ctx, s.c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Returnval) == 0 {
+		return nil, nil
+	}
+
+	var references []Reference
+	for _, returnval := range res.Returnval {
+		references = append(references, NewReference(s.c, returnval))
+	}
+	return references, nil
+}

--- a/vendor/github.com/vmware/govmomi/object/virtual_machine.go
+++ b/vendor/github.com/vmware/govmomi/object/virtual_machine.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	PropRuntimePowerState = "summary.runtime.powerState"
+	PropConfigTemplate    = "summary.config.template"
 )
 
 type VirtualMachine struct {
@@ -54,6 +55,17 @@ func (v VirtualMachine) PowerState(ctx context.Context) (types.VirtualMachinePow
 	}
 
 	return o.Summary.Runtime.PowerState, nil
+}
+
+func (v VirtualMachine) IsTemplate(ctx context.Context) (bool, error) {
+	var o mo.VirtualMachine
+
+	err := v.Properties(ctx, v.Reference(), []string{PropConfigTemplate}, &o)
+	if err != nil {
+		return false, err
+	}
+
+	return o.Summary.Config.Template, nil
 }
 
 func (v VirtualMachine) PowerOn(ctx context.Context) (*Task, error) {
@@ -221,7 +233,9 @@ func (v VirtualMachine) RefreshStorageInfo(ctx context.Context) error {
 	return err
 }
 
-func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
+// WaitForIP waits for the VM guest.ipAddress property to report an IP address.
+// Waits for an IPv4 address if the v4 param is true.
+func (v VirtualMachine) WaitForIP(ctx context.Context, v4 ...bool) (string, error) {
 	var ip string
 
 	p := property.DefaultCollector(v.c)
@@ -238,6 +252,11 @@ func (v VirtualMachine) WaitForIP(ctx context.Context) (string, error) {
 			}
 
 			ip = c.Val.(string)
+			if len(v4) == 1 && v4[0] {
+				if net.ParseIP(ip).To4() == nil {
+					return false
+				}
+			}
 			return true
 		}
 
@@ -838,4 +857,68 @@ func (v VirtualMachine) UUID(ctx context.Context) string {
 	}
 
 	return o.Config.Uuid
+}
+
+func (v VirtualMachine) QueryChangedDiskAreas(ctx context.Context, baseSnapshot, curSnapshot *types.ManagedObjectReference, disk *types.VirtualDisk, offset int64) (types.DiskChangeInfo, error) {
+	var noChange types.DiskChangeInfo
+	var err error
+
+	if offset > disk.CapacityInBytes {
+		return noChange, fmt.Errorf("offset is greater than the disk size (%#x and %#x)", offset, disk.CapacityInBytes)
+	} else if offset == disk.CapacityInBytes {
+		return types.DiskChangeInfo{StartOffset: offset, Length: 0}, nil
+	}
+
+	var b mo.VirtualMachineSnapshot
+	err = v.Properties(ctx, baseSnapshot.Reference(), []string{"config.hardware"}, &b)
+	if err != nil {
+		return noChange, fmt.Errorf("failed to fetch config.hardware of snapshot %s: %s", baseSnapshot, err)
+	}
+
+	var changeId *string
+	for _, vd := range b.Config.Hardware.Device {
+		d := vd.GetVirtualDevice()
+		if d.Key != disk.Key {
+			continue
+		}
+
+		// As per VDDK programming guide, these are the four types of disks
+		// that support CBT, see "Gathering Changed Block Information".
+		if b, ok := d.Backing.(*types.VirtualDiskFlatVer2BackingInfo); ok {
+			changeId = &b.ChangeId
+			break
+		}
+		if b, ok := d.Backing.(*types.VirtualDiskSparseVer2BackingInfo); ok {
+			changeId = &b.ChangeId
+			break
+		}
+		if b, ok := d.Backing.(*types.VirtualDiskRawDiskMappingVer1BackingInfo); ok {
+			changeId = &b.ChangeId
+			break
+		}
+		if b, ok := d.Backing.(*types.VirtualDiskRawDiskVer2BackingInfo); ok {
+			changeId = &b.ChangeId
+			break
+		}
+
+		return noChange, fmt.Errorf("disk %d has backing info without .ChangeId: %t", disk.Key, d.Backing)
+	}
+	if changeId == nil || *changeId == "" {
+		return noChange, fmt.Errorf("CBT is not enabled on disk %d", disk.Key)
+	}
+
+	req := types.QueryChangedDiskAreas{
+		This:        v.Reference(),
+		Snapshot:    curSnapshot,
+		DeviceKey:   disk.Key,
+		StartOffset: offset,
+		ChangeId:    *changeId,
+	}
+
+	res, err := methods.QueryChangedDiskAreas(ctx, v.Client(), &req)
+	if err != nil {
+		return noChange, err
+	}
+
+	return res.Returnval, nil
 }

--- a/vendor/github.com/vmware/govmomi/object/vmware_distributed_virtual_switch.go
+++ b/vendor/github.com/vmware/govmomi/object/vmware_distributed_virtual_switch.go
@@ -19,3 +19,7 @@ package object
 type VmwareDistributedVirtualSwitch struct {
 	DistributedVirtualSwitch
 }
+
+func (s VmwareDistributedVirtualSwitch) GetInventoryPath() string {
+	return s.InventoryPath
+}

--- a/vendor/github.com/vmware/govmomi/ovf/cim.go
+++ b/vendor/github.com/vmware/govmomi/ovf/cim.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package ovf
 
+import (
+	"github.com/vmware/govmomi/vim25/types"
+)
+
 /*
 Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_VirtualSystemSettingData.xsd
 */
@@ -75,4 +79,50 @@ type CIMResourceAllocationSettingData struct {
 	VirtualQuantity       *uint    `xml:"VirtualQuantity"`
 	VirtualQuantityUnits  *string  `xml:"VirtualQuantityUnits"`
 	Weight                *uint    `xml:"Weight"`
+}
+
+/*
+Source: http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.24.0/CIM_StorageAllocationSettingData.xsd
+*/
+type CIMStorageAllocationSettingData struct {
+	ElementName string `xml:"ElementName"`
+	InstanceID  string `xml:"InstanceID"`
+
+	ResourceType      *uint16 `xml:"ResourceType"`
+	OtherResourceType *string `xml:"OtherResourceType"`
+	ResourceSubType   *string `xml:"ResourceSubType"`
+
+	Access                       *uint16         `xml:"Access"`
+	Address                      *string         `xml:"Address"`
+	AddressOnParent              *string         `xml:"AddressOnParent"`
+	AllocationUnits              *string         `xml:"AllocationUnits"`
+	AutomaticAllocation          *bool           `xml:"AutomaticAllocation"`
+	AutomaticDeallocation        *bool           `xml:"AutomaticDeallocation"`
+	Caption                      *string         `xml:"Caption"`
+	ChangeableType               *uint16         `xml:"ChangeableType"`
+	ComponentSetting             []types.AnyType `xml:"ComponentSetting"`
+	ConfigurationName            *string         `xml:"ConfigurationName"`
+	Connection                   []string        `xml:"Connection"`
+	ConsumerVisibility           *uint16         `xml:"ConsumerVisibility"`
+	Description                  *string         `xml:"Description"`
+	Generation                   *uint64         `xml:"Generation"`
+	HostExtentName               *string         `xml:"HostExtentName"`
+	HostExtentNameFormat         *uint16         `xml:"HostExtentNameFormat"`
+	HostExtentNameNamespace      *uint16         `xml:"HostExtentNameNamespace"`
+	HostExtentStartingAddress    *uint64         `xml:"HostExtentStartingAddress"`
+	HostResource                 []string        `xml:"HostResource"`
+	HostResourceBlockSize        *uint64         `xml:"HostResourceBlockSize"`
+	Limit                        *uint64         `xml:"Limit"`
+	MappingBehavior              *uint           `xml:"MappingBehavior"`
+	OtherHostExtentNameFormat    *string         `xml:"OtherHostExtentNameFormat"`
+	OtherHostExtentNameNamespace *string         `xml:"OtherHostExtentNameNamespace"`
+	Parent                       *string         `xml:"Parent"`
+	PoolID                       *string         `xml:"PoolID"`
+	Reservation                  *uint64         `xml:"Reservation"`
+	SoID                         *string         `xml:"SoID"`
+	SoOrgID                      *string         `xml:"SoOrgID"`
+	VirtualQuantity              *uint           `xml:"VirtualQuantity"`
+	VirtualQuantityUnits         *string         `xml:"VirtualQuantityUnits"`
+	VirtualResourceBlockSize     *uint64         `xml:"VirtualResourceBlockSize"`
+	Weight                       *uint           `xml:"Weight"`
 }

--- a/vendor/github.com/vmware/govmomi/ovf/envelope.go
+++ b/vendor/github.com/vmware/govmomi/ovf/envelope.go
@@ -154,8 +154,9 @@ type VirtualHardwareSection struct {
 	ID        *string `xml:"id,attr"`
 	Transport *string `xml:"transport,attr"`
 
-	System *VirtualSystemSettingData       `xml:"System"`
-	Item   []ResourceAllocationSettingData `xml:"Item"`
+	System      *VirtualSystemSettingData       `xml:"System"`
+	Item        []ResourceAllocationSettingData `xml:"Item"`
+	StorageItem []StorageAllocationSettingData  `xml:"StorageItem"`
 }
 
 type VirtualSystemSettingData struct {
@@ -164,6 +165,14 @@ type VirtualSystemSettingData struct {
 
 type ResourceAllocationSettingData struct {
 	CIMResourceAllocationSettingData
+
+	Required      *bool   `xml:"required,attr"`
+	Configuration *string `xml:"configuration,attr"`
+	Bound         *string `xml:"bound,attr"`
+}
+
+type StorageAllocationSettingData struct {
+	CIMStorageAllocationSettingData
 
 	Required      *bool   `xml:"required,attr"`
 	Configuration *string `xml:"configuration,attr"`

--- a/vendor/github.com/vmware/govmomi/property/collector.go
+++ b/vendor/github.com/vmware/govmomi/property/collector.go
@@ -179,7 +179,7 @@ func (p *Collector) Retrieve(ctx context.Context, objs []types.ManagedObjectRefe
 		return nil
 	}
 
-	return mo.LoadRetrievePropertiesResponse(res, dst)
+	return mo.LoadObjectContent(res.Returnval, dst)
 }
 
 // RetrieveWithFilter populates dst as Retrieve does, but only for entities matching the given filter.

--- a/vendor/github.com/vmware/govmomi/property/wait.go
+++ b/vendor/github.com/vmware/govmomi/property/wait.go
@@ -20,13 +20,15 @@ import (
 	"context"
 
 	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/soap"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 // WaitFilter provides helpers to construct a types.CreateFilter for use with property.Wait
 type WaitFilter struct {
 	types.CreateFilter
-	Options *types.WaitOptions
+	Options          *types.WaitOptions
+	PropagateMissing bool
 }
 
 // Add a new ObjectSpec and PropertySpec to the WaitFilter
@@ -81,6 +83,8 @@ func Wait(ctx context.Context, c *Collector, obj types.ManagedObjectReference, p
 // The newly created collector is destroyed before this function returns (both
 // in case of success or error).
 //
+// By default, ObjectUpdate.MissingSet faults are not propagated to the returned error,
+// set WaitFilter.PropagateMissing=true to enable MissingSet fault propagation.
 func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f func([]types.ObjectUpdate) bool) error {
 	p, err := c.Create(ctx)
 	if err != nil {
@@ -125,6 +129,15 @@ func WaitForUpdates(ctx context.Context, c *Collector, filter *WaitFilter, f fun
 		req.Version = set.Version
 
 		for _, fs := range set.FilterSet {
+			if filter.PropagateMissing {
+				for i := range fs.ObjectSet {
+					for _, p := range fs.ObjectSet[i].MissingSet {
+						// Same behavior as mo.ObjectContentToType()
+						return soap.WrapVimFault(p.Fault.Fault)
+					}
+				}
+			}
+
 			if f(fs.ObjectSet) {
 				return nil
 			}

--- a/vendor/github.com/vmware/govmomi/session/keep_alive.go
+++ b/vendor/github.com/vmware/govmomi/session/keep_alive.go
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+Copyright (c) 2015,2019 VMware, Inc. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -80,17 +80,18 @@ func (k *keepAlive) start() {
 	k.notifyWaitGroup.Add(1)
 
 	go func() {
-		defer k.notifyWaitGroup.Done()
-
 		for t := time.NewTimer(k.idleTime); ; {
 			select {
 			case <-k.notifyStop:
+				k.notifyWaitGroup.Done()
 				return
 			case <-k.notifyRequest:
 				t.Reset(k.idleTime)
 			case <-t.C:
 				if err := k.keepAlive(k.roundTripper); err != nil {
+					k.notifyWaitGroup.Done()
 					k.stop()
+					return
 				}
 				t = time.NewTimer(k.idleTime)
 			}
@@ -110,16 +111,20 @@ func (k *keepAlive) stop() {
 }
 
 func (k *keepAlive) RoundTrip(ctx context.Context, req, res soap.HasFault) error {
+	// Stop ticker on logout.
+	switch req.(type) {
+	case *methods.LogoutBody:
+		k.stop()
+	}
+
 	err := k.roundTripper.RoundTrip(ctx, req, res)
 	if err != nil {
 		return err
 	}
-	// Start ticker on login, stop ticker on logout.
+	// Start ticker on login.
 	switch req.(type) {
 	case *methods.LoginBody, *methods.LoginExtensionByCertificateBody, *methods.LoginByTokenBody:
 		k.start()
-	case *methods.LogoutBody:
-		k.stop()
 	}
 
 	return nil

--- a/vendor/github.com/vmware/govmomi/session/manager.go
+++ b/vendor/github.com/vmware/govmomi/session/manager.go
@@ -50,10 +50,10 @@ func Secret(value string) (string, error) {
 	}
 	contents, err := ioutil.ReadFile(value)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return value, nil
+		if os.IsPermission(err) {
+			return "", err
 		}
-		return "", err
+		return value, nil
 	}
 	return strings.TrimSpace(string(contents)), nil
 }

--- a/vendor/github.com/vmware/govmomi/simulator/authorization_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/authorization_manager.go
@@ -36,11 +36,12 @@ type AuthorizationManager struct {
 	nextID      int32
 }
 
-func NewAuthorizationManager(ref types.ManagedObjectReference) object.Reference {
-	m := &AuthorizationManager{}
-	m.Self = ref
-	m.RoleList = make([]types.AuthorizationRole, len(esx.RoleList))
-	copy(m.RoleList, esx.RoleList)
+func (m *AuthorizationManager) init(r *Registry) {
+	if len(m.RoleList) == 0 {
+		m.RoleList = make([]types.AuthorizationRole, len(esx.RoleList))
+		copy(m.RoleList, esx.RoleList)
+	}
+
 	m.permissions = make(map[types.ManagedObjectReference][]types.Permission)
 
 	l := object.AuthorizationRoleList(m.RoleList)
@@ -52,7 +53,7 @@ func NewAuthorizationManager(ref types.ManagedObjectReference) object.Reference 
 		m.privileges[id] = struct{}{}
 	}
 
-	root := Map.content().RootFolder
+	root := r.content().RootFolder
 
 	for _, u := range DefaultUserGroup {
 		m.permissions[root] = append(m.permissions[root], types.Permission{
@@ -63,8 +64,6 @@ func NewAuthorizationManager(ref types.ManagedObjectReference) object.Reference 
 			Propagate: true,
 		})
 	}
-
-	return m
 }
 
 func (m *AuthorizationManager) RetrieveEntityPermissions(req *types.RetrieveEntityPermissions) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/container.go
+++ b/vendor/github.com/vmware/govmomi/simulator/container.go
@@ -17,18 +17,42 @@ limitations under the License.
 package simulator
 
 import (
+	"archive/tar"
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os/exec"
 	"strings"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/vmware/govmomi/vim25/types"
 )
 
+var (
+	shell = "/bin/sh"
+)
+
+func init() {
+	if sh, err := exec.LookPath("bash"); err != nil {
+		shell = sh
+	}
+}
+
 // container provides methods to manage a container within a simulator VM lifecycle.
 type container struct {
-	id string
+	id   string
+	name string
+}
+
+type networkSettings struct {
+	Gateway     string
+	IPAddress   string
+	IPPrefixLen int
+	MacAddress  string
 }
 
 // inspect applies container network settings to vm.Guest properties.
@@ -39,10 +63,8 @@ func (c *container) inspect(vm *VirtualMachine) error {
 
 	var objects []struct {
 		NetworkSettings struct {
-			Gateway     string
-			IPAddress   string
-			IPPrefixLen int
-			MacAddress  string
+			networkSettings
+			Networks map[string]networkSettings
 		}
 	}
 
@@ -59,7 +81,13 @@ func (c *container) inspect(vm *VirtualMachine) error {
 	vm.logPrintf("%s: %s", vm.Config.Annotation, string(out))
 
 	for _, o := range objects {
-		s := o.NetworkSettings
+		s := o.NetworkSettings.networkSettings
+
+		for _, n := range o.NetworkSettings.Networks {
+			s = n
+			break
+		}
+
 		if s.IPAddress == "" {
 			continue
 		}
@@ -75,6 +103,46 @@ func (c *container) inspect(vm *VirtualMachine) error {
 	}
 
 	return nil
+}
+
+// createDMI writes BIOS UUID DMI files to a container volume
+func (c *container) createDMI(vm *VirtualMachine, name string) error {
+	cmd := exec.Command("docker", "run", "--rm", "-i", "-v", name+":"+"/"+name, "busybox", "tar", "-C", "/"+name, "-xf", "-")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	tw := tar.NewWriter(stdin)
+
+	dmi := []struct {
+		name string
+		val  func(uuid.UUID) string
+	}{
+		{"product_uuid", productUUID},
+		{"product_serial", productSerial},
+	}
+
+	for _, file := range dmi {
+		val := file.val(vm.uid)
+		_ = tw.WriteHeader(&tar.Header{
+			Name:    file.name,
+			Size:    int64(len(val) + 1),
+			Mode:    0444,
+			ModTime: time.Now(),
+		})
+		_, _ = fmt.Fprintln(tw, val)
+	}
+
+	_ = tw.Close()
+	_ = stdin.Close()
+
+	return cmd.Wait()
 }
 
 // start runs the container if specified by the RUN.container extraConfig property.
@@ -93,6 +161,7 @@ func (c *container) start(vm *VirtualMachine) {
 	}
 
 	var args []string
+	var env []string
 
 	for _, opt := range vm.Config.ExtraConfig {
 		val := opt.GetOptionValue()
@@ -103,16 +172,33 @@ func (c *container) start(vm *VirtualMachine) {
 				args = []string{run}
 			}
 
-			break
+			continue
+		}
+		if strings.HasPrefix(val.Key, "guestinfo.") {
+			key := strings.Replace(strings.ToUpper(val.Key), ".", "_", -1)
+			env = append(env, "--env", fmt.Sprintf("VMX_%s=%s", key, val.Value.(string)))
 		}
 	}
 
 	if len(args) == 0 {
 		return
 	}
+	if len(env) != 0 {
+		// Configure env as the data access method for cloud-init-vmware-guestinfo
+		env = append(env, "--env", "VMX_GUESTINFO=true")
+	}
 
-	args = append([]string{"run", "-d", "--name", vm.Name}, args...)
-	cmd := exec.Command("docker", args...)
+	c.name = fmt.Sprintf("vcsim-%s-%s", vm.Name, vm.uid)
+	run := append([]string{"docker", "run", "-d", "--name", c.name}, env...)
+
+	if err := c.createDMI(vm, c.name); err != nil {
+		log.Printf("%s: %s", vm.Name, err)
+		return
+	}
+	run = append(run, "-v", fmt.Sprintf("%s:%s:ro", c.name, "/sys/class/dmi/id"))
+
+	args = append(run, args...)
+	cmd := exec.Command(shell, "-c", strings.Join(args, " "))
 	out, err := cmd.Output()
 	if err != nil {
 		log.Printf("%s %s: %s", vm.Name, cmd.Args, err)
@@ -159,9 +245,61 @@ func (c *container) remove(vm *VirtualMachine) {
 		return
 	}
 
-	cmd := exec.Command("docker", "rm", "-f", c.id)
-	err := cmd.Run()
-	if err != nil {
-		log.Printf("%s %s: %s", vm.Name, cmd.Args, err)
+	args := [][]string{
+		[]string{"rm", "-v", "-f", c.id},
+		[]string{"volume", "rm", "-f", c.name},
 	}
+
+	for i := range args {
+		cmd := exec.Command("docker", args[i]...)
+		err := cmd.Run()
+		if err != nil {
+			log.Printf("%s %s: %s", vm.Name, cmd.Args, err)
+		}
+	}
+
+	c.id = ""
+}
+
+// productSerial returns the uuid in /sys/class/dmi/id/product_serial format
+func productSerial(id uuid.UUID) string {
+	var dst [len(id)*2 + len(id) - 1]byte
+
+	j := 0
+	for i := 0; i < len(id); i++ {
+		hex.Encode(dst[j:j+2], id[i:i+1])
+		j += 3
+		if j < len(dst) {
+			s := j - 1
+			if s == len(dst)/2 {
+				dst[s] = '-'
+			} else {
+				dst[s] = ' '
+			}
+		}
+	}
+
+	return fmt.Sprintf("VMware-%s", string(dst[:]))
+}
+
+// productUUID returns the uuid in /sys/class/dmi/id/product_uuid format
+func productUUID(id uuid.UUID) string {
+	var dst [36]byte
+
+	hex.Encode(dst[0:2], id[3:4])
+	hex.Encode(dst[2:4], id[2:3])
+	hex.Encode(dst[4:6], id[1:2])
+	hex.Encode(dst[6:8], id[0:1])
+	dst[8] = '-'
+	hex.Encode(dst[9:11], id[5:6])
+	hex.Encode(dst[11:13], id[4:5])
+	dst[13] = '-'
+	hex.Encode(dst[14:16], id[7:8])
+	hex.Encode(dst[16:18], id[6:7])
+	dst[18] = '-'
+	hex.Encode(dst[19:23], id[8:10])
+	dst[23] = '-'
+	hex.Encode(dst[24:], id[10:])
+
+	return strings.ToUpper(string(dst[:]))
 }

--- a/vendor/github.com/vmware/govmomi/simulator/custom_fields_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/custom_fields_manager.go
@@ -17,7 +17,6 @@ limitations under the License.
 package simulator
 
 import (
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -28,12 +27,6 @@ type CustomFieldsManager struct {
 	mo.CustomFieldsManager
 
 	nextKey int32
-}
-
-func NewCustomFieldsManager(ref types.ManagedObjectReference) object.Reference {
-	m := &CustomFieldsManager{}
-	m.Self = ref
-	return m
 }
 
 // Iterates through all entities of passed field type;

--- a/vendor/github.com/vmware/govmomi/simulator/customization_spec_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/customization_spec_manager.go
@@ -1,0 +1,349 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+var DefaultCustomizationSpec = []types.CustomizationSpecItem{
+	types.CustomizationSpecItem{
+		Info: types.CustomizationSpecInfo{
+			Name:           "vcsim-linux",
+			Description:    "",
+			Type:           "Linux",
+			ChangeVersion:  "1569965707",
+			LastUpdateTime: types.NewTime(time.Now()),
+		},
+		Spec: types.CustomizationSpec{
+			Options: &types.CustomizationLinuxOptions{},
+			Identity: &types.CustomizationLinuxPrep{
+				CustomizationIdentitySettings: types.CustomizationIdentitySettings{},
+				HostName:                      &types.CustomizationVirtualMachineName{},
+				Domain:                        "eng.vmware.com",
+				TimeZone:                      "Pacific/Apia",
+				HwClockUTC:                    types.NewBool(true),
+			},
+			GlobalIPSettings: types.CustomizationGlobalIPSettings{
+				DnsSuffixList: nil,
+				DnsServerList: []string{"127.0.1.1"},
+			},
+			NicSettingMap: []types.CustomizationAdapterMapping{
+				{
+					MacAddress: "",
+					Adapter: types.CustomizationIPSettings{
+						Ip:            &types.CustomizationDhcpIpGenerator{},
+						SubnetMask:    "",
+						Gateway:       nil,
+						IpV6Spec:      (*types.CustomizationIPSettingsIpV6AddressSpec)(nil),
+						DnsServerList: nil,
+						DnsDomain:     "",
+						PrimaryWINS:   "",
+						SecondaryWINS: "",
+						NetBIOS:       "",
+					},
+				},
+			},
+			EncryptionKey: nil,
+		},
+	},
+	types.CustomizationSpecItem{
+		Info: types.CustomizationSpecInfo{
+			Name:           "vcsim-linux-static",
+			Description:    "",
+			Type:           "Linux",
+			ChangeVersion:  "1569969598",
+			LastUpdateTime: types.NewTime(time.Now()),
+		},
+		Spec: types.CustomizationSpec{
+			Options: &types.CustomizationLinuxOptions{},
+			Identity: &types.CustomizationLinuxPrep{
+				CustomizationIdentitySettings: types.CustomizationIdentitySettings{},
+				HostName: &types.CustomizationPrefixName{
+					CustomizationName: types.CustomizationName{},
+					Base:              "vcsim",
+				},
+				Domain:     "eng.vmware.com",
+				TimeZone:   "Africa/Cairo",
+				HwClockUTC: types.NewBool(true),
+			},
+			GlobalIPSettings: types.CustomizationGlobalIPSettings{
+				DnsSuffixList: nil,
+				DnsServerList: []string{"127.0.1.1"},
+			},
+			NicSettingMap: []types.CustomizationAdapterMapping{
+				{
+					MacAddress: "",
+					Adapter: types.CustomizationIPSettings{
+						Ip:            &types.CustomizationUnknownIpGenerator{},
+						SubnetMask:    "255.255.255.0",
+						Gateway:       []string{"10.0.0.1"},
+						IpV6Spec:      (*types.CustomizationIPSettingsIpV6AddressSpec)(nil),
+						DnsServerList: nil,
+						DnsDomain:     "",
+						PrimaryWINS:   "",
+						SecondaryWINS: "",
+						NetBIOS:       "",
+					},
+				},
+			},
+			EncryptionKey: nil,
+		},
+	},
+	types.CustomizationSpecItem{
+		Info: types.CustomizationSpecInfo{
+			Name:           "vcsim-windows-static",
+			Description:    "",
+			Type:           "Windows",
+			ChangeVersion:  "1569978029",
+			LastUpdateTime: types.NewTime(time.Now()),
+		},
+		Spec: types.CustomizationSpec{
+			Options: &types.CustomizationWinOptions{
+				CustomizationOptions: types.CustomizationOptions{},
+				ChangeSID:            true,
+				DeleteAccounts:       false,
+				Reboot:               "",
+			},
+			Identity: &types.CustomizationSysprep{
+				CustomizationIdentitySettings: types.CustomizationIdentitySettings{},
+				GuiUnattended: types.CustomizationGuiUnattended{
+					Password:       (*types.CustomizationPassword)(nil),
+					TimeZone:       2,
+					AutoLogon:      false,
+					AutoLogonCount: 1,
+				},
+				UserData: types.CustomizationUserData{
+					FullName:     "vcsim",
+					OrgName:      "VMware",
+					ComputerName: &types.CustomizationVirtualMachineName{},
+					ProductId:    "",
+				},
+				GuiRunOnce: (*types.CustomizationGuiRunOnce)(nil),
+				Identification: types.CustomizationIdentification{
+					JoinWorkgroup:       "WORKGROUP",
+					JoinDomain:          "",
+					DomainAdmin:         "",
+					DomainAdminPassword: (*types.CustomizationPassword)(nil),
+				},
+				LicenseFilePrintData: &types.CustomizationLicenseFilePrintData{
+					AutoMode:  "perServer",
+					AutoUsers: 5,
+				},
+			},
+			GlobalIPSettings: types.CustomizationGlobalIPSettings{},
+			NicSettingMap: []types.CustomizationAdapterMapping{
+				{
+					MacAddress: "",
+					Adapter: types.CustomizationIPSettings{
+						Ip:            &types.CustomizationUnknownIpGenerator{},
+						SubnetMask:    "255.255.255.0",
+						Gateway:       []string{"10.0.0.1"},
+						IpV6Spec:      (*types.CustomizationIPSettingsIpV6AddressSpec)(nil),
+						DnsServerList: nil,
+						DnsDomain:     "",
+						PrimaryWINS:   "",
+						SecondaryWINS: "",
+						NetBIOS:       "",
+					},
+				},
+			},
+			EncryptionKey: []uint8{0x30},
+		},
+	},
+	types.CustomizationSpecItem{
+		Info: types.CustomizationSpecInfo{
+			Name:           "vcsim-windows-domain",
+			Description:    "",
+			Type:           "Windows",
+			ChangeVersion:  "1569970234",
+			LastUpdateTime: types.NewTime(time.Now()),
+		},
+		Spec: types.CustomizationSpec{
+			Options: &types.CustomizationWinOptions{
+				CustomizationOptions: types.CustomizationOptions{},
+				ChangeSID:            true,
+				DeleteAccounts:       false,
+				Reboot:               "",
+			},
+			Identity: &types.CustomizationSysprep{
+				CustomizationIdentitySettings: types.CustomizationIdentitySettings{},
+				GuiUnattended: types.CustomizationGuiUnattended{
+					Password: &types.CustomizationPassword{
+						Value:     "3Gs...==",
+						PlainText: false,
+					},
+					TimeZone:       15,
+					AutoLogon:      false,
+					AutoLogonCount: 1,
+				},
+				UserData: types.CustomizationUserData{
+					FullName:     "dougm",
+					OrgName:      "VMware",
+					ComputerName: &types.CustomizationVirtualMachineName{},
+					ProductId:    "",
+				},
+				GuiRunOnce: (*types.CustomizationGuiRunOnce)(nil),
+				Identification: types.CustomizationIdentification{
+					JoinWorkgroup: "",
+					JoinDomain:    "DOMAIN",
+					DomainAdmin:   "vcsim",
+					DomainAdminPassword: &types.CustomizationPassword{
+						Value:     "H3g...==",
+						PlainText: false,
+					},
+				},
+				LicenseFilePrintData: &types.CustomizationLicenseFilePrintData{
+					AutoMode:  "perServer",
+					AutoUsers: 5,
+				},
+			},
+			GlobalIPSettings: types.CustomizationGlobalIPSettings{},
+			NicSettingMap: []types.CustomizationAdapterMapping{
+				{
+					MacAddress: "",
+					Adapter: types.CustomizationIPSettings{
+						Ip:            &types.CustomizationUnknownIpGenerator{},
+						SubnetMask:    "255.255.255.0",
+						Gateway:       []string{"10.0.0.1"},
+						IpV6Spec:      (*types.CustomizationIPSettingsIpV6AddressSpec)(nil),
+						DnsServerList: nil,
+						DnsDomain:     "",
+						PrimaryWINS:   "",
+						SecondaryWINS: "",
+						NetBIOS:       "",
+					},
+				},
+			},
+			EncryptionKey: []uint8{0x30},
+		},
+	},
+}
+
+type CustomizationSpecManager struct {
+	mo.CustomizationSpecManager
+
+	items []types.CustomizationSpecItem
+}
+
+func (m *CustomizationSpecManager) init(r *Registry) {
+	m.items = DefaultCustomizationSpec
+}
+
+var customizeNameCounter uint64
+
+func customizeName(vm *VirtualMachine, base types.BaseCustomizationName) string {
+	n := atomic.AddUint64(&customizeNameCounter, 1)
+
+	switch name := base.(type) {
+	case *types.CustomizationPrefixName:
+		return fmt.Sprintf("%s-%d", name.Base, n)
+	case *types.CustomizationCustomName:
+		return fmt.Sprintf("%s-%d", name.Argument, n)
+	case *types.CustomizationFixedName:
+		return name.Name
+	case *types.CustomizationUnknownName:
+		return ""
+	case *types.CustomizationVirtualMachineName:
+		return fmt.Sprintf("%s-%d", vm.Name, n)
+	default:
+		return ""
+	}
+}
+
+func (m *CustomizationSpecManager) DoesCustomizationSpecExist(ctx *Context, req *types.DoesCustomizationSpecExist) soap.HasFault {
+	exists := false
+
+	for _, item := range m.items {
+		if item.Info.Name == req.Name {
+			exists = true
+			break
+		}
+	}
+
+	return &methods.DoesCustomizationSpecExistBody{
+		Res: &types.DoesCustomizationSpecExistResponse{
+			Returnval: exists,
+		},
+	}
+}
+
+func (m *CustomizationSpecManager) GetCustomizationSpec(ctx *Context, req *types.GetCustomizationSpec) soap.HasFault {
+	body := new(methods.GetCustomizationSpecBody)
+
+	for _, item := range m.items {
+		if item.Info.Name == req.Name {
+			body.Res = &types.GetCustomizationSpecResponse{
+				Returnval: item,
+			}
+			return body
+		}
+	}
+
+	body.Fault_ = Fault("", new(types.NotFound))
+
+	return body
+}
+
+func (m *CustomizationSpecManager) CreateCustomizationSpec(ctx *Context, req *types.CreateCustomizationSpec) soap.HasFault {
+	body := new(methods.CreateCustomizationSpecBody)
+
+	for _, item := range m.items {
+		if item.Info.Name == req.Item.Info.Name {
+			body.Fault_ = Fault("", &types.AlreadyExists{Name: req.Item.Info.Name})
+			return body
+		}
+	}
+
+	m.items = append(m.items, req.Item)
+	body.Res = new(types.CreateCustomizationSpecResponse)
+
+	return body
+}
+
+func (m *CustomizationSpecManager) OverwriteCustomizationSpec(ctx *Context, req *types.OverwriteCustomizationSpec) soap.HasFault {
+	body := new(methods.OverwriteCustomizationSpecBody)
+
+	for i, item := range m.items {
+		if item.Info.Name == req.Item.Info.Name {
+			m.items[i] = req.Item
+			body.Res = new(types.OverwriteCustomizationSpecResponse)
+			return body
+		}
+	}
+
+	body.Fault_ = Fault("", new(types.NotFound))
+
+	return body
+}
+
+func (m *CustomizationSpecManager) Get() mo.Reference {
+	clone := *m
+
+	for i := range clone.items {
+		clone.Info = append(clone.Info, clone.items[i].Info)
+	}
+
+	return &clone
+}

--- a/vendor/github.com/vmware/govmomi/simulator/datacenter.go
+++ b/vendor/github.com/vmware/govmomi/simulator/datacenter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simulator
 
 import (
+	"log"
 	"strings"
 
 	"github.com/vmware/govmomi/simulator/esx"
@@ -47,6 +48,10 @@ func NewDatacenter(f *Folder) *Datacenter {
 	dc.createFolders()
 
 	return dc
+}
+
+func (dc *Datacenter) RenameTask(r *types.Rename_Task) soap.HasFault {
+	return RenameTask(dc, r)
 }
 
 // Create Datacenter Folders.
@@ -102,6 +107,33 @@ func (dc *Datacenter) createFolders() {
 
 func (dc *Datacenter) defaultNetwork() []types.ManagedObjectReference {
 	return dc.Network[:1] // VM Network
+}
+
+// folder returns the Datacenter folder that can contain the given object type
+func (dc *Datacenter) folder(obj mo.Entity) *Folder {
+	folders := []types.ManagedObjectReference{
+		dc.VmFolder,
+		dc.HostFolder,
+		dc.DatastoreFolder,
+		dc.NetworkFolder,
+	}
+	otype := getManagedObject(obj).Type()
+	rtype := obj.Reference().Type
+
+	for i := range folders {
+		folder := Map.Get(folders[i]).(*Folder)
+		for _, kind := range folder.ChildType {
+			if rtype == kind {
+				return folder
+			}
+			if f, ok := otype.FieldByName(kind); ok && f.Anonymous {
+				return folder
+			}
+		}
+	}
+
+	log.Panicf("failed to find folder for type=%s", rtype)
+	return nil
 }
 
 func datacenterEventArgument(obj mo.Entity) *types.DatacenterEventArgument {

--- a/vendor/github.com/vmware/govmomi/simulator/dvs.go
+++ b/vendor/github.com/vmware/govmomi/simulator/dvs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package simulator
 
 import (
+	"strconv"
+
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -104,7 +106,9 @@ func (s *DistributedVirtualSwitch) AddDVPortgroupTask(c *types.AddDVPortgroup_Ta
 				}
 			}
 
-			pg.PortKeys = []string{}
+			for i := 0; i < int(spec.NumPorts); i++ {
+				pg.PortKeys = append(pg.PortKeys, strconv.Itoa(i))
+			}
 
 			portgroups = append(portgroups, pg.Self)
 			portgroupNames = append(portgroupNames, pg.Name)

--- a/vendor/github.com/vmware/govmomi/simulator/esx/host_config_info.go
+++ b/vendor/github.com/vmware/govmomi/simulator/esx/host_config_info.go
@@ -545,6 +545,30 @@ var HostConfigInfo = types.HostConfigInfo{
 				MultiSelectAllowed: true,
 				CandidateVnic: []types.HostVirtualNic{
 					{
+						Device:    "vmk1",
+						Key:       "management.key-vim.host.VirtualNic-vmk1",
+						Portgroup: "",
+						Spec: types.HostVirtualNicSpec{
+							Ip: &types.HostIpConfig{
+								Dhcp:       true,
+								IpAddress:  "192.168.0.1",
+								SubnetMask: "255.0.0.0",
+								IpV6Config: (*types.HostIpConfigIpV6AddressConfiguration)(nil),
+							},
+							Mac:                    "00:0c:29:81:d8:00",
+							DistributedVirtualPort: (*types.DistributedVirtualSwitchPortConnection)(nil),
+							Portgroup:              "Management Network",
+							Mtu:                    1500,
+							TsoEnabled:             types.NewBool(true),
+							NetStackInstanceKey:    "defaultTcpipStack",
+							OpaqueNetwork:          (*types.HostVirtualNicOpaqueNetworkSpec)(nil),
+							ExternalId:             "",
+							PinnedPnic:             "",
+							IpRouteSpec:            (*types.HostVirtualNicIpRouteSpec)(nil),
+						},
+						Port: "",
+					},
+					{
 						Device:    "vmk0",
 						Key:       "management.key-vim.host.VirtualNic-vmk0",
 						Portgroup: "Management Network",

--- a/vendor/github.com/vmware/govmomi/simulator/file_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/file_manager.go
@@ -22,7 +22,6 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -32,12 +31,6 @@ import (
 
 type FileManager struct {
 	mo.FileManager
-}
-
-func NewFileManager(ref types.ManagedObjectReference) object.Reference {
-	m := &FileManager{}
-	m.Self = ref
-	return m
 }
 
 func (f *FileManager) findDatastore(ref mo.Reference, name string) (*Datastore, types.BaseMethodFault) {

--- a/vendor/github.com/vmware/govmomi/simulator/host_local_account_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/host_local_account_manager.go
@@ -17,7 +17,6 @@ limitations under the License.
 package simulator
 
 import (
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -28,13 +27,6 @@ import (
 
 type HostLocalAccountManager struct {
 	mo.HostLocalAccountManager
-}
-
-func NewHostLocalAccountManager(ref types.ManagedObjectReference) object.Reference {
-	m := &HostLocalAccountManager{}
-	m.Self = ref
-
-	return m
 }
 
 func (h *HostLocalAccountManager) CreateUser(req *types.CreateUser) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/ip_pool_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/ip_pool_manager.go
@@ -59,16 +59,11 @@ type IpPoolManager struct {
 	nextPoolId int32
 }
 
-func NewIpPoolManager(ref types.ManagedObjectReference) *IpPoolManager {
-	m := &IpPoolManager{}
-	m.Self = ref
-
+func (m *IpPoolManager) init(*Registry) {
 	m.pools = map[int32]*IpPool{
 		1: ipPool,
 	}
 	m.nextPoolId = 2
-
-	return m
 }
 
 func (m *IpPoolManager) CreateIpPool(req *types.CreateIpPool) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/license_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/license_manager.go
@@ -30,7 +30,6 @@ limitations under the License.
 package simulator
 
 import (
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -64,17 +63,13 @@ type LicenseManager struct {
 	mo.LicenseManager
 }
 
-func NewLicenseManager(ref types.ManagedObjectReference) object.Reference {
-	m := &LicenseManager{}
-	m.Self = ref
+func (m *LicenseManager) init(r *Registry) {
 	m.Licenses = []types.LicenseManagerLicenseInfo{EvalLicense}
 
-	if Map.IsVPX() {
+	if r.IsVPX() {
 		am := Map.Put(&LicenseAssignmentManager{}).Reference()
 		m.LicenseAssignmentManager = &am
 	}
-
-	return m
 }
 
 func (m *LicenseManager) AddLicense(req *types.AddLicense) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/object.go
+++ b/vendor/github.com/vmware/govmomi/simulator/object.go
@@ -24,7 +24,6 @@ import (
 )
 
 func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
-	ctx.Caller = &req.This
 	body := &methods.SetCustomValueBody{}
 
 	cfm := Map.CustomFieldsManager()
@@ -51,7 +50,12 @@ func SetCustomValue(ctx *Context, req *types.SetCustomValue) soap.HasFault {
 	return body
 }
 
-// newUUID returns a stable UUID based on input s
+// newUUID returns a stable UUID string based on input s
 func newUUID(s string) string {
-	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(s)).String()
+	return sha1UUID(s).String()
+}
+
+// sha1UUID returns a stable UUID based on input s
+func sha1UUID(s string) uuid.UUID {
+	return uuid.NewSHA1(uuid.NameSpaceOID, []byte(s))
 }

--- a/vendor/github.com/vmware/govmomi/simulator/option_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/option_manager.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/simulator/esx"
+	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -37,6 +39,16 @@ func NewOptionManager(ref *types.ManagedObjectReference, setting []types.BaseOpt
 	}
 	s.Setting = setting
 	return s
+}
+
+func (m *OptionManager) init(r *Registry) {
+	if len(m.Setting) == 0 {
+		if r.IsVPX() {
+			m.Setting = vpx.Setting
+		} else {
+			m.Setting = esx.Setting
+		}
+	}
 }
 
 func (m *OptionManager) QueryOptions(req *types.QueryOptions) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/ovf_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/ovf_manager.go
@@ -36,12 +36,6 @@ type OvfManager struct {
 	mo.OvfManager
 }
 
-func NewOvfManager(ref types.ManagedObjectReference) object.Reference {
-	s := &OvfManager{}
-	s.Self = ref
-	return s
-}
-
 func ovfDisk(e *ovf.Envelope, diskID string) *ovf.VirtualDiskDesc {
 	for _, disk := range e.Disk.Disks {
 		if strings.HasSuffix(diskID, disk.DiskID) {
@@ -219,6 +213,19 @@ func (m *OvfManager) CreateImportSpec(ctx *Context, req *types.CreateImportSpec)
 				} else {
 					unsupported(err)
 				}
+			}
+		case 14: // Floppy Drive
+			if device.PickController((*types.VirtualSIOController)(nil)) == nil {
+				c := &types.VirtualSIOController{}
+				c.Key = device.NewKey()
+				device = append(device, c)
+			}
+			d, err := device.CreateFloppy()
+			if err == nil {
+				device = append(device, d)
+				resources[item.InstanceID] = d
+			} else {
+				unsupported(err)
 			}
 		case 15: // CD/DVD
 			c, ok := resources[*item.Parent]

--- a/vendor/github.com/vmware/govmomi/simulator/performance_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/performance_manager.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vim25/methods"
@@ -54,10 +53,8 @@ type PerformanceManager struct {
 	metricData        map[string]map[int32][]int64
 }
 
-func NewPerformanceManager(ref types.ManagedObjectReference) object.Reference {
-	m := &PerformanceManager{}
-	m.Self = ref
-	if Map.IsESX() {
+func (m *PerformanceManager) init(r *Registry) {
+	if r.IsESX() {
 		m.PerfCounter = esx.PerfCounter
 		m.hostMetrics = esx.HostMetrics
 		m.vmMetrics = esx.VmMetrics
@@ -77,7 +74,6 @@ func NewPerformanceManager(ref types.ManagedObjectReference) object.Reference {
 	for _, p := range m.PerfCounter {
 		m.perfCounterIndex[p.Key] = p
 	}
-	return m
 }
 
 func (p *PerformanceManager) QueryPerfCounter(ctx *Context, req *types.QueryPerfCounter) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/registry.go
+++ b/vendor/github.com/vmware/govmomi/simulator/registry.go
@@ -287,11 +287,14 @@ func (r *Registry) Update(obj mo.Reference, changes []types.PropertyChange) {
 // If no object of type kind is found, the method will panic when it reaches the
 // inventory root Folder where the Parent field is nil.
 func (r *Registry) getEntityParent(item mo.Entity, kind string) mo.Entity {
+	var ok bool
 	for {
 		parent := item.Entity().Parent
 
-		item = r.Get(*parent).(mo.Entity)
-
+		item, ok = r.Get(*parent).(mo.Entity)
+		if !ok {
+			return nil
+		}
 		if item.Reference().Type == kind {
 			return item
 		}
@@ -300,7 +303,11 @@ func (r *Registry) getEntityParent(item mo.Entity, kind string) mo.Entity {
 
 // getEntityDatacenter returns the Datacenter containing the given item
 func (r *Registry) getEntityDatacenter(item mo.Entity) *Datacenter {
-	return r.getEntityParent(item, "Datacenter").(*Datacenter)
+	dc, ok := r.getEntityParent(item, "Datacenter").(*Datacenter)
+	if ok {
+		return dc
+	}
+	return nil
 }
 
 func (r *Registry) getEntityFolder(item mo.Entity, kind string) *Folder {

--- a/vendor/github.com/vmware/govmomi/simulator/resource_pool.go
+++ b/vendor/github.com/vmware/govmomi/simulator/resource_pool.go
@@ -204,7 +204,6 @@ func (p *ResourcePool) ImportVApp(ctx *Context, req *types.ImportVApp) soap.HasF
 		folder = ctx.Map.Get(*req.Folder).(*Folder)
 	}
 
-	ctx.Caller = &p.Self
 	res := folder.CreateVMTask(ctx, &types.CreateVM_Task{
 		This:   folder.Self,
 		Config: spec.ConfigSpec,
@@ -331,7 +330,6 @@ func (p *ResourcePool) CreateVApp(req *types.CreateVApp) soap.HasFault {
 }
 
 func (a *VirtualApp) CreateChildVMTask(ctx *Context, req *types.CreateChildVM_Task) soap.HasFault {
-	ctx.Caller = &a.Self
 	body := &methods.CreateChildVM_TaskBody{}
 
 	folder := Map.Get(*a.ParentFolder).(*Folder)

--- a/vendor/github.com/vmware/govmomi/simulator/search_index.go
+++ b/vendor/github.com/vmware/govmomi/simulator/search_index.go
@@ -19,7 +19,6 @@ package simulator
 import (
 	"strings"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -28,12 +27,6 @@ import (
 
 type SearchIndex struct {
 	mo.SearchIndex
-}
-
-func NewSearchIndex(ref types.ManagedObjectReference) object.Reference {
-	m := &SearchIndex{}
-	m.Self = ref
-	return m
 }
 
 func (s *SearchIndex) FindByDatastorePath(r *types.FindByDatastorePath) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/service_instance.go
+++ b/vendor/github.com/vmware/govmomi/simulator/service_instance.go
@@ -20,9 +20,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/internal"
-	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -47,53 +45,23 @@ func NewServiceInstance(content types.ServiceContent, folder mo.Folder) *Service
 	f := &Folder{Folder: folder}
 	Map.Put(f)
 
-	var setting []types.BaseOptionValue
-
 	if content.About.ApiType == "HostAgent" {
 		CreateDefaultESX(f)
 	} else {
 		content.About.InstanceUuid = uuid.New().String()
-		setting = vpx.Setting
 	}
 
-	objects := []object.Reference{
-		NewSessionManager(*s.Content.SessionManager),
-		NewAuthorizationManager(*s.Content.AuthorizationManager),
-		NewPerformanceManager(*s.Content.PerfManager),
-		NewPropertyCollector(s.Content.PropertyCollector),
-		NewFileManager(*s.Content.FileManager),
-		NewVirtualDiskManager(*s.Content.VirtualDiskManager),
-		NewLicenseManager(*s.Content.LicenseManager),
-		NewSearchIndex(*s.Content.SearchIndex),
-		NewViewManager(*s.Content.ViewManager),
-		NewEventManager(*s.Content.EventManager),
-		NewTaskManager(*s.Content.TaskManager),
-		NewUserDirectory(*s.Content.UserDirectory),
-		NewOptionManager(s.Content.Setting, setting),
-		NewStorageResourceManager(*s.Content.StorageResourceManager),
-		NewOvfManager(*s.Content.OvfManager),
-	}
+	refs := mo.References(content)
 
-	switch content.VStorageObjectManager.Type {
-	case "HostVStorageObjectManager":
-		// TODO: NewHostVStorageObjectManager(*content.VStorageObjectManager)
-	case "VcenterVStorageObjectManager":
-		objects = append(objects, NewVcenterVStorageObjectManager(*content.VStorageObjectManager))
-	}
-
-	if s.Content.CustomFieldsManager != nil {
-		objects = append(objects, NewCustomFieldsManager(*s.Content.CustomFieldsManager))
-	}
-
-	if s.Content.IpPoolManager != nil {
-		objects = append(objects, NewIpPoolManager(*s.Content.IpPoolManager))
-	}
-
-	if s.Content.AccountManager != nil {
-		objects = append(objects, NewHostLocalAccountManager(*s.Content.AccountManager))
-	}
-
-	for _, o := range objects {
+	for i := range refs {
+		if Map.Get(refs[i]) != nil {
+			continue
+		}
+		content := types.ObjectContent{Obj: refs[i]}
+		o, err := loadObject(content)
+		if err != nil {
+			panic(err)
+		}
 		Map.Put(o)
 	}
 

--- a/vendor/github.com/vmware/govmomi/simulator/storage_resource_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/storage_resource_manager.go
@@ -31,13 +31,6 @@ type StorageResourceManager struct {
 	mo.StorageResourceManager
 }
 
-func NewStorageResourceManager(ref types.ManagedObjectReference) object.Reference {
-	m := &StorageResourceManager{}
-	m.Self = ref
-
-	return m
-}
-
 func (m *StorageResourceManager) ConfigureStorageDrsForPodTask(req *types.ConfigureStorageDrsForPod_Task) soap.HasFault {
 	task := CreateTask(m, "configureStorageDrsForPod", func(*Task) (types.AnyType, types.BaseMethodFault) {
 		cluster := Map.Get(req.Pod).(*StoragePod)

--- a/vendor/github.com/vmware/govmomi/simulator/task_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/task_manager.go
@@ -19,7 +19,6 @@ package simulator
 import (
 	"sync"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/simulator/esx"
 	"github.com/vmware/govmomi/simulator/vpx"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -33,16 +32,15 @@ type TaskManager struct {
 	sync.Mutex
 }
 
-func NewTaskManager(ref types.ManagedObjectReference) object.Reference {
-	s := &TaskManager{}
-	s.Self = ref
-	if Map.IsESX() {
-		s.Description = esx.Description
-	} else {
-		s.Description = vpx.Description
+func (m *TaskManager) init(r *Registry) {
+	if len(m.Description.MethodInfo) == 0 {
+		if r.IsVPX() {
+			m.Description = vpx.Description
+		} else {
+			m.Description = esx.Description
+		}
 	}
-	Map.AddHandler(s)
-	return s
+	r.AddHandler(m)
 }
 
 func (m *TaskManager) PutObject(obj mo.Reference) {

--- a/vendor/github.com/vmware/govmomi/simulator/user_directory.go
+++ b/vendor/github.com/vmware/govmomi/simulator/user_directory.go
@@ -19,7 +19,6 @@ package simulator
 import (
 	"strings"
 
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -38,13 +37,8 @@ type UserDirectory struct {
 	userGroup []*types.UserSearchResult
 }
 
-func NewUserDirectory(ref types.ManagedObjectReference) object.Reference {
-	u := &UserDirectory{}
-
-	u.Self = ref
-	u.userGroup = DefaultUserGroup
-
-	return u
+func (m *UserDirectory) init(*Registry) {
+	m.userGroup = DefaultUserGroup
 }
 
 func (u *UserDirectory) RetrieveUserGroups(req *types.RetrieveUserGroups) soap.HasFault {

--- a/vendor/github.com/vmware/govmomi/simulator/virtual_disk_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/virtual_disk_manager.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/methods"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/soap"
@@ -30,12 +29,6 @@ import (
 
 type VirtualDiskManager struct {
 	mo.VirtualDiskManager
-}
-
-func NewVirtualDiskManager(ref types.ManagedObjectReference) object.Reference {
-	m := &VirtualDiskManager{}
-	m.Self = ref
-	return m
 }
 
 func (m *VirtualDiskManager) names(name string) []string {

--- a/vendor/github.com/vmware/govmomi/simulator/vstorage_object_manager.go
+++ b/vendor/github.com/vmware/govmomi/simulator/vstorage_object_manager.go
@@ -43,11 +43,8 @@ type VcenterVStorageObjectManager struct {
 	objects map[types.ManagedObjectReference]map[types.ID]*VStorageObject
 }
 
-func NewVcenterVStorageObjectManager(ref types.ManagedObjectReference) object.Reference {
-	m := &VcenterVStorageObjectManager{}
-	m.Self = ref
+func (m *VcenterVStorageObjectManager) init(*Registry) {
 	m.objects = make(map[types.ManagedObjectReference]map[types.ID]*VStorageObject)
-	return m
 }
 
 func (m *VcenterVStorageObjectManager) object(ds types.ManagedObjectReference, id types.ID) *VStorageObject {

--- a/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
+++ b/vendor/github.com/vmware/govmomi/vapi/internal/internal.go
@@ -17,33 +17,30 @@ limitations under the License.
 package internal
 
 import (
-	"bytes"
-	"encoding/json"
-	"io"
-	"net/http"
-	"net/url"
-
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 )
 
 // VAPI REST Paths
 const (
-	Path                           = "/rest/com/vmware"
-	SessionPath                    = "/cis/session"
-	CategoryPath                   = "/cis/tagging/category"
-	TagPath                        = "/cis/tagging/tag"
-	AssociationPath                = "/cis/tagging/tag-association"
-	LibraryPath                    = "/content/library"
-	LibraryItemFileData            = "/cis/data"
-	LibraryItemPath                = "/content/library/item"
-	LibraryItemFilePath            = "/content/library/item/file"
-	LibraryItemUpdateSession       = "/content/library/item/update-session"
-	LibraryItemUpdateSessionFile   = "/content/library/item/updatesession/file"
-	LibraryItemDownloadSession     = "/content/library/item/download-session"
-	LibraryItemDownloadSessionFile = "/content/library/item/downloadsession/file"
-	LocalLibraryPath               = "/content/local-library"
-	VCenterOVFLibraryItem          = "/vcenter/ovf/library-item"
+	SessionPath                    = "/com/vmware/cis/session"
+	CategoryPath                   = "/com/vmware/cis/tagging/category"
+	TagPath                        = "/com/vmware/cis/tagging/tag"
+	AssociationPath                = "/com/vmware/cis/tagging/tag-association"
+	LibraryPath                    = "/com/vmware/content/library"
+	LibraryItemFileData            = "/com/vmware/cis/data"
+	LibraryItemPath                = "/com/vmware/content/library/item"
+	LibraryItemFilePath            = "/com/vmware/content/library/item/file"
+	LibraryItemUpdateSession       = "/com/vmware/content/library/item/update-session"
+	LibraryItemUpdateSessionFile   = "/com/vmware/content/library/item/updatesession/file"
+	LibraryItemDownloadSession     = "/com/vmware/content/library/item/download-session"
+	LibraryItemDownloadSessionFile = "/com/vmware/content/library/item/downloadsession/file"
+	LocalLibraryPath               = "/com/vmware/content/local-library"
+	SubscribedLibraryPath          = "/com/vmware/content/subscribed-library"
+	SubscribedLibraryItem          = "/com/vmware/content/library/subscribed-item"
+	VCenterOVFLibraryItem          = "/com/vmware/vcenter/ovf/library-item"
+	VCenterVMTXLibraryItem         = "/vcenter/vm-template/library-items"
+	VCenterVM                      = "/vcenter/vm"
 	SessionCookieName              = "vmware-api-session-id"
 )
 
@@ -71,79 +68,4 @@ func NewAssociation(ref mo.Reference) Association {
 	return Association{
 		ObjectID: &obj,
 	}
-}
-
-// CloneURL defines an interface for cloned urls
-type CloneURL interface {
-	URL() *url.URL
-}
-
-// Resource wraps url.URL with helpers
-type Resource struct {
-	u *url.URL
-}
-
-// URL creates a URL resource
-func URL(c CloneURL, path string) *Resource {
-	r := &Resource{u: c.URL()}
-	r.u.Path = Path + path
-	return r
-}
-
-func (r *Resource) String() string {
-	return r.u.String()
-}
-
-// WithID appends id to the URL.Path
-func (r *Resource) WithID(id string) *Resource {
-	r.u.Path += "/id:" + id
-	return r
-}
-
-// WithAction sets adds action to the URL.RawQuery
-func (r *Resource) WithAction(action string) *Resource {
-	r.u.RawQuery = url.Values{
-		"~action": []string{action},
-	}.Encode()
-	return r
-}
-
-// WithParameter sets adds a parameter to the URL.RawQuery
-func (r *Resource) WithParameter(name string, value string) *Resource {
-	parameter := url.Values{}
-	parameter.Set(name, value)
-	r.u.RawQuery = parameter.Encode()
-	return r
-}
-
-// Request returns a new http.Request for the given method.
-// An optional body can be provided for POST and PATCH methods.
-func (r *Resource) Request(method string, body ...interface{}) *http.Request {
-	rdr := io.MultiReader() // empty body by default
-	if len(body) != 0 {
-		rdr = encode(body[0])
-	}
-	req, err := http.NewRequest(method, r.u.String(), rdr)
-	if err != nil {
-		panic(err)
-	}
-	return req
-}
-
-type errorReader struct {
-	e error
-}
-
-func (e errorReader) Read([]byte) (int, error) {
-	return -1, e.e
-}
-
-// encode body as JSON, deferring any errors until io.Reader is used.
-func encode(body interface{}) io.Reader {
-	var b bytes.Buffer
-	err := json.NewEncoder(&b).Encode(body)
-	if err != nil {
-		return errorReader{err}
-	}
-	return &b
 }

--- a/vendor/github.com/vmware/govmomi/vapi/library/library.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library.go
@@ -1,0 +1,206 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// StorageBackings for Content Libraries
+type StorageBackings struct {
+	DatastoreID string `json:"datastore_id,omitempty"`
+	Type        string `json:"type,omitempty"`
+}
+
+// Library  provides methods to create, read, update, delete, and enumerate libraries.
+type Library struct {
+	CreationTime     *time.Time        `json:"creation_time,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	ID               string            `json:"id,omitempty"`
+	LastModifiedTime *time.Time        `json:"last_modified_time,omitempty"`
+	LastSyncTime     *time.Time        `json:"last_sync_time,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Storage          []StorageBackings `json:"storage_backings,omitempty"`
+	Type             string            `json:"type,omitempty"`
+	Version          string            `json:"version,omitempty"`
+	Subscription     *Subscription     `json:"subscription_info,omitempty"`
+}
+
+// Subscription info
+type Subscription struct {
+	AuthenticationMethod string `json:"authentication_method"`
+	AutomaticSyncEnabled *bool  `json:"automatic_sync_enabled,omitempty"`
+	OnDemand             *bool  `json:"on_demand,omitempty"`
+	Password             string `json:"password,omitempty"`
+	SslThumbprint        string `json:"ssl_thumbprint,omitempty"`
+	SubscriptionURL      string `json:"subscription_url,omitempty"`
+	UserName             string `json:"user_name,omitempty"`
+}
+
+// Patch merges updates from the given src.
+func (l *Library) Patch(src *Library) {
+	if src.Name != "" {
+		l.Name = src.Name
+	}
+	if src.Description != "" {
+		l.Description = src.Description
+	}
+	if src.Version != "" {
+		l.Version = src.Version
+	}
+}
+
+// Manager extends rest.Client, adding content library related methods.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+// Find is the search criteria for finding libraries.
+type Find struct {
+	Name string `json:"name,omitempty"`
+	Type string `json:"type,omitempty"`
+}
+
+// FindLibrary returns one or more libraries that match the provided search
+// criteria.
+//
+// The provided name is case-insensitive.
+//
+// Either the name or type of library may be set to empty values in order
+// to search for all libraries, all libraries with a specific name, regardless
+// of type, or all libraries of a specified type.
+func (c *Manager) FindLibrary(ctx context.Context, search Find) ([]string, error) {
+	url := c.Resource(internal.LibraryPath).WithAction("find")
+	spec := struct {
+		Spec Find `json:"spec"`
+	}{search}
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// CreateLibrary creates a new library with the given Type, Name,
+// Description, and CategoryID.
+func (c *Manager) CreateLibrary(ctx context.Context, library Library) (string, error) {
+	spec := struct {
+		Library Library `json:"create_spec"`
+	}{library}
+	path := internal.LocalLibraryPath
+	if library.Type == "SUBSCRIBED" {
+		path = internal.SubscribedLibraryPath
+		sub := library.Subscription
+		u, err := url.Parse(sub.SubscriptionURL)
+		if err != nil {
+			return "", err
+		}
+		if u.Scheme == "https" && sub.SslThumbprint == "" {
+			thumbprint := c.Thumbprint(u.Host)
+			if thumbprint == "" {
+				t := c.Transport.(*http.Transport)
+				if t.TLSClientConfig.InsecureSkipVerify {
+					var info object.HostCertificateInfo
+					_ = info.FromURL(u, t.TLSClientConfig)
+					thumbprint = info.ThumbprintSHA1
+				}
+				sub.SslThumbprint = thumbprint
+			}
+		}
+	}
+	url := c.Resource(path)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// SyncLibrary syncs a subscribed library.
+func (c *Manager) SyncLibrary(ctx context.Context, library *Library) error {
+	path := internal.SubscribedLibraryPath
+	url := c.Resource(path).WithID(library.ID).WithAction("sync")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// DeleteLibrary deletes an existing library.
+func (c *Manager) DeleteLibrary(ctx context.Context, library *Library) error {
+	path := internal.LocalLibraryPath
+	if library.Type == "SUBSCRIBED" {
+		path = internal.SubscribedLibraryPath
+	}
+	url := c.Resource(path).WithID(library.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// ListLibraries returns a list of all content library IDs in the system.
+func (c *Manager) ListLibraries(ctx context.Context) ([]string, error) {
+	url := c.Resource(internal.LibraryPath)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryByID returns information on a library for the given ID.
+func (c *Manager) GetLibraryByID(ctx context.Context, id string) (*Library, error) {
+	url := c.Resource(internal.LibraryPath).WithID(id)
+	var res Library
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryByName returns information on a library for the given name.
+func (c *Manager) GetLibraryByName(ctx context.Context, name string) (*Library, error) {
+	// Lookup by name
+	libraries, err := c.GetLibraries(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for i := range libraries {
+		if libraries[i].Name == name {
+			return &libraries[i], nil
+		}
+	}
+	return nil, fmt.Errorf("library name (%s) not found", name)
+}
+
+// GetLibraries returns a list of all content library details in the system.
+func (c *Manager) GetLibraries(ctx context.Context) ([]Library, error) {
+	ids, err := c.ListLibraries(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get libraries failed for: %s", err)
+	}
+
+	var libraries []Library
+	for _, id := range ids {
+		library, err := c.GetLibraryByID(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get library %s failed for %s", id, err)
+		}
+
+		libraries = append(libraries, *library)
+
+	}
+	return libraries, nil
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_file.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_file.go
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+// Checksum provides checksum information on library item files.
+type Checksum struct {
+	Algorithm string `json:"algorithm,omitempty"`
+	Checksum  string `json:"checksum"`
+}
+
+// File provides methods to get information on library item files.
+type File struct {
+	Cached   *bool     `json:"cached,omitempty"`
+	Checksum *Checksum `json:"checksum_info,omitempty"`
+	Name     string    `json:"name,omitempty"`
+	Size     *int64    `json:"size,omitempty"`
+	Version  string    `json:"version,omitempty"`
+}
+
+// ListLibraryItemFiles returns a list of all the files for a library item.
+func (c *Manager) ListLibraryItemFiles(ctx context.Context, id string) ([]File, error) {
+	url := c.Resource(internal.LibraryItemFilePath).WithParam("library_item_id", id)
+	var res []File
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryItemFile returns a file with the provided name for a library item.
+func (c *Manager) GetLibraryItemFile(ctx context.Context, id, fileName string) (*File, error) {
+	url := c.Resource(internal.LibraryItemFilePath).WithID(id).WithAction("get")
+	spec := struct {
+		Name string `json:"name"`
+	}{fileName}
+	var res File
+	return &res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item.go
@@ -1,0 +1,157 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/internal"
+)
+
+const (
+	ItemTypeISO  = "iso"
+	ItemTypeOVF  = "ovf"
+	ItemTypeVMTX = "vm-template"
+)
+
+// Item provides methods to create, read, update, delete, and enumerate library items.
+type Item struct {
+	Cached           bool       `json:"cached,omitempty"`
+	ContentVersion   string     `json:"content_version,omitempty"`
+	CreationTime     *time.Time `json:"creation_time,omitempty"`
+	Description      string     `json:"description,omitempty"`
+	ID               string     `json:"id,omitempty"`
+	LastModifiedTime *time.Time `json:"last_modified_time,omitempty"`
+	LastSyncTime     *time.Time `json:"last_sync_time,omitempty"`
+	LibraryID        string     `json:"library_id,omitempty"`
+	MetadataVersion  string     `json:"metadata_version,omitempty"`
+	Name             string     `json:"name,omitempty"`
+	Size             int64      `json:"size,omitempty"`
+	SourceID         string     `json:"source_id,omitempty"`
+	Type             string     `json:"type,omitempty"`
+	Version          string     `json:"version,omitempty"`
+}
+
+// Patch merges updates from the given src.
+func (i *Item) Patch(src *Item) {
+	if src.Name != "" {
+		i.Name = src.Name
+	}
+	if src.Description != "" {
+		i.Description = src.Description
+	}
+	if src.Type != "" {
+		i.Type = src.Type
+	}
+	if src.Version != "" {
+		i.Version = src.Version
+	}
+}
+
+// CreateLibraryItem creates a new library item
+func (c *Manager) CreateLibraryItem(ctx context.Context, item Item) (string, error) {
+	type createItemSpec struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		LibraryID   string `json:"library_id,omitempty"`
+		Type        string `json:"type"`
+	}
+	spec := struct {
+		Item createItemSpec `json:"create_spec"`
+	}{
+		Item: createItemSpec{
+			Name:        item.Name,
+			Description: item.Description,
+			LibraryID:   item.LibraryID,
+			Type:        item.Type,
+		},
+	}
+	url := c.Resource(internal.LibraryItemPath)
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// SyncLibraryItem syncs a subscribed library item
+func (c *Manager) SyncLibraryItem(ctx context.Context, item *Item, force bool) error {
+	body := struct {
+		Force bool `json:"force_sync_content"`
+	}{force}
+	url := c.Resource(internal.SubscribedLibraryItem).WithID(item.ID).WithAction("sync")
+	return c.Do(ctx, url.Request(http.MethodPost, body), nil)
+}
+
+// DeleteLibraryItem deletes an existing library item.
+func (c *Manager) DeleteLibraryItem(ctx context.Context, item *Item) error {
+	url := c.Resource(internal.LibraryItemPath).WithID(item.ID)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// ListLibraryItems returns a list of all items in a content library.
+func (c *Manager) ListLibraryItems(ctx context.Context, id string) ([]string, error) {
+	url := c.Resource(internal.LibraryItemPath).WithParam("library_id", id)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryItem returns information on a library item for the given ID.
+func (c *Manager) GetLibraryItem(ctx context.Context, id string) (*Item, error) {
+	url := c.Resource(internal.LibraryItemPath).WithID(id)
+	var res Item
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// GetLibraryItems returns a list of all the library items for the specified library.
+func (c *Manager) GetLibraryItems(ctx context.Context, libraryID string) ([]Item, error) {
+	ids, err := c.ListLibraryItems(ctx, libraryID)
+	if err != nil {
+		return nil, fmt.Errorf("get library items failed for: %s", err)
+	}
+	var items []Item
+	for _, id := range ids {
+		item, err := c.GetLibraryItem(ctx, id)
+		if err != nil {
+			return nil, fmt.Errorf("get library item for %s failed for %s", id, err)
+		}
+		items = append(items, *item)
+	}
+	return items, nil
+}
+
+// FindItem is the search criteria for finding library items.
+type FindItem struct {
+	Cached    *bool  `json:"cached,omitempty"`
+	LibraryID string `json:"library_id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	SourceID  string `json:"source_id,omitempty"`
+	Type      string `json:"type,omitempty"`
+}
+
+// FindLibraryItems returns the IDs of all the library items that match the
+// search criteria.
+func (c *Manager) FindLibraryItems(
+	ctx context.Context, search FindItem) ([]string, error) {
+
+	url := c.Resource(internal.LibraryItemPath).WithAction("find")
+	spec := struct {
+		Spec FindItem `json:"spec"`
+	}{search}
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item_downloadsession_file.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item_downloadsession_file.go
@@ -1,0 +1,71 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// DownloadFile is the specification for the downloadsession
+// operations file:add, file:get, and file:list.
+type DownloadFile struct {
+	BytesTransferred int64                    `json:"bytes_transferred"`
+	Checksum         *Checksum                `json:"checksum_info,omitempty"`
+	DownloadEndpoint *TransferEndpoint        `json:"download_endpoint,omitempty"`
+	ErrorMessage     *rest.LocalizableMessage `json:"error_message,omitempty"`
+	Name             string                   `json:"name"`
+	Size             int64                    `json:"size,omitempty"`
+	Status           string                   `json:"status"`
+}
+
+// GetLibraryItemDownloadSessionFile retrieves information about a specific file that is a part of an download session.
+func (c *Manager) GetLibraryItemDownloadSessionFile(ctx context.Context, sessionID string, name string) (*DownloadFile, error) {
+	url := c.Resource(internal.LibraryItemDownloadSessionFile).WithID(sessionID).WithAction("get")
+	spec := struct {
+		Name string `json:"file_name"`
+	}{name}
+	var res DownloadFile
+	err := c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	if err != nil {
+		return nil, err
+	}
+	if res.Status == "ERROR" {
+		return nil, res.ErrorMessage
+	}
+	return &res, nil
+}
+
+// ListLibraryItemDownloadSessionFile retrieves information about a specific file that is a part of an download session.
+func (c *Manager) ListLibraryItemDownloadSessionFile(ctx context.Context, sessionID string) ([]DownloadFile, error) {
+	url := c.Resource(internal.LibraryItemDownloadSessionFile).WithParam("download_session_id", sessionID)
+	var res []DownloadFile
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// PrepareLibraryItemDownloadSessionFile retrieves information about a specific file that is a part of an download session.
+func (c *Manager) PrepareLibraryItemDownloadSessionFile(ctx context.Context, sessionID string, name string) (*DownloadFile, error) {
+	url := c.Resource(internal.LibraryItemDownloadSessionFile).WithID(sessionID).WithAction("prepare")
+	spec := struct {
+		Name string `json:"file_name"`
+	}{name}
+	var res DownloadFile
+	return &res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession.go
@@ -1,0 +1,165 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+)
+
+// Session is used to create an initial update or download session
+type Session struct {
+	ClientProgress            int64                    `json:"client_progress,omitempty"`
+	ErrorMessage              *rest.LocalizableMessage `json:"error_message,omitempty"`
+	ExpirationTime            *time.Time               `json:"expiration_time,omitempty"`
+	ID                        string                   `json:"id,omitempty"`
+	LibraryItemContentVersion string                   `json:"library_item_content_version,omitempty"`
+	LibraryItemID             string                   `json:"library_item_id,omitempty"`
+	State                     string                   `json:"state,omitempty"`
+}
+
+// CreateLibraryItemUpdateSession creates a new library item
+func (c *Manager) CreateLibraryItemUpdateSession(ctx context.Context, session Session) (string, error) {
+	url := c.Resource(internal.LibraryItemUpdateSession)
+	spec := struct {
+		CreateSpec Session `json:"create_spec"`
+	}{session}
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetLibraryItemUpdateSession gets the update session information with status
+func (c *Manager) GetLibraryItemUpdateSession(ctx context.Context, id string) (*Session, error) {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id)
+	var res Session
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// ListLibraryItemUpdateSession gets the list of update sessions
+func (c *Manager) ListLibraryItemUpdateSession(ctx context.Context) ([]string, error) {
+	url := c.Resource(internal.LibraryItemUpdateSession)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// CancelLibraryItemUpdateSession cancels an update session
+func (c *Manager) CancelLibraryItemUpdateSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id).WithAction("cancel")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// CompleteLibraryItemUpdateSession completes an update session
+func (c *Manager) CompleteLibraryItemUpdateSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id).WithAction("complete")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// DeleteLibraryItemUpdateSession deletes an update session
+func (c *Manager) DeleteLibraryItemUpdateSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// FailLibraryItemUpdateSession fails an update session
+func (c *Manager) FailLibraryItemUpdateSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id).WithAction("fail")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// KeepAliveLibraryItemUpdateSession keeps an inactive update session alive.
+func (c *Manager) KeepAliveLibraryItemUpdateSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemUpdateSession).WithID(id).WithAction("keep-alive")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// WaitOnLibraryItemUpdateSession blocks until the update session is no longer
+// in the ACTIVE state.
+func (c *Manager) WaitOnLibraryItemUpdateSession(
+	ctx context.Context, sessionID string,
+	interval time.Duration, intervalCallback func()) error {
+
+	// Wait until the upload operation is complete to return.
+	for {
+		session, err := c.GetLibraryItemUpdateSession(ctx, sessionID)
+		if err != nil {
+			return err
+		}
+
+		if session.State != "ACTIVE" {
+			if session.State == "ERROR" {
+				return session.ErrorMessage
+			}
+			return nil
+		}
+		time.Sleep(interval)
+		if intervalCallback != nil {
+			intervalCallback()
+		}
+	}
+}
+
+// CreateLibraryItemDownloadSession creates a new library item
+func (c *Manager) CreateLibraryItemDownloadSession(ctx context.Context, session Session) (string, error) {
+	url := c.Resource(internal.LibraryItemDownloadSession)
+	spec := struct {
+		CreateSpec Session `json:"create_spec"`
+	}{session}
+	var res string
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// GetLibraryItemDownloadSession gets the download session information with status
+func (c *Manager) GetLibraryItemDownloadSession(ctx context.Context, id string) (*Session, error) {
+	url := c.Resource(internal.LibraryItemDownloadSession).WithID(id)
+	var res Session
+	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// ListLibraryItemDownloadSession gets the list of download sessions
+func (c *Manager) ListLibraryItemDownloadSession(ctx context.Context) ([]string, error) {
+	url := c.Resource(internal.LibraryItemDownloadSession)
+	var res []string
+	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
+}
+
+// CancelLibraryItemDownloadSession cancels an download session
+func (c *Manager) CancelLibraryItemDownloadSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemDownloadSession).WithID(id).WithAction("cancel")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// DeleteLibraryItemDownloadSession deletes an download session
+func (c *Manager) DeleteLibraryItemDownloadSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemDownloadSession).WithID(id)
+	return c.Do(ctx, url.Request(http.MethodDelete), nil)
+}
+
+// FailLibraryItemDownloadSession fails an download session
+func (c *Manager) FailLibraryItemDownloadSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemDownloadSession).WithID(id).WithAction("fail")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}
+
+// KeepAliveLibraryItemDownloadSession keeps an inactive download session alive.
+func (c *Manager) KeepAliveLibraryItemDownloadSession(ctx context.Context, id string) error {
+	url := c.Resource(internal.LibraryItemDownloadSession).WithID(id).WithAction("keep-alive")
+	return c.Do(ctx, url.Request(http.MethodPost), nil)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession_file.go
+++ b/vendor/github.com/vmware/govmomi/vapi/library/library_item_updatesession_file.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package library
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/soap"
+)
+
+// TransferEndpoint provides information on the source of a library item file.
+type TransferEndpoint struct {
+	URI                      string `json:"uri,omitempty"`
+	SSLCertificateThumbprint string `json:"ssl_certificate_thumbprint,omitempty"`
+}
+
+// UpdateFile is the specification for the updatesession
+// operations file:add, file:get, and file:list.
+type UpdateFile struct {
+	BytesTransferred int64                    `json:"bytes_transferred,omitempty"`
+	Checksum         *Checksum                `json:"checksum_info,omitempty"`
+	ErrorMessage     *rest.LocalizableMessage `json:"error_message,omitempty"`
+	Name             string                   `json:"name"`
+	Size             int64                    `json:"size,omitempty"`
+	SourceEndpoint   *TransferEndpoint        `json:"source_endpoint,omitempty"`
+	SourceType       string                   `json:"source_type"`
+	Status           string                   `json:"status,omitempty"`
+	UploadEndpoint   *TransferEndpoint        `json:"upload_endpoint,omitempty"`
+}
+
+// AddLibraryItemFile adds a file
+func (c *Manager) AddLibraryItemFile(ctx context.Context, sessionID string, updateFile UpdateFile) (*UpdateFile, error) {
+	url := c.Resource(internal.LibraryItemUpdateSessionFile).WithID(sessionID).WithAction("add")
+	spec := struct {
+		FileSpec UpdateFile `json:"file_spec"`
+	}{updateFile}
+	var res UpdateFile
+	err := c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	if err != nil {
+		return nil, err
+	}
+	if res.Status == "ERROR" {
+		return nil, res.ErrorMessage
+	}
+	return &res, nil
+}
+
+// AddLibraryItemFileFromURI adds a file from a remote URI.
+func (c *Manager) AddLibraryItemFileFromURI(
+	ctx context.Context,
+	sessionID, fileName, uri string) (*UpdateFile, error) {
+
+	n, fingerprint, err := c.getContentLengthAndFingerprint(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := c.AddLibraryItemFile(ctx, sessionID, UpdateFile{
+		Name:       fileName,
+		SourceType: "PULL",
+		Size:       n,
+		SourceEndpoint: &TransferEndpoint{
+			URI:                      uri,
+			SSLCertificateThumbprint: fingerprint,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return info, c.CompleteLibraryItemUpdateSession(ctx, sessionID)
+}
+
+// GetLibraryItemUpdateSessionFile retrieves information about a specific file
+// that is a part of an update session.
+func (c *Manager) GetLibraryItemUpdateSessionFile(ctx context.Context, sessionID string, fileName string) (*UpdateFile, error) {
+	url := c.Resource(internal.LibraryItemUpdateSessionFile).WithID(sessionID).WithAction("get")
+	spec := struct {
+		Name string `json:"file_name"`
+	}{fileName}
+	var res UpdateFile
+	return &res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// getContentLengthAndFingerprint gets the number of bytes returned
+// by the URI as well as the SHA1 fingerprint of the peer certificate
+// if the URI's scheme is https.
+func (c *Manager) getContentLengthAndFingerprint(
+	ctx context.Context, uri string) (int64, string, error) {
+	resp, err := c.Head(uri)
+	if err != nil {
+		return 0, "", err
+	}
+	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
+		return resp.ContentLength, "", nil
+	}
+	fingerprint := c.Thumbprint(resp.Request.URL.Host)
+	if fingerprint == "" {
+		if c.Transport.(*http.Transport).TLSClientConfig.InsecureSkipVerify {
+			fingerprint = soap.ThumbprintSHA1(resp.TLS.PeerCertificates[0])
+		}
+	}
+	return resp.ContentLength, fingerprint, nil
+}
+
+// ReadManifest converts an ovf manifest to a map of file name -> Checksum.
+func ReadManifest(m io.Reader) (map[string]*Checksum, error) {
+	// expected format: openssl sha1 *.{ovf,vmdk}
+	c := make(map[string]*Checksum)
+
+	scanner := bufio.NewScanner(m)
+	for scanner.Scan() {
+		line := strings.SplitN(scanner.Text(), ")=", 2)
+		if len(line) != 2 {
+			continue
+		}
+		name := strings.SplitN(line[0], "(", 2)
+		if len(name) != 2 {
+			continue
+		}
+		sum := &Checksum{
+			Algorithm: strings.TrimSpace(name[0]),
+			Checksum:  strings.TrimSpace(line[1]),
+		}
+		c[name[1]] = sum
+	}
+
+	return c, scanner.Err()
+}

--- a/vendor/github.com/vmware/govmomi/vapi/rest/resource.go
+++ b/vendor/github.com/vmware/govmomi/vapi/rest/resource.go
@@ -1,0 +1,89 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+const (
+	Path = "/rest"
+)
+
+// Resource wraps url.URL with helpers
+type Resource struct {
+	u *url.URL
+}
+
+func (r *Resource) String() string {
+	return r.u.String()
+}
+
+// WithID appends id to the URL.Path
+func (r *Resource) WithID(id string) *Resource {
+	r.u.Path += "/id:" + id
+	return r
+}
+
+// WithAction sets adds action to the URL.RawQuery
+func (r *Resource) WithAction(action string) *Resource {
+	return r.WithParam("~action", action)
+}
+
+// WithParam sets adds a parameter to the URL.RawQuery
+func (r *Resource) WithParam(name string, value string) *Resource {
+	r.u.RawQuery = url.Values{
+		name: []string{value},
+	}.Encode()
+	return r
+}
+
+// Request returns a new http.Request for the given method.
+// An optional body can be provided for POST and PATCH methods.
+func (r *Resource) Request(method string, body ...interface{}) *http.Request {
+	rdr := io.MultiReader() // empty body by default
+	if len(body) != 0 {
+		rdr = encode(body[0])
+	}
+	req, err := http.NewRequest(method, r.u.String(), rdr)
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+type errorReader struct {
+	e error
+}
+
+func (e errorReader) Read([]byte) (int, error) {
+	return -1, e.e
+}
+
+// encode body as JSON, deferring any errors until io.Reader is used.
+func encode(body interface{}) io.Reader {
+	var b bytes.Buffer
+	err := json.NewEncoder(&b).Encode(body)
+	if err != nil {
+		return errorReader{err}
+	}
+	return &b
+}

--- a/vendor/github.com/vmware/govmomi/vapi/simulator/simulator.go
+++ b/vendor/github.com/vmware/govmomi/vapi/simulator/simulator.go
@@ -1,0 +1,1758 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package simulator
+
+import (
+	"archive/tar"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/vmware/govmomi"
+	"github.com/vmware/govmomi/nfc"
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/ovf"
+	"github.com/vmware/govmomi/simulator"
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vapi/tags"
+	"github.com/vmware/govmomi/vapi/vcenter"
+	"github.com/vmware/govmomi/view"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+	vim "github.com/vmware/govmomi/vim25/types"
+)
+
+type item struct {
+	*library.Item
+	File     []library.File
+	Template *types.ManagedObjectReference
+}
+
+type content struct {
+	*library.Library
+	Item map[string]*item
+}
+
+type update struct {
+	*library.Session
+	Library *library.Library
+	File    map[string]*library.UpdateFile
+}
+
+type download struct {
+	*library.Session
+	Library *library.Library
+	File    map[string]*library.DownloadFile
+}
+
+type handler struct {
+	sync.Mutex
+	ServeMux    *http.ServeMux
+	URL         url.URL
+	Category    map[string]*tags.Category
+	Tag         map[string]*tags.Tag
+	Association map[string]map[internal.AssociatedObject]bool
+	Session     map[string]*rest.Session
+	Library     map[string]content
+	Update      map[string]update
+	Download    map[string]download
+}
+
+func init() {
+	simulator.RegisterEndpoint(func(s *simulator.Service, r *simulator.Registry) {
+		if r.IsVPX() {
+			path, handler := New(s.Listen, r.OptionManager().Setting)
+			s.Handle(path, handler)
+		}
+	})
+}
+
+// New creates a vAPI simulator.
+func New(u *url.URL, settings []vim.BaseOptionValue) (string, http.Handler) {
+	s := &handler{
+		ServeMux:    http.NewServeMux(),
+		URL:         *u,
+		Category:    make(map[string]*tags.Category),
+		Tag:         make(map[string]*tags.Tag),
+		Association: make(map[string]map[internal.AssociatedObject]bool),
+		Session:     make(map[string]*rest.Session),
+		Library:     make(map[string]content),
+		Update:      make(map[string]update),
+		Download:    make(map[string]download),
+	}
+
+	handlers := []struct {
+		p string
+		m http.HandlerFunc
+	}{
+		{internal.SessionPath, s.session},
+		{internal.CategoryPath, s.category},
+		{internal.CategoryPath + "/", s.categoryID},
+		{internal.TagPath, s.tag},
+		{internal.TagPath + "/", s.tagID},
+		{internal.AssociationPath, s.association},
+		{internal.AssociationPath + "/", s.associationID},
+		{internal.LibraryPath, s.library},
+		{internal.LocalLibraryPath, s.library},
+		{internal.SubscribedLibraryPath, s.library},
+		{internal.LibraryPath + "/", s.libraryID},
+		{internal.LocalLibraryPath + "/", s.libraryID},
+		{internal.SubscribedLibraryPath + "/", s.libraryID},
+		{internal.LibraryItemPath, s.libraryItem},
+		{internal.LibraryItemPath + "/", s.libraryItemID},
+		{internal.SubscribedLibraryItem + "/", s.libraryItemID},
+		{internal.LibraryItemUpdateSession, s.libraryItemUpdateSession},
+		{internal.LibraryItemUpdateSession + "/", s.libraryItemUpdateSessionID},
+		{internal.LibraryItemUpdateSessionFile, s.libraryItemUpdateSessionFile},
+		{internal.LibraryItemUpdateSessionFile + "/", s.libraryItemUpdateSessionFileID},
+		{internal.LibraryItemDownloadSession, s.libraryItemDownloadSession},
+		{internal.LibraryItemDownloadSession + "/", s.libraryItemDownloadSessionID},
+		{internal.LibraryItemDownloadSessionFile, s.libraryItemDownloadSessionFile},
+		{internal.LibraryItemDownloadSessionFile + "/", s.libraryItemDownloadSessionFileID},
+		{internal.LibraryItemFileData + "/", s.libraryItemFileData},
+		{internal.LibraryItemFilePath, s.libraryItemFile},
+		{internal.LibraryItemFilePath + "/", s.libraryItemFileID},
+		{internal.VCenterOVFLibraryItem + "/", s.libraryItemDeployID},
+		{internal.VCenterVMTXLibraryItem, s.libraryItemCreateTemplate},
+		{internal.VCenterVMTXLibraryItem + "/", s.libraryItemTemplateID},
+		{internal.VCenterVM + "/", s.vmID},
+	}
+
+	for i := range handlers {
+		h := handlers[i]
+		s.HandleFunc(h.p, h.m)
+	}
+
+	return rest.Path + "/", s
+}
+
+func (s *handler) withClient(f func(context.Context, *vim25.Client) error) error {
+	ctx := context.Background()
+	c, err := govmomi.NewClient(ctx, &s.URL, true)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = c.Logout(ctx)
+	}()
+	return f(ctx, c.Client)
+}
+
+// HandleFunc wraps the given handler with authorization checks and passes to http.ServeMux.HandleFunc
+func (s *handler) HandleFunc(pattern string, handler func(http.ResponseWriter, *http.Request)) {
+	if !strings.HasPrefix(pattern, rest.Path) {
+		pattern = rest.Path + pattern
+	}
+
+	s.ServeMux.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+		s.Lock()
+		defer s.Unlock()
+
+		if !s.isAuthorized(r) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		handler(w, r)
+	})
+}
+
+func (s *handler) isAuthorized(r *http.Request) bool {
+	if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, internal.SessionPath) && s.action(r) == "" {
+		return true
+	}
+	id := r.Header.Get(internal.SessionCookieName)
+	if id == "" {
+		if cookie, err := r.Cookie(internal.SessionCookieName); err == nil {
+			id = cookie.Value
+			r.Header.Set(internal.SessionCookieName, id)
+		}
+	}
+	info, ok := s.Session[id]
+	if ok {
+		info.LastAccessed = time.Now()
+	} else {
+		_, ok = s.Update[id]
+	}
+	return ok
+}
+
+func (s *handler) hasAuthorization(r *http.Request) (string, bool) {
+	u, p, ok := r.BasicAuth()
+	if ok { // user+pass auth
+		if u == "" || p == "" {
+			return u, false
+		}
+		return u, true
+	}
+	auth := r.Header.Get("Authorization")
+	return "TODO", strings.HasPrefix(auth, "SIGN ") // token auth
+}
+
+func (s *handler) findTag(e vim.VslmTagEntry) *tags.Tag {
+	for _, c := range s.Category {
+		if c.Name == e.ParentCategoryName {
+			for _, t := range s.Tag {
+				if t.Name == e.TagName && t.CategoryID == c.ID {
+					return t
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// AttachedObjects is meant for internal use via simulator.Registry.tagManager
+func (s *handler) AttachedObjects(tag vim.VslmTagEntry) ([]vim.ManagedObjectReference, vim.BaseMethodFault) {
+	t := s.findTag(tag)
+	if t == nil {
+		return nil, new(vim.NotFound)
+	}
+	var ids []vim.ManagedObjectReference
+	for id := range s.Association[t.ID] {
+		ids = append(ids, vim.ManagedObjectReference(id))
+	}
+	return ids, nil
+}
+
+// AttachedTags is meant for internal use via simulator.Registry.tagManager
+func (s *handler) AttachedTags(ref vim.ManagedObjectReference) ([]vim.VslmTagEntry, vim.BaseMethodFault) {
+	oid := internal.AssociatedObject(ref)
+	var tags []vim.VslmTagEntry
+	for id, objs := range s.Association {
+		if objs[oid] {
+			tag := s.Tag[id]
+			cat := s.Category[tag.CategoryID]
+			tags = append(tags, vim.VslmTagEntry{
+				TagName:            tag.Name,
+				ParentCategoryName: cat.Name,
+			})
+		}
+	}
+	return tags, nil
+}
+
+// AttachTag is meant for internal use via simulator.Registry.tagManager
+func (s *handler) AttachTag(ref vim.ManagedObjectReference, tag vim.VslmTagEntry) vim.BaseMethodFault {
+	t := s.findTag(tag)
+	if t == nil {
+		return new(vim.NotFound)
+	}
+	s.Association[t.ID][internal.AssociatedObject(ref)] = true
+	return nil
+}
+
+// DetachTag is meant for internal use via simulator.Registry.tagManager
+func (s *handler) DetachTag(id vim.ManagedObjectReference, tag vim.VslmTagEntry) vim.BaseMethodFault {
+	t := s.findTag(tag)
+	if t == nil {
+		return new(vim.NotFound)
+	}
+	delete(s.Association[t.ID], internal.AssociatedObject(id))
+	return nil
+}
+
+// OK responds with http.StatusOK and json encoded val if given.
+func OK(w http.ResponseWriter, val ...interface{}) {
+	w.WriteHeader(http.StatusOK)
+
+	if len(val) == 0 {
+		return
+	}
+
+	err := json.NewEncoder(w).Encode(struct {
+		Value interface{} `json:"value,omitempty"`
+	}{
+		val[0],
+	})
+
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+// BadRequest responds with http.StatusBadRequest and json encoded vAPI error of type kind.
+func BadRequest(w http.ResponseWriter, kind string) {
+	w.WriteHeader(http.StatusBadRequest)
+
+	err := json.NewEncoder(w).Encode(struct {
+		Type  string `json:"type"`
+		Value struct {
+			Messages []string `json:"messages,omitempty"`
+		} `json:"value,omitempty"`
+	}{
+		Type: kind,
+	})
+
+	if err != nil {
+		log.Panic(err)
+	}
+}
+
+func (*handler) error(w http.ResponseWriter, err error) {
+	http.Error(w, err.Error(), http.StatusInternalServerError)
+	log.Print(err)
+}
+
+// ServeHTTP handles vAPI requests.
+func (s *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost, http.MethodDelete, http.MethodGet, http.MethodPatch, http.MethodPut:
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	h, _ := s.ServeMux.Handler(r)
+	h.ServeHTTP(w, r)
+}
+
+func (s *handler) decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+	return Decode(r, w, val)
+}
+
+// Decode the request Body into val.
+// Returns true on success, otherwise false and sends the http.StatusBadRequest response.
+func Decode(r *http.Request, w http.ResponseWriter, val interface{}) bool {
+	defer r.Body.Close()
+	err := json.NewDecoder(r.Body).Decode(val)
+	if err != nil {
+		log.Printf("%s %s: %s", r.Method, r.RequestURI, err)
+		w.WriteHeader(http.StatusBadRequest)
+		return false
+	}
+	return true
+}
+
+func (s *handler) session(w http.ResponseWriter, r *http.Request) {
+	id := r.Header.Get(internal.SessionCookieName)
+
+	switch r.Method {
+	case http.MethodPost:
+		if s.action(r) != "" {
+			if session, ok := s.Session[id]; ok {
+				OK(w, session)
+			} else {
+				w.WriteHeader(http.StatusUnauthorized)
+			}
+			return
+		}
+		user, ok := s.hasAuthorization(r)
+		if !ok {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		id = uuid.New().String()
+		now := time.Now()
+		s.Session[id] = &rest.Session{User: user, Created: now, LastAccessed: now}
+		http.SetCookie(w, &http.Cookie{
+			Name:  internal.SessionCookieName,
+			Value: id,
+			Path:  rest.Path,
+		})
+		OK(w, id)
+	case http.MethodDelete:
+		delete(s.Session, id)
+		OK(w)
+	case http.MethodGet:
+		OK(w, s.Session[id])
+	}
+}
+
+func (s *handler) action(r *http.Request) string {
+	return r.URL.Query().Get("~action")
+}
+
+func (s *handler) id(r *http.Request) string {
+	base := path.Base(r.URL.Path)
+	id := strings.TrimPrefix(base, "id:")
+	if id == base {
+		return "" // trigger 404 Not Found w/o id: prefix
+	}
+	return id
+}
+
+func newID(kind string) string {
+	return fmt.Sprintf("urn:vmomi:InventoryService%s:%s:GLOBAL", kind, uuid.New().String())
+}
+
+func (s *handler) category(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec struct {
+			Category tags.Category `json:"create_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			for _, category := range s.Category {
+				if category.Name == spec.Category.Name {
+					BadRequest(w, "com.vmware.vapi.std.errors.already_exists")
+					return
+				}
+			}
+			id := newID("Category")
+			spec.Category.ID = id
+			s.Category[id] = &spec.Category
+			OK(w, id)
+		}
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Category {
+			ids = append(ids, id)
+		}
+
+		OK(w, ids)
+	}
+}
+
+func (s *handler) categoryID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+
+	o, ok := s.Category[id]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		delete(s.Category, id)
+		for ix, tag := range s.Tag {
+			if tag.CategoryID == id {
+				delete(s.Tag, ix)
+				delete(s.Association, ix)
+			}
+		}
+		OK(w)
+	case http.MethodPatch:
+		var spec struct {
+			Category tags.Category `json:"update_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			ntypes := len(spec.Category.AssociableTypes)
+			if ntypes != 0 {
+				// Validate that AssociableTypes is only appended to.
+				etypes := len(o.AssociableTypes)
+				fail := ntypes < etypes
+				if !fail {
+					fail = !reflect.DeepEqual(o.AssociableTypes, spec.Category.AssociableTypes[:etypes])
+				}
+				if fail {
+					BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+					return
+				}
+			}
+			o.Patch(&spec.Category)
+			OK(w)
+		}
+	case http.MethodGet:
+		OK(w, o)
+	}
+}
+
+func (s *handler) tag(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec struct {
+			Tag tags.Tag `json:"create_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			for _, tag := range s.Tag {
+				if tag.Name == spec.Tag.Name {
+					BadRequest(w, "com.vmware.vapi.std.errors.already_exists")
+					return
+				}
+			}
+			id := newID("Tag")
+			spec.Tag.ID = id
+			s.Tag[id] = &spec.Tag
+			s.Association[id] = make(map[internal.AssociatedObject]bool)
+			OK(w, id)
+		}
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Tag {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	}
+}
+
+func (s *handler) tagID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+
+	switch s.action(r) {
+	case "list-tags-for-category":
+		var ids []string
+		for _, tag := range s.Tag {
+			if tag.CategoryID == id {
+				ids = append(ids, tag.ID)
+			}
+		}
+		OK(w, ids)
+		return
+	}
+
+	o, ok := s.Tag[id]
+	if !ok {
+		log.Printf("tag not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		delete(s.Tag, id)
+		delete(s.Association, id)
+		OK(w)
+	case http.MethodPatch:
+		var spec struct {
+			Tag tags.Tag `json:"update_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			o.Patch(&spec.Tag)
+			OK(w)
+		}
+	case http.MethodGet:
+		OK(w, o)
+	}
+}
+
+func (s *handler) association(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var spec struct {
+		internal.Association
+		TagIDs    []string                    `json:"tag_ids,omitempty"`
+		ObjectIDs []internal.AssociatedObject `json:"object_ids,omitempty"`
+	}
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	switch s.action(r) {
+	case "list-attached-tags":
+		var ids []string
+		for id, objs := range s.Association {
+			if objs[*spec.ObjectID] {
+				ids = append(ids, id)
+			}
+		}
+		OK(w, ids)
+	case "list-attached-objects-on-tags":
+		var res []tags.AttachedObjects
+		for _, id := range spec.TagIDs {
+			o := tags.AttachedObjects{TagID: id}
+			for i := range s.Association[id] {
+				o.ObjectIDs = append(o.ObjectIDs, i)
+			}
+			res = append(res, o)
+		}
+		OK(w, res)
+	case "list-attached-tags-on-objects":
+		var res []tags.AttachedTags
+		for _, ref := range spec.ObjectIDs {
+			o := tags.AttachedTags{ObjectID: ref}
+			for id, objs := range s.Association {
+				if objs[ref] {
+					o.TagIDs = append(o.TagIDs, id)
+				}
+			}
+			res = append(res, o)
+		}
+		OK(w, res)
+	}
+}
+
+func (s *handler) associationID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := s.id(r)
+	if _, exists := s.Association[id]; !exists {
+		log.Printf("association tag not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	var spec internal.Association
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	switch s.action(r) {
+	case "attach":
+		s.Association[id][*spec.ObjectID] = true
+		OK(w)
+	case "detach":
+		delete(s.Association[id], *spec.ObjectID)
+		OK(w)
+	case "list-attached-objects":
+		var ids []internal.AssociatedObject
+		for id := range s.Association[id] {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	}
+}
+
+func (s *handler) library(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec struct {
+			Library library.Library `json:"create_spec"`
+			Find    library.Find    `json:"spec"`
+		}
+		if !s.decode(r, w, &spec) {
+			return
+		}
+
+		switch s.action(r) {
+		case "find":
+			var ids []string
+			for _, l := range s.Library {
+				if spec.Find.Type != "" {
+					if spec.Find.Type != l.Library.Type {
+						continue
+					}
+				}
+				if spec.Find.Name != "" {
+					if !strings.EqualFold(l.Library.Name, spec.Find.Name) {
+						continue
+					}
+				}
+				ids = append(ids, l.ID)
+			}
+			OK(w, ids)
+		case "":
+			id := uuid.New().String()
+			spec.Library.ID = id
+			spec.Library.CreationTime = types.NewTime(time.Now())
+			spec.Library.LastModifiedTime = types.NewTime(time.Now())
+			dir := libraryPath(&spec.Library, "")
+			if err := os.Mkdir(dir, 0750); err != nil {
+				s.error(w, err)
+				return
+			}
+			s.Library[id] = content{
+				Library: &spec.Library,
+				Item:    make(map[string]*item),
+			}
+			OK(w, id)
+		}
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Library {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	}
+}
+
+func (s *handler) libraryID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+	l, ok := s.Library[id]
+	if !ok {
+		log.Printf("library not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		p := libraryPath(l.Library, "")
+		if err := os.RemoveAll(p); err != nil {
+			s.error(w, err)
+			return
+		}
+		for _, item := range l.Item {
+			s.deleteVM(item.Template)
+		}
+		delete(s.Library, id)
+		OK(w)
+	case http.MethodPatch:
+		var spec struct {
+			Library library.Library `json:"update_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			l.Patch(&spec.Library)
+			OK(w)
+		}
+	case http.MethodPost:
+	case "sync":
+		if l.Type == "SUBSCRIBED" {
+			l.LastSyncTime = types.NewTime(time.Now())
+			OK(w)
+		} else {
+			http.NotFound(w, r)
+		}
+	case http.MethodGet:
+		OK(w, l)
+	}
+}
+
+func (s *handler) libraryItem(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var spec struct {
+			Item library.Item     `json:"create_spec"`
+			Find library.FindItem `json:"spec"`
+		}
+		if !s.decode(r, w, &spec) {
+			return
+		}
+
+		switch s.action(r) {
+		case "find":
+			var ids []string
+			for _, l := range s.Library {
+				if spec.Find.LibraryID != "" {
+					if spec.Find.LibraryID != l.ID {
+						continue
+					}
+				}
+				for _, i := range l.Item {
+					if spec.Find.Name != "" {
+						if spec.Find.Name != i.Name {
+							continue
+						}
+					}
+					if spec.Find.Type != "" {
+						if spec.Find.Type != i.Type {
+							continue
+						}
+					}
+					ids = append(ids, i.ID)
+				}
+			}
+			OK(w, ids)
+		case "create", "":
+			id := spec.Item.LibraryID
+			l, ok := s.Library[id]
+			if !ok {
+				log.Printf("library not found: %s", id)
+				http.NotFound(w, r)
+				return
+			}
+			for _, item := range l.Item {
+				if item.Name == spec.Item.Name {
+					BadRequest(w, "com.vmware.vapi.std.errors.already_exists")
+					return
+				}
+			}
+			id = uuid.New().String()
+			spec.Item.ID = id
+			spec.Item.CreationTime = types.NewTime(time.Now())
+			spec.Item.LastModifiedTime = types.NewTime(time.Now())
+			l.Item[id] = &item{Item: &spec.Item}
+			OK(w, id)
+		}
+	case http.MethodGet:
+		id := r.URL.Query().Get("library_id")
+		l, ok := s.Library[id]
+		if !ok {
+			log.Printf("library not found: %s", id)
+			http.NotFound(w, r)
+			return
+		}
+
+		var ids []string
+		for id := range l.Item {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	}
+}
+
+func (s *handler) libraryItemID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+	lid := r.URL.Query().Get("library_id")
+	if lid == "" {
+		if l := s.itemLibrary(id); l != nil {
+			lid = l.ID
+		}
+	}
+	l, ok := s.Library[lid]
+	if !ok {
+		log.Printf("library not found: %q", lid)
+		http.NotFound(w, r)
+		return
+	}
+	item, ok := l.Item[id]
+	if !ok {
+		log.Printf("library item not found: %q", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodDelete:
+		p := libraryPath(l.Library, id)
+		if err := os.RemoveAll(p); err != nil {
+			s.error(w, err)
+			return
+		}
+		s.deleteVM(l.Item[item.ID].Template)
+		delete(l.Item, item.ID)
+		OK(w)
+	case http.MethodPatch:
+		var spec struct {
+			Item library.Item `json:"update_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			item.Patch(&spec.Item)
+			OK(w)
+		}
+	case http.MethodPost:
+		switch s.action(r) {
+		case "sync":
+			if l.Type == "SUBSCRIBED" {
+				item.LastSyncTime = types.NewTime(time.Now())
+				OK(w)
+			} else {
+				http.NotFound(w, r)
+			}
+		}
+	case http.MethodGet:
+		OK(w, item)
+	}
+}
+
+func (s *handler) libraryItemUpdateSession(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Update {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	case http.MethodPost:
+		var spec struct {
+			Session library.Session `json:"create_spec"`
+		}
+		if !s.decode(r, w, &spec) {
+			return
+		}
+
+		switch s.action(r) {
+		case "create", "":
+			lib := s.itemLibrary(spec.Session.LibraryItemID)
+			if lib == nil {
+				log.Printf("library for item %q not found", spec.Session.LibraryItemID)
+				http.NotFound(w, r)
+				return
+			}
+			session := &library.Session{
+				ID:                        uuid.New().String(),
+				LibraryItemID:             spec.Session.LibraryItemID,
+				LibraryItemContentVersion: "1",
+				ClientProgress:            0,
+				State:                     "ACTIVE",
+				ExpirationTime:            types.NewTime(time.Now().Add(time.Hour)),
+			}
+			s.Update[session.ID] = update{
+				Session: session,
+				Library: lib,
+				File:    make(map[string]*library.UpdateFile),
+			}
+			OK(w, session.ID)
+		}
+	}
+}
+
+func (s *handler) libraryItemUpdateSessionID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+	up, ok := s.Update[id]
+	if !ok {
+		log.Printf("update session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	session := up.Session
+	done := func(state string) {
+		up.State = state
+		go time.AfterFunc(session.ExpirationTime.Sub(time.Now()), func() {
+			s.Lock()
+			delete(s.Update, id)
+			s.Unlock()
+		})
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		OK(w, session)
+	case http.MethodPost:
+		switch s.action(r) {
+		case "cancel":
+			done("CANCELED")
+		case "complete":
+			done("DONE")
+		case "fail":
+			done("ERROR")
+		case "keep-alive":
+			session.ExpirationTime = types.NewTime(time.Now().Add(time.Hour))
+		}
+		OK(w)
+	case http.MethodDelete:
+		delete(s.Update, id)
+		OK(w)
+	}
+}
+
+func (s *handler) libraryItemUpdateSessionFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := r.URL.Query().Get("update_session_id")
+	up, ok := s.Update[id]
+	if !ok {
+		log.Printf("update session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	var files []*library.UpdateFile
+	for _, f := range up.File {
+		files = append(files, f)
+	}
+	OK(w, files)
+}
+
+func (s *handler) pullSource(up update, info *library.UpdateFile) {
+	done := func(err error) {
+		s.Lock()
+		info.Status = "READY"
+		if err != nil {
+			log.Printf("PULL %s: %s", info.SourceEndpoint.URI, err)
+			info.Status = "ERROR"
+			up.State = "ERROR"
+			up.ErrorMessage = &rest.LocalizableMessage{DefaultMessage: err.Error()}
+		}
+		s.Unlock()
+	}
+
+	c := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
+	}
+
+	res, err := c.Get(info.SourceEndpoint.URI)
+	if err != nil {
+		done(err)
+		return
+	}
+
+	err = s.libraryItemFileCreate(&up, info.Name, res.Body)
+	done(err)
+}
+
+func (s *handler) libraryItemUpdateSessionFileID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := s.id(r)
+	up, ok := s.Update[id]
+	if !ok {
+		log.Printf("update session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	switch s.action(r) {
+	case "add":
+		var spec struct {
+			File library.UpdateFile `json:"file_spec"`
+		}
+		if s.decode(r, w, &spec) {
+			id = uuid.New().String()
+			info := &library.UpdateFile{
+				Name:             spec.File.Name,
+				SourceType:       spec.File.SourceType,
+				Status:           "WAITING_FOR_TRANSFER",
+				BytesTransferred: 0,
+			}
+			switch info.SourceType {
+			case "PUSH":
+				u := url.URL{
+					Scheme: s.URL.Scheme,
+					Host:   s.URL.Host,
+					Path:   path.Join(rest.Path, internal.LibraryItemFileData, id, info.Name),
+				}
+				info.UploadEndpoint = &library.TransferEndpoint{URI: u.String()}
+			case "PULL":
+				info.SourceEndpoint = spec.File.SourceEndpoint
+				go s.pullSource(up, info)
+			}
+			up.File[id] = info
+			OK(w, info)
+		}
+	case "get":
+		OK(w, up.Session)
+	case "list":
+		var ids []string
+		for id := range up.File {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	case "remove":
+		delete(s.Update, id)
+		OK(w)
+	case "validate":
+		// TODO
+	}
+}
+
+func (s *handler) libraryItemDownloadSession(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		var ids []string
+		for id := range s.Download {
+			ids = append(ids, id)
+		}
+		OK(w, ids)
+	case http.MethodPost:
+		var spec struct {
+			Session library.Session `json:"create_spec"`
+		}
+		if !s.decode(r, w, &spec) {
+			return
+		}
+
+		switch s.action(r) {
+		case "create", "":
+			var lib *library.Library
+			var files []library.File
+			for _, l := range s.Library {
+				if item, ok := l.Item[spec.Session.LibraryItemID]; ok {
+					lib = l.Library
+					files = item.File
+					break
+				}
+			}
+			if lib == nil {
+				log.Printf("library for item %q not found", spec.Session.LibraryItemID)
+				http.NotFound(w, r)
+				return
+			}
+			session := &library.Session{
+				ID:                        uuid.New().String(),
+				LibraryItemID:             spec.Session.LibraryItemID,
+				LibraryItemContentVersion: "1",
+				ClientProgress:            0,
+				State:                     "ACTIVE",
+				ExpirationTime:            types.NewTime(time.Now().Add(time.Hour)),
+			}
+			s.Download[session.ID] = download{
+				Session: session,
+				Library: lib,
+				File:    make(map[string]*library.DownloadFile),
+			}
+			for _, file := range files {
+				s.Download[session.ID].File[file.Name] = &library.DownloadFile{
+					Name:   file.Name,
+					Status: "UNPREPARED",
+				}
+			}
+			OK(w, session.ID)
+		}
+	}
+}
+
+func (s *handler) libraryItemDownloadSessionID(w http.ResponseWriter, r *http.Request) {
+	id := s.id(r)
+	up, ok := s.Download[id]
+	if !ok {
+		log.Printf("download session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	session := up.Session
+	switch r.Method {
+	case http.MethodGet:
+		OK(w, session)
+	case http.MethodPost:
+		switch s.action(r) {
+		case "cancel", "complete", "fail":
+			delete(s.Download, id) // TODO: fully mock VC's behavior
+		case "keep-alive":
+			session.ExpirationTime = types.NewTime(time.Now().Add(time.Hour))
+		}
+		OK(w)
+	case http.MethodDelete:
+		delete(s.Download, id)
+		OK(w)
+	}
+}
+
+func (s *handler) libraryItemDownloadSessionFile(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := r.URL.Query().Get("download_session_id")
+	dl, ok := s.Download[id]
+	if !ok {
+		log.Printf("download session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	var files []*library.DownloadFile
+	for _, f := range dl.File {
+		files = append(files, f)
+	}
+	OK(w, files)
+}
+
+func (s *handler) libraryItemDownloadSessionFileID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := s.id(r)
+	dl, ok := s.Download[id]
+	if !ok {
+		log.Printf("download session not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	var spec struct {
+		File string `json:"file_name"`
+	}
+
+	switch s.action(r) {
+	case "prepare":
+		if s.decode(r, w, &spec) {
+			u := url.URL{
+				Scheme: s.URL.Scheme,
+				Host:   s.URL.Host,
+				Path:   path.Join(rest.Path, internal.LibraryItemFileData, id, spec.File),
+			}
+			info := &library.DownloadFile{
+				Name:             spec.File,
+				Status:           "PREPARED",
+				BytesTransferred: 0,
+				DownloadEndpoint: &library.TransferEndpoint{
+					URI: u.String(),
+				},
+			}
+			dl.File[spec.File] = info
+			OK(w, info)
+		}
+	case "get":
+		if s.decode(r, w, &spec) {
+			OK(w, dl.File[spec.File])
+		}
+	}
+}
+
+func (s *handler) itemLibrary(id string) *library.Library {
+	for _, l := range s.Library {
+		if _, ok := l.Item[id]; ok {
+			return l.Library
+		}
+	}
+	return nil
+}
+
+func (s *handler) updateFileInfo(id string) *update {
+	for _, up := range s.Update {
+		for i := range up.File {
+			if i == id {
+				return &up
+			}
+		}
+	}
+	return nil
+}
+
+// libraryPath returns the local Datastore fs path for a Library or Item if id is specified.
+func libraryPath(l *library.Library, id string) string {
+	// DatastoreID (moref) format is "$local-path@$ds-folder-id",
+	// see simulator.HostDatastoreSystem.CreateLocalDatastore
+	ds := strings.SplitN(l.Storage[0].DatastoreID, "@", 2)[0]
+	return path.Join(append([]string{ds, "contentlib-" + l.ID}, id)...)
+}
+
+func (s *handler) libraryItemFileCreate(up *update, name string, body io.ReadCloser) error {
+	var in io.Reader = body
+	dir := libraryPath(up.Library, up.Session.LibraryItemID)
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		return err
+	}
+
+	if path.Ext(name) == ".ova" {
+		// All we need is the .ovf, vcsim has no use for .vmdk or .mf
+		r := tar.NewReader(body)
+		for {
+			h, err := r.Next()
+			if err != nil {
+				return err
+			}
+
+			if path.Ext(h.Name) == ".ovf" {
+				name = h.Name
+				in = io.LimitReader(body, h.Size)
+				break
+			}
+		}
+	}
+
+	file, err := os.Create(path.Join(dir, name))
+	if err != nil {
+		return err
+	}
+
+	n, err := io.Copy(file, in)
+	_ = body.Close()
+	if err != nil {
+		return err
+	}
+	err = file.Close()
+	if err != nil {
+		return err
+	}
+
+	i := s.Library[up.Library.ID].Item[up.Session.LibraryItemID]
+	i.File = append(i.File, library.File{
+		Cached:  types.NewBool(true),
+		Name:    name,
+		Size:    types.NewInt64(n),
+		Version: "1",
+	})
+
+	return nil
+}
+
+func (s *handler) libraryItemFileData(w http.ResponseWriter, r *http.Request) {
+	p := strings.Split(r.URL.Path, "/")
+	id, name := p[len(p)-2], p[len(p)-1]
+
+	if r.Method == http.MethodGet {
+		dl, ok := s.Download[id]
+		if !ok {
+			log.Printf("library download not found: %s", id)
+			http.NotFound(w, r)
+			return
+		}
+		p := path.Join(libraryPath(dl.Library, dl.Session.LibraryItemID), name)
+		f, err := os.Open(p)
+		if err != nil {
+			s.error(w, err)
+			return
+		}
+		_, err = io.Copy(w, f)
+		if err != nil {
+			log.Printf("copy %s: %s", p, err)
+		}
+		_ = f.Close()
+		return
+	}
+
+	if r.Method != http.MethodPut {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	up := s.updateFileInfo(id)
+	if up == nil {
+		log.Printf("library update not found: %s", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	err := s.libraryItemFileCreate(up, name, r.Body)
+	if err != nil {
+		s.error(w, err)
+	}
+}
+
+func (s *handler) libraryItemFile(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("library_item_id")
+	for _, l := range s.Library {
+		if i, ok := l.Item[id]; ok {
+			OK(w, i.File)
+			return
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (s *handler) libraryItemFileID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	id := s.id(r)
+	var spec struct {
+		Name string `json:"name"`
+	}
+	if !s.decode(r, w, &spec) {
+		return
+	}
+	for _, l := range s.Library {
+		if i, ok := l.Item[id]; ok {
+			for _, f := range i.File {
+				if f.Name == spec.Name {
+					OK(w, f)
+					return
+				}
+			}
+		}
+	}
+	http.NotFound(w, r)
+}
+
+func (i *item) ovf() string {
+	for _, f := range i.File {
+		if strings.HasSuffix(f.Name, ".ovf") {
+			return f.Name
+		}
+	}
+	return ""
+}
+
+func (s *handler) libraryDeploy(ctx context.Context, c *vim25.Client, lib *library.Library, item *item, deploy vcenter.Deploy) (*nfc.LeaseInfo, error) {
+	name := item.ovf()
+	desc, err := ioutil.ReadFile(filepath.Join(libraryPath(lib, item.ID), name))
+	if err != nil {
+		return nil, err
+	}
+	ds := types.ManagedObjectReference{Type: "Datastore", Value: deploy.DeploymentSpec.DefaultDatastoreID}
+	pool := types.ManagedObjectReference{Type: "ResourcePool", Value: deploy.Target.ResourcePoolID}
+	var folder, host *types.ManagedObjectReference
+	if deploy.Target.FolderID != "" {
+		folder = &types.ManagedObjectReference{Type: "Folder", Value: deploy.Target.FolderID}
+	}
+	if deploy.Target.HostID != "" {
+		host = &types.ManagedObjectReference{Type: "HostSystem", Value: deploy.Target.HostID}
+	}
+
+	v, err := view.NewManager(c).CreateContainerView(ctx, c.ServiceContent.RootFolder, nil, true)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = v.Destroy(ctx)
+	}()
+	refs, err := v.Find(ctx, []string{"Network"}, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var network []types.OvfNetworkMapping
+	for _, net := range deploy.NetworkMappings {
+		for i := range refs {
+			if refs[i].Value == net.Value {
+				network = append(network, types.OvfNetworkMapping{Name: net.Key, Network: refs[i]})
+				break
+			}
+		}
+	}
+
+	if ds.Value == "" {
+		// Datastore is optional in the deploy spec, but not in OvfManager.CreateImportSpec
+		refs, err = v.Find(ctx, []string{"Datastore"}, nil)
+		if err != nil {
+			return nil, err
+		}
+		// TODO: consider StorageProfileID
+		ds = refs[0]
+	}
+
+	cisp := types.OvfCreateImportSpecParams{
+		DiskProvisioning: deploy.DeploymentSpec.StorageProvisioning,
+		EntityName:       deploy.DeploymentSpec.Name,
+		NetworkMapping:   network,
+	}
+
+	for _, p := range deploy.AdditionalParams {
+		switch p.Type {
+		case vcenter.TypePropertyParams:
+			for _, prop := range p.Properties {
+				cisp.PropertyMapping = append(cisp.PropertyMapping, types.KeyValue{
+					Key:   prop.ID,
+					Value: prop.Value,
+				})
+			}
+		case vcenter.TypeDeploymentOptionParams:
+			cisp.OvfManagerCommonParams.DeploymentOption = p.SelectedKey
+		}
+	}
+
+	m := ovf.NewManager(c)
+	spec, err := m.CreateImportSpec(ctx, string(desc), pool, ds, cisp)
+	if err != nil {
+		return nil, err
+	}
+	if spec.Error != nil {
+		return nil, errors.New(spec.Error[0].LocalizedMessage)
+	}
+
+	req := types.ImportVApp{
+		This:   pool,
+		Spec:   spec.ImportSpec,
+		Folder: folder,
+		Host:   host,
+	}
+	res, err := methods.ImportVApp(ctx, c, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	lease := nfc.NewLease(c, res.Returnval)
+	info, err := lease.Wait(ctx, spec.FileItem)
+	if err != nil {
+		return nil, err
+	}
+
+	return info, lease.Complete(ctx)
+}
+
+func (s *handler) libraryItemDeployID(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	id := s.id(r)
+	ok := false
+	var lib *library.Library
+	var item *item
+	for _, l := range s.Library {
+		item, ok = l.Item[id]
+		if ok {
+			lib = l.Library
+			break
+		}
+	}
+	if !ok {
+		log.Printf("library item not found: %q", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	var spec struct {
+		vcenter.Deploy
+	}
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	switch s.action(r) {
+	case "deploy":
+		var d vcenter.Deployment
+		err := s.withClient(func(ctx context.Context, c *vim25.Client) error {
+			info, err := s.libraryDeploy(ctx, c, lib, item, spec.Deploy)
+			if err != nil {
+				return err
+			}
+			id := vcenter.ResourceID(info.Entity)
+			d.Succeeded = true
+			d.ResourceID = &id
+			return nil
+		})
+		if err != nil {
+			d.Error = &vcenter.DeploymentError{
+				Errors: []vcenter.OVFError{{
+					Category: "SERVER",
+					Error: &vcenter.Error{
+						Class: "com.vmware.vapi.std.errors.error",
+						Messages: []rest.LocalizableMessage{
+							{
+								DefaultMessage: err.Error(),
+							},
+						},
+					},
+				}},
+			}
+		}
+		OK(w, d)
+	case "filter":
+		res := vcenter.FilterResponse{
+			Name: item.Name,
+		}
+		OK(w, res)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *handler) deleteVM(ref *types.ManagedObjectReference) {
+	if ref == nil {
+		return
+	}
+	_ = s.withClient(func(ctx context.Context, c *vim25.Client) error {
+		_, _ = object.NewVirtualMachine(c, *ref).Destroy(ctx)
+		return nil
+	})
+}
+
+func (s *handler) cloneVM(source string, name string, p *vcenter.Placement, storage *vcenter.DiskStorage) (*types.ManagedObjectReference, error) {
+	var folder, pool, host, ds *types.ManagedObjectReference
+	if p.Folder != "" {
+		folder = &types.ManagedObjectReference{Type: "Folder", Value: p.Folder}
+	}
+	if p.ResourcePool != "" {
+		pool = &types.ManagedObjectReference{Type: "ResourcePool", Value: p.ResourcePool}
+	}
+	if p.Host != "" {
+		host = &types.ManagedObjectReference{Type: "HostSystem", Value: p.Host}
+	}
+	if storage != nil {
+		if storage.Datastore != "" {
+			ds = &types.ManagedObjectReference{Type: "Datastore", Value: storage.Datastore}
+		}
+	}
+
+	spec := types.VirtualMachineCloneSpec{
+		Template: true,
+		Location: types.VirtualMachineRelocateSpec{
+			Folder:    folder,
+			Pool:      pool,
+			Host:      host,
+			Datastore: ds,
+		},
+	}
+
+	var ref *types.ManagedObjectReference
+
+	return ref, s.withClient(func(ctx context.Context, c *vim25.Client) error {
+		vm := object.NewVirtualMachine(c, types.ManagedObjectReference{Type: "VirtualMachine", Value: source})
+
+		task, err := vm.Clone(ctx, object.NewFolder(c, *folder), name, spec)
+		if err != nil {
+			return err
+		}
+		res, err := task.WaitForResult(ctx, nil)
+		if err != nil {
+			return err
+		}
+		ref = types.NewReference(res.Result.(types.ManagedObjectReference))
+		return nil
+	})
+}
+
+func (s *handler) templateCreate(l content, deploy vcenter.Template) error {
+	ref, err := s.cloneVM(deploy.SourceVM, deploy.Name, deploy.Placement, nil)
+	if err != nil {
+		return err
+	}
+
+	id := uuid.New().String()
+	l.Item[id] = &item{
+		Item: &library.Item{
+			ID:               id,
+			LibraryID:        l.Library.ID,
+			Name:             deploy.Name,
+			Type:             library.ItemTypeVMTX,
+			CreationTime:     types.NewTime(time.Now()),
+			LastModifiedTime: types.NewTime(time.Now()),
+		},
+		Template: ref,
+	}
+
+	return nil
+}
+
+func (s *handler) libraryItemCreateTemplate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+
+	var spec struct {
+		vcenter.Template `json:"spec"`
+	}
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	l, ok := s.Library[spec.Library]
+	if !ok {
+		http.NotFound(w, r)
+		return
+	}
+
+	ref, err := s.cloneVM(spec.SourceVM, spec.Name, spec.Placement, nil)
+	if err != nil {
+		BadRequest(w, err.Error())
+		return
+	}
+
+	id := uuid.New().String()
+	l.Item[id] = &item{
+		Item: &library.Item{
+			ID:               id,
+			LibraryID:        l.Library.ID,
+			Name:             spec.Name,
+			Type:             library.ItemTypeVMTX,
+			CreationTime:     types.NewTime(time.Now()),
+			LastModifiedTime: types.NewTime(time.Now()),
+		},
+		Template: ref,
+	}
+
+	OK(w, id)
+}
+
+func (s *handler) libraryItemTemplateID(w http.ResponseWriter, r *http.Request) {
+	// Go's ServeMux doesn't support wildcard matching, hacking around that for now to support
+	// CheckOuts, e.g. "/vcenter/vm-template/library-items/{item}/check-outs/{vm}?action=check-in"
+	p := strings.TrimPrefix(r.URL.Path, rest.Path+internal.VCenterVMTXLibraryItem+"/")
+	route := strings.Split(p, "/")
+	if len(route) == 0 {
+		http.NotFound(w, r)
+		return
+	}
+
+	id := route[0]
+	ok := false
+
+	var item *item
+	for _, l := range s.Library {
+		item, ok = l.Item[id]
+		if ok {
+			break
+		}
+	}
+	if !ok {
+		log.Printf("library item not found: %q", id)
+		http.NotFound(w, r)
+		return
+	}
+
+	if item.Type != library.ItemTypeVMTX {
+		BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+		return
+	}
+
+	if len(route) > 1 {
+		switch route[1] {
+		case "check-outs":
+			s.libraryItemCheckOuts(item, w, r)
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}
+
+	var spec struct {
+		vcenter.DeployTemplate `json:"spec"`
+	}
+	if !s.decode(r, w, &spec) {
+		return
+	}
+
+	if r.Method == http.MethodGet {
+		// TODO: place holder as the API supports this method,
+		// but not aware of a use case for the data yet.
+		t := &vcenter.TemplateInfo{}
+		OK(w, t)
+		return
+	}
+
+	switch r.URL.Query().Get("action") {
+	case "deploy":
+		p := spec.Placement
+		if p == nil {
+			BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+			return
+		}
+		if p.Cluster == "" && p.Host == "" && p.ResourcePool == "" {
+			BadRequest(w, "com.vmware.vapi.std.errors.invalid_argument")
+			return
+		}
+
+		ref, err := s.cloneVM(item.Template.Value, spec.Name, p, spec.DiskStorage)
+		if err != nil {
+			BadRequest(w, err.Error())
+			return
+		}
+		OK(w, ref.Value)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *handler) libraryItemCheckOuts(item *item, w http.ResponseWriter, r *http.Request) {
+	switch r.URL.Query().Get("action") {
+	case "check-out":
+		var spec struct {
+			*vcenter.CheckOut `json:"spec"`
+		}
+		if !s.decode(r, w, &spec) {
+			return
+		}
+
+		ref, err := s.cloneVM(item.Template.Value, spec.Name, spec.Placement, nil)
+		if err != nil {
+			BadRequest(w, err.Error())
+			return
+		}
+		OK(w, ref.Value)
+	case "check-in":
+		// TODO: increment ContentVersion
+		OK(w, "0")
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *handler) vmID(w http.ResponseWriter, r *http.Request) {
+	id := path.Base(r.URL.Path)
+
+	switch r.Method {
+	case http.MethodDelete:
+		s.deleteVM(&types.ManagedObjectReference{Type: "VirtualMachine", Value: id})
+	default:
+		http.NotFound(w, r)
+	}
+}

--- a/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/categories.go
@@ -87,7 +87,7 @@ func (c *Manager) CreateCategory(ctx context.Context, category *Category) (strin
 		// otherwise create fails with invalid_argument
 		spec.Category.AssociableTypes = []string{}
 	}
-	url := internal.URL(c, internal.CategoryPath)
+	url := c.Resource(internal.CategoryPath)
 	var res string
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
@@ -104,13 +104,13 @@ func (c *Manager) UpdateCategory(ctx context.Context, category *Category) error 
 			Name:            category.Name,
 		},
 	}
-	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	url := c.Resource(internal.CategoryPath).WithID(category.ID)
 	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
 }
 
 // DeleteCategory deletes an existing category.
 func (c *Manager) DeleteCategory(ctx context.Context, category *Category) error {
-	url := internal.URL(c, internal.CategoryPath).WithID(category.ID)
+	url := c.Resource(internal.CategoryPath).WithID(category.ID)
 	return c.Do(ctx, url.Request(http.MethodDelete), nil)
 }
 
@@ -129,14 +129,14 @@ func (c *Manager) GetCategory(ctx context.Context, id string) (*Category, error)
 			}
 		}
 	}
-	url := internal.URL(c, internal.CategoryPath).WithID(id)
+	url := c.Resource(internal.CategoryPath).WithID(id)
 	var res Category
 	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
 }
 
 // ListCategories returns all category IDs in the system.
 func (c *Manager) ListCategories(ctx context.Context) ([]string, error) {
-	url := internal.URL(c, internal.CategoryPath)
+	url := c.Resource(internal.CategoryPath)
 	var res []string
 	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
 }

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tag_association.go
@@ -44,7 +44,7 @@ func (c *Manager) AttachTag(ctx context.Context, tagID string, ref mo.Reference)
 		return err
 	}
 	spec := internal.NewAssociation(ref)
-	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("attach")
+	url := c.Resource(internal.AssociationPath).WithID(id).WithAction("attach")
 	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
 }
 
@@ -56,14 +56,14 @@ func (c *Manager) DetachTag(ctx context.Context, tagID string, ref mo.Reference)
 		return err
 	}
 	spec := internal.NewAssociation(ref)
-	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("detach")
+	url := c.Resource(internal.AssociationPath).WithID(id).WithAction("detach")
 	return c.Do(ctx, url.Request(http.MethodPost, spec), nil)
 }
 
 // ListAttachedTags fetches the array of tag IDs attached to the given object.
 func (c *Manager) ListAttachedTags(ctx context.Context, ref mo.Reference) ([]string, error) {
 	spec := internal.NewAssociation(ref)
-	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags")
+	url := c.Resource(internal.AssociationPath).WithAction("list-attached-tags")
 	var res []string
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
@@ -92,7 +92,7 @@ func (c *Manager) ListAttachedObjects(ctx context.Context, tagID string) ([]mo.R
 	if err != nil {
 		return nil, err
 	}
-	url := internal.URL(c, internal.AssociationPath).WithID(id).WithAction("list-attached-objects")
+	url := c.Resource(internal.AssociationPath).WithID(id).WithAction("list-attached-objects")
 	var res []internal.AssociatedObject
 	if err := c.Do(ctx, url.Request(http.MethodPost, nil), &res); err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (c *Manager) ListAttachedObjectsOnTags(ctx context.Context, tagID []string)
 		TagIDs []string `json:"tag_ids"`
 	}{ids}
 
-	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-objects-on-tags")
+	url := c.Resource(internal.AssociationPath).WithAction("list-attached-objects-on-tags")
 	var res []AttachedObjects
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
@@ -212,7 +212,7 @@ func (c *Manager) ListAttachedTagsOnObjects(ctx context.Context, objectID []mo.R
 		ObjectIDs []internal.AssociatedObject `json:"object_ids"`
 	}{ids}
 
-	url := internal.URL(c, internal.AssociationPath).WithAction("list-attached-tags-on-objects")
+	url := c.Resource(internal.AssociationPath).WithAction("list-attached-tags-on-objects")
 	var res []AttachedTags
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }

--- a/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
+++ b/vendor/github.com/vmware/govmomi/vapi/tags/tags.go
@@ -90,7 +90,7 @@ func (c *Manager) CreateTag(ctx context.Context, tag *Tag) (string, error) {
 		}
 		spec.Tag.CategoryID = cat.ID
 	}
-	url := internal.URL(c, internal.TagPath)
+	url := c.Resource(internal.TagPath)
 	var res string
 	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
 }
@@ -105,13 +105,13 @@ func (c *Manager) UpdateTag(ctx context.Context, tag *Tag) error {
 			Description: tag.Description,
 		},
 	}
-	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	url := c.Resource(internal.TagPath).WithID(tag.ID)
 	return c.Do(ctx, url.Request(http.MethodPatch, spec), nil)
 }
 
 // DeleteTag deletes an existing tag.
 func (c *Manager) DeleteTag(ctx context.Context, tag *Tag) error {
-	url := internal.URL(c, internal.TagPath).WithID(tag.ID)
+	url := c.Resource(internal.TagPath).WithID(tag.ID)
 	return c.Do(ctx, url.Request(http.MethodDelete), nil)
 }
 
@@ -131,7 +131,7 @@ func (c *Manager) GetTag(ctx context.Context, id string) (*Tag, error) {
 		}
 	}
 
-	url := internal.URL(c, internal.TagPath).WithID(id)
+	url := c.Resource(internal.TagPath).WithID(id)
 	var res Tag
 	return &res, c.Do(ctx, url.Request(http.MethodGet), &res)
 
@@ -163,7 +163,7 @@ func (c *Manager) GetTagForCategory(ctx context.Context, id, category string) (*
 
 // ListTags returns all tag IDs in the system.
 func (c *Manager) ListTags(ctx context.Context) ([]string, error) {
-	url := internal.URL(c, internal.TagPath)
+	url := c.Resource(internal.TagPath)
 	var res []string
 	return res, c.Do(ctx, url.Request(http.MethodGet), &res)
 }
@@ -201,7 +201,7 @@ func (c *Manager) ListTagsForCategory(ctx context.Context, id string) ([]string,
 	body := struct {
 		ID string `json:"category_id"`
 	}{id}
-	url := internal.URL(c, internal.TagPath).WithID(id).WithAction("list-tags-for-category")
+	url := c.Resource(internal.TagPath).WithID(id).WithAction("list-tags-for-category")
 	var res []string
 	return res, c.Do(ctx, url.Request(http.MethodPost, body), &res)
 }

--- a/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_ovf.go
+++ b/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_ovf.go
@@ -1,0 +1,261 @@
+/*
+Copyright (c) 2018 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcenter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/rest"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// AdditionalParams are additional OVF parameters which can be specified for a deployment target.
+// This structure is a union where based on Type, only one of each commented section will be set.
+type AdditionalParams struct {
+	Class string `json:"@class"`
+	Type  string `json:"type"`
+
+	// DeploymentOptionParams
+	SelectedKey       string             `json:"selected_key,omitempty"`
+	DeploymentOptions []DeploymentOption `json:"deployment_options,omitempty"`
+
+	// ExtraConfigs
+	ExtraConfig []ExtraConfig `json:"extra_configs,omitempty"`
+
+	// PropertyParams
+	Properties []Property `json:"properties,omitempty"`
+
+	// SizeParams
+	ApproximateSparseDeploymentSize int64 `json:"approximate_sparse_deployment_size,omitempty"`
+	VariableDiskSize                bool  `json:"variable_disk_size,omitempty"`
+	ApproximateDownloadSize         int64 `json:"approximate_download_size,omitempty"`
+	ApproximateFlatDeploymentSize   int64 `json:"approximate_flat_deployment_size,omitempty"`
+
+	// IpAllocationParams
+	SupportedAllocationScheme   []string `json:"supported_allocation_scheme,omitempty"`
+	SupportedIPProtocol         []string `json:"supported_ip_protocol,omitempty"`
+	SupportedIPAllocationPolicy []string `json:"supported_ip_allocation_policy,omitempty"`
+	IPAllocationPolicy          string   `json:"ip_allocation_policy,omitempty"`
+	IPProtocol                  string   `json:"ip_protocol,omitempty"`
+
+	// UnknownSections
+	UnknownSections []UnknownSection `json:"unknown_sections,omitempty"`
+}
+
+const (
+	ClassOvfParams             = "com.vmware.vcenter.ovf.ovf_params"
+	ClassPropertyParams        = "com.vmware.vcenter.ovf.property_params"
+	TypeDeploymentOptionParams = "DeploymentOptionParams"
+	TypeExtraConfigParams      = "ExtraConfigParams"
+	TypeExtraConfigs           = "ExtraConfigs"
+	TypeIPAllocationParams     = "IpAllocationParams"
+	TypePropertyParams         = "PropertyParams"
+	TypeSizeParams             = "SizeParams"
+)
+
+// DeploymentOption contains the information about a deployment option as defined in the OVF specification
+type DeploymentOption struct {
+	Key           string `json:"key,omitempty"`
+	Label         string `json:"label,omitempty"`
+	Description   string `json:"description,omitempty"`
+	DefaultChoice bool   `json:"default_choice,omitempty"`
+}
+
+// ExtraConfig contains information about a vmw:ExtraConfig OVF element
+type ExtraConfig struct {
+	Key             string `json:"key,omitempty"`
+	Value           string `json:"value,omitempty"`
+	VirtualSystemID string `json:"virtual_system_id,omitempty"`
+}
+
+// Property contains information about a property in an OVF package
+type Property struct {
+	Category    string `json:"category,omitempty"`
+	ClassID     string `json:"class_id,omitempty"`
+	Description string `json:"description,omitempty"`
+	ID          string `json:"id,omitempty"`
+	InstanceID  string `json:"instance_id,omitempty"`
+	Label       string `json:"label,omitempty"`
+	Type        string `json:"type,omitempty"`
+	UIOptional  bool   `json:"ui_optional,omitempty"`
+	Value       string `json:"value,omitempty"`
+}
+
+// UnknownSection contains information about an unknown section in an OVF package
+type UnknownSection struct {
+	Tag  string `json:"tag,omitempty"`
+	Info string `json:"info,omitempty"`
+}
+
+// NetworkMapping specifies the target network to use for sections of type ovf:NetworkSection in the OVF descriptor
+type NetworkMapping struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// StorageGroupMapping defines the storage deployment target and storage provisioning type for a section of type vmw:StorageGroupSection in the OVF descriptor
+type StorageGroupMapping struct {
+	Type             string `json:"type"`
+	StorageProfileID string `json:"storage_profile_id,omitempty"`
+	DatastoreID      string `json:"datastore_id,omitempty"`
+	Provisioning     string `json:"provisioning,omitempty"`
+}
+
+// StorageMapping specifies the target storage to use for sections of type vmw:StorageGroupSection in the OVF descriptor
+type StorageMapping struct {
+	Key   string              `json:"key"`
+	Value StorageGroupMapping `json:"value"`
+}
+
+// DeploymentSpec is the deployment specification for the deployment
+type DeploymentSpec struct {
+	Name                string             `json:"name,omitempty"`
+	Annotation          string             `json:"annotation,omitempty"`
+	AcceptAllEULA       bool               `json:"accept_all_EULA,omitempty"`
+	NetworkMappings     []NetworkMapping   `json:"network_mappings,omitempty"`
+	StorageMappings     []StorageMapping   `json:"storage_mappings,omitempty"`
+	StorageProvisioning string             `json:"storage_provisioning,omitempty"`
+	StorageProfileID    string             `json:"storage_profile_id,omitempty"`
+	Locale              string             `json:"locale,omitempty"`
+	Flags               []string           `json:"flags,omitempty"`
+	AdditionalParams    []AdditionalParams `json:"additional_parameters,omitempty"`
+	DefaultDatastoreID  string             `json:"default_datastore_id,omitempty"`
+}
+
+// Target is the target for the deployment
+type Target struct {
+	ResourcePoolID string `json:"resource_pool_id,omitempty"`
+	HostID         string `json:"host_id,omitempty"`
+	FolderID       string `json:"folder_id,omitempty"`
+}
+
+// Deploy contains the information to start the deployment of a library OVF
+type Deploy struct {
+	DeploymentSpec `json:"deployment_spec,omitempty"`
+	Target         `json:"target,omitempty"`
+}
+
+// Error is a SERVER error
+type Error struct {
+	Class    string                    `json:"@class,omitempty"`
+	Messages []rest.LocalizableMessage `json:"messages,omitempty"`
+}
+
+// ParseIssue is a parse issue struct
+type ParseIssue struct {
+	Category     string                  `json:"@classcategory,omitempty"`
+	File         string                  `json:"file,omitempty"`
+	LineNumber   int64                   `json:"line_number,omitempty"`
+	ColumnNumber int64                   `json:"column_number,omitempty"`
+	Message      rest.LocalizableMessage `json:"message,omitempty"`
+}
+
+// OVFError is a list of errors from create or deploy
+type OVFError struct {
+	Category string                   `json:"category,omitempty"`
+	Error    *Error                   `json:"error,omitempty"`
+	Issues   []ParseIssue             `json:"issues,omitempty"`
+	Message  *rest.LocalizableMessage `json:"message,omitempty"`
+}
+
+// ResourceID is a managed object reference for a deployed resource.
+type ResourceID struct {
+	Type  string `json:"type,omitempty"`
+	Value string `json:"id,omitempty"`
+}
+
+// DeploymentError is an error that occurs when deploying and OVF from
+// a library item.
+type DeploymentError struct {
+	Errors []OVFError `json:"errors,omitempty"`
+}
+
+// Error implements the error interface
+func (e *DeploymentError) Error() string {
+	msg := ""
+	if len(e.Errors) != 0 {
+		err := e.Errors[0]
+		if err.Message != nil {
+			msg = err.Message.DefaultMessage
+		} else if err.Error != nil && len(err.Error.Messages) != 0 {
+			msg = err.Error.Messages[0].DefaultMessage
+		}
+	}
+	if msg == "" {
+		msg = fmt.Sprintf("%#v", e)
+	}
+	return "deploy error: " + msg
+}
+
+// Deployment is the results from issuing a library OVF deployment
+type Deployment struct {
+	Succeeded  bool             `json:"succeeded,omitempty"`
+	ResourceID *ResourceID      `json:"resource_id,omitempty"`
+	Error      *DeploymentError `json:"error,omitempty"`
+}
+
+// FilterRequest contains the information to start a vcenter filter call
+type FilterRequest struct {
+	Target `json:"target,omitempty"`
+}
+
+// FilterResponse returns information from the vcenter filter call
+type FilterResponse struct {
+	EULAs            []string           `json:"EULAs,omitempty"`
+	AdditionalParams []AdditionalParams `json:"additional_params,omitempty"`
+	Annotation       string             `json:"Annotation,omitempty"`
+	Name             string             `json:"name,omitempty"`
+	Networks         []string           `json:"Networks,omitempty"`
+	StorageGroups    []string           `json:"storage_groups,omitempty"`
+}
+
+// Manager extends rest.Client, adding content library related methods.
+type Manager struct {
+	*rest.Client
+}
+
+// NewManager creates a new Manager instance with the given client.
+func NewManager(client *rest.Client) *Manager {
+	return &Manager{
+		Client: client,
+	}
+}
+
+// DeployLibraryItem deploys a library OVF
+func (c *Manager) DeployLibraryItem(ctx context.Context, libraryItemID string, deploy Deploy) (*types.ManagedObjectReference, error) {
+	url := c.Resource(internal.VCenterOVFLibraryItem).WithID(libraryItemID).WithAction("deploy")
+	var res Deployment
+	err := c.Do(ctx, url.Request(http.MethodPost, deploy), &res)
+	if err != nil {
+		return nil, err
+	}
+	if res.Succeeded {
+		ref := types.ManagedObjectReference(*res.ResourceID)
+		return &ref, nil
+	}
+	return nil, res.Error
+}
+
+// FilterLibraryItem deploys a library OVF
+func (c *Manager) FilterLibraryItem(ctx context.Context, libraryItemID string, filter FilterRequest) (FilterResponse, error) {
+	url := c.Resource(internal.VCenterOVFLibraryItem).WithID(libraryItemID).WithAction("filter")
+	var res FilterResponse
+	return res, c.Do(ctx, url.Request(http.MethodPost, filter), &res)
+}

--- a/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_vmtx.go
+++ b/vendor/github.com/vmware/govmomi/vapi/vcenter/vcenter_vmtx.go
@@ -1,0 +1,290 @@
+/*
+Copyright (c) 2019 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcenter
+
+import (
+	"context"
+	"crypto/sha1"
+	"fmt"
+	"log"
+	"net/http"
+	"path"
+
+	"github.com/vmware/govmomi/vapi/internal"
+	"github.com/vmware/govmomi/vapi/library"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// vcenter vm template
+// The vcenter.vm_template API provides structures and services that will let its client manage VMTX template in Content Library.
+// http://vmware.github.io/vsphere-automation-sdk-rest/6.7.1/index.html#SVC_com.vmware.vcenter.vm_template.library_items
+
+// Template create spec
+type Template struct {
+	Description          string                `json:"description,omitempty"`
+	DiskStorage          *DiskStorage          `json:"disk_storage,omitempty"`
+	DiskStorageOverrides []DiskStorageOverride `json:"disk_storage_overrides,omitempty"`
+	Library              string                `json:"library,omitempty"`
+	Name                 string                `json:"name,omitempty"`
+	Placement            *Placement            `json:"placement,omitempty"`
+	SourceVM             string                `json:"source_vm,omitempty"`
+	VMHomeStorage        *DiskStorage          `json:"vm_home_storage,omitempty"`
+}
+
+// TemplateInfo for a VM template contained in an existing library item
+type TemplateInfo struct {
+	GuestOS string `json:"guest_OS,omitempty"`
+	// TODO...
+}
+
+// Placement information used to place the virtual machine template
+type Placement struct {
+	ResourcePool string `json:"resource_pool,omitempty"`
+	Host         string `json:"host,omitempty"`
+	Folder       string `json:"folder,omitempty"`
+	Cluster      string `json:"cluster,omitempty"`
+}
+
+// StoragePolicy for DiskStorage
+type StoragePolicy struct {
+	Policy string `json:"policy,omitempty"`
+	Type   string `json:"type"`
+}
+
+// DiskStorage defines the storage specification for VM files
+type DiskStorage struct {
+	Datastore     string         `json:"datastore,omitempty"`
+	StoragePolicy *StoragePolicy `json:"storage_policy,omitempty"`
+}
+
+// DiskStorageOverride storage specification for individual disks in the virtual machine template
+type DiskStorageOverride struct {
+	Key   string      `json:"key"`
+	Value DiskStorage `json:"value"`
+}
+
+// GuestCustomization spec to apply to the deployed VM
+type GuestCustomization struct {
+	Name string `json:"name,omitempty"`
+}
+
+// HardwareCustomization spec which specifies updates to the deployed VM
+type HardwareCustomization struct {
+	// TODO
+}
+
+// DeployTemplate specification of how a library VM template clone should be deployed.
+type DeployTemplate struct {
+	Description           string                 `json:"description,omitempty"`
+	DiskStorage           *DiskStorage           `json:"disk_storage,omitempty"`
+	DiskStorageOverrides  []DiskStorageOverride  `json:"disk_storage_overrides,omitempty"`
+	GuestCustomization    *GuestCustomization    `json:"guest_customization,omitempty"`
+	HardwareCustomization *HardwareCustomization `json:"hardware_customization,omitempty"`
+	Name                  string                 `json:"name,omitempty"`
+	Placement             *Placement             `json:"placement,omitempty"`
+	PoweredOn             bool                   `json:"powered_on"`
+	VMHomeStorage         *DiskStorage           `json:"vm_home_storage,omitempty"`
+}
+
+// CheckOut specification
+type CheckOut struct {
+	Name      string     `json:"name,omitempty"`
+	Placement *Placement `json:"placement,omitempty"`
+	PoweredOn bool       `json:"powered_on,omitempty"`
+}
+
+// CheckIn specification
+type CheckIn struct {
+	Message string `json:"message"`
+}
+
+// CreateTemplate creates a library item in content library from an existing VM
+func (c *Manager) CreateTemplate(ctx context.Context, vmtx Template) (string, error) {
+	url := c.Resource(internal.VCenterVMTXLibraryItem)
+	var res string
+	spec := struct {
+		Template `json:"spec"`
+	}{vmtx}
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// DeployTemplateLibraryItem deploys a VM as a copy of the source VM template contained in the given library item
+func (c *Manager) DeployTemplateLibraryItem(ctx context.Context, libraryItemID string, deploy DeployTemplate) (*types.ManagedObjectReference, error) {
+	url := c.Resource(path.Join(internal.VCenterVMTXLibraryItem, libraryItemID)).WithParam("action", "deploy")
+	var res string
+	spec := struct {
+		DeployTemplate `json:"spec"`
+	}{deploy}
+	err := c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	if err != nil {
+		return nil, err
+	}
+	return &types.ManagedObjectReference{Type: "VirtualMachine", Value: res}, nil
+}
+
+// CheckOut a library item containing a VM template.
+func (c *Manager) CheckOut(ctx context.Context, libraryItemID string, checkout *CheckOut) (*types.ManagedObjectReference, error) {
+	url := c.Resource(path.Join(internal.VCenterVMTXLibraryItem, libraryItemID, "check-outs")).WithParam("action", "check-out")
+	var res string
+	spec := struct {
+		*CheckOut `json:"spec"`
+	}{checkout}
+	err := c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+	if err != nil {
+		return nil, err
+	}
+	return &types.ManagedObjectReference{Type: "VirtualMachine", Value: res}, nil
+}
+
+// CheckIn a VM into the library item.
+func (c *Manager) CheckIn(ctx context.Context, libraryItemID string, vm mo.Reference, checkin *CheckIn) (string, error) {
+	p := path.Join(internal.VCenterVMTXLibraryItem, libraryItemID, "check-outs", vm.Reference().Value)
+	url := c.Resource(p).WithParam("action", "check-in")
+	var res string
+	spec := struct {
+		*CheckIn `json:"spec"`
+	}{checkin}
+	return res, c.Do(ctx, url.Request(http.MethodPost, spec), &res)
+}
+
+// TemplateLibrary params for synchronizing subscription library OVF items to VM Template items
+type TemplateLibrary struct {
+	Source      library.Library
+	Destination library.Library
+	Placement   Target
+	Include     func(library.Item, *library.Item) bool
+	SyncItem    func(context.Context, library.Item, *Deploy, *Template) error
+}
+
+func (c *Manager) includeTemplateLibraryItem(src library.Item, dst *library.Item) bool {
+	return dst == nil
+}
+
+// SyncTemplateLibraryItem deploys an Library OVF item from which a VM template (vmtx) Library item is created.
+// The deployed VM is deleted after being converted to a Library vmtx item.
+func (c *Manager) SyncTemplateLibraryItem(ctx context.Context, item library.Item, deploy *Deploy, spec *Template) error {
+	destroy := false
+	if spec.SourceVM == "" {
+		ref, err := c.DeployLibraryItem(ctx, item.ID, *deploy)
+		if err != nil {
+			return err
+		}
+
+		destroy = true
+		spec.SourceVM = ref.Value
+	}
+
+	_, err := c.CreateTemplate(ctx, *spec)
+
+	if destroy {
+		// Delete source VM regardless of CreateTemplate result
+		url := c.Resource("/vcenter/vm/" + spec.SourceVM)
+		derr := c.Do(ctx, url.Request(http.MethodDelete), nil)
+		if derr != nil {
+			if err == nil {
+				// Return Delete error if CreateTemplate was successful
+				return derr
+			}
+			// Return CreateTemplate error and just log Delete error
+			log.Printf("destroy %s: %s", spec.SourceVM, derr)
+		}
+	}
+
+	return err
+}
+
+func vmtxSourceName(l library.Library, item library.Item) string {
+	sum := sha1.Sum([]byte(path.Join(l.Name, item.Name)))
+	return fmt.Sprintf("vmtx-src-%x", sum)
+}
+
+// SyncTemplateLibrary converts TemplateLibrary.Source OVF items to VM Template items within TemplateLibrary.Destination
+// The optional TemplateLibrary.Include func can be used to filter which items are synced.
+// By default all items that don't exist in the Destination library are synced.
+// The optional TemplateLibrary.SyncItem func can be used to change how the item is synced, by default SyncTemplateLibraryItem is used.
+func (c *Manager) SyncTemplateLibrary(ctx context.Context, l TemplateLibrary, items ...library.Item) error {
+	m := library.NewManager(c.Client)
+	var err error
+	if len(items) == 0 {
+		items, err = m.GetLibraryItems(ctx, l.Source.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	templates, err := m.GetLibraryItems(ctx, l.Destination.ID)
+	if err != nil {
+		return err
+	}
+
+	existing := make(map[string]*library.Item)
+	for i := range templates {
+		existing[templates[i].Name] = &templates[i]
+	}
+
+	include := l.Include
+	if include == nil {
+		include = c.includeTemplateLibraryItem
+	}
+
+	sync := l.SyncItem
+	if sync == nil {
+		sync = c.SyncTemplateLibraryItem
+	}
+
+	for _, item := range items {
+		if item.Type != library.ItemTypeOVF {
+			continue
+		}
+
+		// Deploy source VM from library ovf item
+		deploy := Deploy{
+			DeploymentSpec: DeploymentSpec{
+				Name:               vmtxSourceName(l.Destination, item),
+				DefaultDatastoreID: l.Destination.Storage[0].DatastoreID,
+				AcceptAllEULA:      true,
+			},
+			Target: l.Placement,
+		}
+
+		// Create library vmtx item from source VM
+		storage := &DiskStorage{
+			Datastore: deploy.DeploymentSpec.DefaultDatastoreID,
+		}
+		spec := Template{
+			Name:          item.Name,
+			Library:       l.Destination.ID,
+			DiskStorage:   storage,
+			VMHomeStorage: storage,
+			Placement: &Placement{
+				Folder:       deploy.Target.FolderID,
+				ResourcePool: deploy.Target.ResourcePoolID,
+			},
+		}
+
+		if !l.Include(item, existing[item.Name]) {
+			continue
+		}
+
+		if err = sync(ctx, item, &deploy, &spec); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/vmware/govmomi/view/container_view.go
+++ b/vendor/github.com/vmware/govmomi/view/container_view.go
@@ -1,0 +1,130 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ContainerView struct {
+	ManagedObjectView
+}
+
+func NewContainerView(c *vim25.Client, ref types.ManagedObjectReference) *ContainerView {
+	return &ContainerView{
+		ManagedObjectView: *NewManagedObjectView(c, ref),
+	}
+}
+
+// Retrieve populates dst as property.Collector.Retrieve does, for all entities in the view of types specified by kind.
+func (v ContainerView) Retrieve(ctx context.Context, kind []string, ps []string, dst interface{}) error {
+	pc := property.DefaultCollector(v.Client())
+
+	ospec := types.ObjectSpec{
+		Obj:  v.Reference(),
+		Skip: types.NewBool(true),
+		SelectSet: []types.BaseSelectionSpec{
+			&types.TraversalSpec{
+				Type: v.Reference().Type,
+				Path: "view",
+			},
+		},
+	}
+
+	var pspec []types.PropertySpec
+
+	if len(kind) == 0 {
+		kind = []string{"ManagedEntity"}
+	}
+
+	for _, t := range kind {
+		spec := types.PropertySpec{
+			Type: t,
+		}
+
+		if len(ps) == 0 {
+			spec.All = types.NewBool(true)
+		} else {
+			spec.PathSet = ps
+		}
+
+		pspec = append(pspec, spec)
+	}
+
+	req := types.RetrieveProperties{
+		SpecSet: []types.PropertyFilterSpec{
+			{
+				ObjectSet: []types.ObjectSpec{ospec},
+				PropSet:   pspec,
+			},
+		},
+	}
+
+	res, err := pc.RetrieveProperties(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	if d, ok := dst.(*[]types.ObjectContent); ok {
+		*d = res.Returnval
+		return nil
+	}
+
+	return mo.LoadObjectContent(res.Returnval, dst)
+}
+
+// RetrieveWithFilter populates dst as Retrieve does, but only for entities matching the given filter.
+func (v ContainerView) RetrieveWithFilter(ctx context.Context, kind []string, ps []string, dst interface{}, filter property.Filter) error {
+	if len(filter) == 0 {
+		return v.Retrieve(ctx, kind, ps, dst)
+	}
+
+	var content []types.ObjectContent
+
+	err := v.Retrieve(ctx, kind, filter.Keys(), &content)
+	if err != nil {
+		return err
+	}
+
+	objs := filter.MatchObjectContent(content)
+
+	pc := property.DefaultCollector(v.Client())
+
+	return pc.Retrieve(ctx, objs, ps, dst)
+}
+
+// Find returns object references for entities of type kind, matching the given filter.
+func (v ContainerView) Find(ctx context.Context, kind []string, filter property.Filter) ([]types.ManagedObjectReference, error) {
+	if len(filter) == 0 {
+		// Ensure we have at least 1 filter to avoid retrieving all properties.
+		filter = property.Filter{"name": "*"}
+	}
+
+	var content []types.ObjectContent
+
+	err := v.Retrieve(ctx, kind, filter.Keys(), &content)
+	if err != nil {
+		return nil, err
+	}
+
+	return filter.MatchObjectContent(content), nil
+}

--- a/vendor/github.com/vmware/govmomi/view/list_view.go
+++ b/vendor/github.com/vmware/govmomi/view/list_view.go
@@ -1,0 +1,62 @@
+/*
+Copyright (c) 2015-2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ListView struct {
+	ManagedObjectView
+}
+
+func NewListView(c *vim25.Client, ref types.ManagedObjectReference) *ListView {
+	return &ListView{
+		ManagedObjectView: *NewManagedObjectView(c, ref),
+	}
+}
+
+func (v ListView) Add(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ModifyListView{
+		This: v.Reference(),
+		Add:  refs,
+	}
+	_, err := methods.ModifyListView(ctx, v.Client(), &req)
+	return err
+}
+
+func (v ListView) Remove(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ModifyListView{
+		This:   v.Reference(),
+		Remove: refs,
+	}
+	_, err := methods.ModifyListView(ctx, v.Client(), &req)
+	return err
+}
+
+func (v ListView) Reset(ctx context.Context, refs []types.ManagedObjectReference) error {
+	req := types.ResetListView{
+		This: v.Reference(),
+		Obj:  refs,
+	}
+	_, err := methods.ResetListView(ctx, v.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/view/managed_object_view.go
+++ b/vendor/github.com/vmware/govmomi/view/managed_object_view.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type ManagedObjectView struct {
+	object.Common
+}
+
+func NewManagedObjectView(c *vim25.Client, ref types.ManagedObjectReference) *ManagedObjectView {
+	return &ManagedObjectView{
+		Common: object.NewCommon(c, ref),
+	}
+}
+
+func (v *ManagedObjectView) TraversalSpec() *types.TraversalSpec {
+	return &types.TraversalSpec{
+		Path: "view",
+		Type: v.Reference().Type,
+	}
+}
+
+func (v *ManagedObjectView) Destroy(ctx context.Context) error {
+	req := types.DestroyView{
+		This: v.Reference(),
+	}
+
+	_, err := methods.DestroyView(ctx, v.Client(), &req)
+	return err
+}

--- a/vendor/github.com/vmware/govmomi/view/manager.go
+++ b/vendor/github.com/vmware/govmomi/view/manager.go
@@ -1,0 +1,69 @@
+/*
+Copyright (c) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/methods"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+type Manager struct {
+	object.Common
+}
+
+func NewManager(c *vim25.Client) *Manager {
+	m := Manager{
+		object.NewCommon(c, *c.ServiceContent.ViewManager),
+	}
+
+	return &m
+}
+
+func (m Manager) CreateListView(ctx context.Context, objects []types.ManagedObjectReference) (*ListView, error) {
+	req := types.CreateListView{
+		This: m.Common.Reference(),
+		Obj:  objects,
+	}
+
+	res, err := methods.CreateListView(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewListView(m.Client(), res.Returnval), nil
+}
+
+func (m Manager) CreateContainerView(ctx context.Context, container types.ManagedObjectReference, managedObjectTypes []string, recursive bool) (*ContainerView, error) {
+
+	req := types.CreateContainerView{
+		This:      m.Common.Reference(),
+		Container: container,
+		Recursive: recursive,
+		Type:      managedObjectTypes,
+	}
+
+	res, err := methods.CreateContainerView(ctx, m.Client(), &req)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewContainerView(m.Client(), res.Returnval), nil
+}

--- a/vendor/github.com/vmware/govmomi/view/task_view.go
+++ b/vendor/github.com/vmware/govmomi/view/task_view.go
@@ -1,0 +1,125 @@
+/*
+Copyright (c) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package view
+
+import (
+	"context"
+
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25/types"
+)
+
+// TaskView extends ListView such that it can follow a ManagedEntity's recentTask updates.
+type TaskView struct {
+	*ListView
+
+	Follow bool
+
+	Watch *types.ManagedObjectReference
+}
+
+// CreateTaskView creates a new ListView that optionally watches for a ManagedEntity's recentTask updates.
+func (m Manager) CreateTaskView(ctx context.Context, watch *types.ManagedObjectReference) (*TaskView, error) {
+	l, err := m.CreateListView(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tv := &TaskView{
+		ListView: l,
+		Watch:    watch,
+	}
+
+	return tv, nil
+}
+
+// Collect calls function f for each Task update.
+func (v TaskView) Collect(ctx context.Context, f func([]types.TaskInfo)) error {
+	// Using TaskHistoryCollector would be less clunky, but it isn't supported on ESX at all.
+	ref := v.Reference()
+	filter := new(property.WaitFilter).Add(ref, "Task", []string{"info"}, v.TraversalSpec())
+
+	if v.Watch != nil {
+		filter.Add(*v.Watch, v.Watch.Type, []string{"recentTask"})
+	}
+
+	pc := property.DefaultCollector(v.Client())
+
+	completed := make(map[string]bool)
+
+	return property.WaitForUpdates(ctx, pc, filter, func(updates []types.ObjectUpdate) bool {
+		var infos []types.TaskInfo
+		var prune []types.ManagedObjectReference
+		var tasks []types.ManagedObjectReference
+		var reset func()
+
+		for _, update := range updates {
+			for _, change := range update.ChangeSet {
+				if change.Name == "recentTask" {
+					tasks = change.Val.(types.ArrayOfManagedObjectReference).ManagedObjectReference
+					if len(tasks) != 0 {
+						reset = func() {
+							_ = v.Reset(ctx, tasks)
+
+							// Remember any tasks we've reported as complete already,
+							// to avoid reporting multiple times when Reset is triggered.
+							rtasks := make(map[string]bool)
+							for i := range tasks {
+								if _, ok := completed[tasks[i].Value]; ok {
+									rtasks[tasks[i].Value] = true
+								}
+							}
+							completed = rtasks
+						}
+					}
+
+					continue
+				}
+
+				info, ok := change.Val.(types.TaskInfo)
+				if !ok {
+					continue
+				}
+
+				if !completed[info.Task.Value] {
+					infos = append(infos, info)
+				}
+
+				if v.Follow && info.CompleteTime != nil {
+					prune = append(prune, info.Task)
+					completed[info.Task.Value] = true
+				}
+			}
+		}
+
+		if len(infos) != 0 {
+			f(infos)
+		}
+
+		if reset != nil {
+			reset()
+		} else if len(prune) != 0 {
+			_ = v.Remove(ctx, prune)
+		}
+
+		if len(tasks) != 0 && len(infos) == 0 {
+			return false
+		}
+
+		return !v.Follow
+	})
+}

--- a/vendor/github.com/vmware/govmomi/vim25/debug/debug.go
+++ b/vendor/github.com/vmware/govmomi/vim25/debug/debug.go
@@ -18,8 +18,7 @@ package debug
 
 import (
 	"io"
-	"os"
-	"path"
+	"regexp"
 )
 
 // Provider specified the interface types must implement to be used as a
@@ -31,6 +30,7 @@ type Provider interface {
 }
 
 var currentProvider Provider = nil
+var scrubPassword = regexp.MustCompile(`<password>(.*)</password>`)
 
 func SetProvider(p Provider) {
 	if currentProvider != nil {
@@ -54,28 +54,9 @@ func Flush() {
 	currentProvider.Flush()
 }
 
-// FileProvider implements a debugging provider that creates a real file for
-// every call to NewFile. It maintains a list of all files that it creates,
-// such that it can close them when its Flush function is called.
-type FileProvider struct {
-	Path string
+func Scrub(in []byte) []byte {
+	out := string(in)
+	out = scrubPassword.ReplaceAllString(out, `<password>********</password>`)
 
-	files []*os.File
-}
-
-func (fp *FileProvider) NewFile(p string) io.WriteCloser {
-	f, err := os.Create(path.Join(fp.Path, p))
-	if err != nil {
-		panic(err)
-	}
-
-	fp.files = append(fp.files, f)
-
-	return f
-}
-
-func (fp *FileProvider) Flush() {
-	for _, f := range fp.files {
-		f.Close()
-	}
+	return []byte(out)
 }

--- a/vendor/github.com/vmware/govmomi/vim25/debug/file.go
+++ b/vendor/github.com/vmware/govmomi/vim25/debug/file.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"io"
+	"os"
+	"path"
+)
+
+// FileProvider implements a debugging provider that creates a real file for
+// every call to NewFile. It maintains a list of all files that it creates,
+// such that it can close them when its Flush function is called.
+type FileProvider struct {
+	Path  string
+	files []*os.File
+}
+
+func (fp *FileProvider) NewFile(p string) io.WriteCloser {
+	f, err := os.Create(path.Join(fp.Path, p))
+	if err != nil {
+		panic(err)
+	}
+
+	fp.files = append(fp.files, f)
+
+	return NewFileWriterCloser(f, p)
+}
+
+func (fp *FileProvider) Flush() {
+	for _, f := range fp.files {
+		f.Close()
+	}
+}
+
+type FileWriterCloser struct {
+	f *os.File
+	p string
+}
+
+func NewFileWriterCloser(f *os.File, p string) *FileWriterCloser {
+	return &FileWriterCloser{
+		f,
+		p,
+	}
+}
+
+func (fwc *FileWriterCloser) Write(p []byte) (n int, err error) {
+	return fwc.f.Write(Scrub(p))
+}
+
+func (fwc *FileWriterCloser) Close() error {
+	return fwc.f.Close()
+}

--- a/vendor/github.com/vmware/govmomi/vim25/debug/log.go
+++ b/vendor/github.com/vmware/govmomi/vim25/debug/log.go
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2014 VMware, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package debug
+
+import (
+	"io"
+	"log"
+)
+
+type LogWriterCloser struct {
+}
+
+func NewLogWriterCloser() *LogWriterCloser {
+	return &LogWriterCloser{}
+}
+
+func (lwc *LogWriterCloser) Write(p []byte) (n int, err error) {
+	log.Print(string(Scrub(p)))
+	return len(p), nil
+}
+
+func (lwc *LogWriterCloser) Close() error {
+	return nil
+}
+
+type LogProvider struct {
+}
+
+func (s *LogProvider) NewFile(p string) io.WriteCloser {
+	log.Print(p)
+	return NewLogWriterCloser()
+}
+
+func (s *LogProvider) Flush() {
+}

--- a/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/mo.go
@@ -79,12 +79,13 @@ func init() {
 type ClusterComputeResource struct {
 	ComputeResource
 
-	Configuration     types.ClusterConfigInfo          `mo:"configuration"`
-	Recommendation    []types.ClusterRecommendation    `mo:"recommendation"`
-	DrsRecommendation []types.ClusterDrsRecommendation `mo:"drsRecommendation"`
-	MigrationHistory  []types.ClusterDrsMigration      `mo:"migrationHistory"`
-	ActionHistory     []types.ClusterActionHistory     `mo:"actionHistory"`
-	DrsFault          []types.ClusterDrsFaults         `mo:"drsFault"`
+	Configuration     types.ClusterConfigInfo                    `mo:"configuration"`
+	Recommendation    []types.ClusterRecommendation              `mo:"recommendation"`
+	DrsRecommendation []types.ClusterDrsRecommendation           `mo:"drsRecommendation"`
+	HciConfig         *types.ClusterComputeResourceHCIConfigInfo `mo:"hciConfig"`
+	MigrationHistory  []types.ClusterDrsMigration                `mo:"migrationHistory"`
+	ActionHistory     []types.ClusterActionHistory               `mo:"actionHistory"`
+	DrsFault          []types.ClusterDrsFaults                   `mo:"drsFault"`
 }
 
 func init() {

--- a/vendor/github.com/vmware/govmomi/vim25/mo/retrieve.go
+++ b/vendor/github.com/vmware/govmomi/vim25/mo/retrieve.go
@@ -46,7 +46,7 @@ func ignoreMissingProperty(ref types.ManagedObjectReference, p types.MissingProp
 // it returns the first fault it finds there as error. If the 'MissingSet'
 // field is empty, it returns a pointer to a reflect.Value. It handles contain
 // nested properties, such as 'guest.ipAddress' or 'config.hardware'.
-func ObjectContentToType(o types.ObjectContent) (interface{}, error) {
+func ObjectContentToType(o types.ObjectContent, ptr ...bool) (interface{}, error) {
 	// Expect no properties in the missing set
 	for _, p := range o.MissingSet {
 		if ignoreMissingProperty(o.Obj, p) {
@@ -62,6 +62,9 @@ func ObjectContentToType(o types.ObjectContent) (interface{}, error) {
 		return nil, err
 	}
 
+	if len(ptr) == 1 && ptr[0] {
+		return v.Interface(), nil
+	}
 	return v.Elem().Interface(), nil
 }
 
@@ -81,9 +84,9 @@ func ApplyPropertyChange(obj Reference, changes []types.PropertyChange) {
 	}
 }
 
-// LoadRetrievePropertiesResponse converts the response of a call to
-// RetrieveProperties to one or more managed objects.
-func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst interface{}) error {
+// LoadObjectContent converts the response of a call to
+// RetrieveProperties{Ex} to one or more managed objects.
+func LoadObjectContent(content []types.ObjectContent, dst interface{}) error {
 	rt := reflect.TypeOf(dst)
 	if rt == nil || rt.Kind() != reflect.Ptr {
 		panic("need pointer")
@@ -104,7 +107,7 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 	}
 
 	if isSlice {
-		for _, p := range res.Returnval {
+		for _, p := range content {
 			v, err := ObjectContentToType(p)
 			if err != nil {
 				return err
@@ -123,10 +126,10 @@ func LoadRetrievePropertiesResponse(res *types.RetrievePropertiesResponse, dst i
 			rv.Set(reflect.Append(rv, reflect.ValueOf(v)))
 		}
 	} else {
-		switch len(res.Returnval) {
+		switch len(content) {
 		case 0:
 		case 1:
-			v, err := ObjectContentToType(res.Returnval[0])
+			v, err := ObjectContentToType(content[0])
 			if err != nil {
 				return err
 			}
@@ -160,7 +163,7 @@ func RetrievePropertiesForRequest(ctx context.Context, r soap.RoundTripper, req 
 		return err
 	}
 
-	return LoadRetrievePropertiesResponse(res, dst)
+	return LoadObjectContent(res.Returnval, dst)
 }
 
 // RetrieveProperties retrieves the properties of the managed object specified
@@ -187,4 +190,66 @@ func RetrieveProperties(ctx context.Context, r soap.RoundTripper, pc, obj types.
 	}
 
 	return RetrievePropertiesForRequest(ctx, r, req, dst)
+}
+
+var morType = reflect.TypeOf((*types.ManagedObjectReference)(nil)).Elem()
+
+// References returns all non-nil moref field values in the given struct.
+// Only Anonymous struct fields are followed by default. The optional follow
+// param will follow any struct fields when true.
+func References(s interface{}, follow ...bool) []types.ManagedObjectReference {
+	var refs []types.ManagedObjectReference
+	rval := reflect.ValueOf(s)
+	rtype := rval.Type()
+
+	if rval.Kind() == reflect.Ptr {
+		rval = rval.Elem()
+		rtype = rval.Type()
+	}
+
+	for i := 0; i < rval.NumField(); i++ {
+		val := rval.Field(i)
+		finfo := rtype.Field(i)
+
+		if finfo.Anonymous {
+			refs = append(refs, References(val.Interface(), follow...)...)
+			continue
+		}
+		if finfo.Name == "Self" {
+			continue
+		}
+
+		ftype := val.Type()
+
+		if ftype.Kind() == reflect.Slice {
+			if ftype.Elem() == morType {
+				s := val.Interface().([]types.ManagedObjectReference)
+				for i := range s {
+					refs = append(refs, s[i])
+				}
+			}
+			continue
+		}
+
+		if ftype.Kind() == reflect.Ptr {
+			if val.IsNil() {
+				continue
+			}
+			val = val.Elem()
+			ftype = val.Type()
+		}
+
+		if ftype == morType {
+			refs = append(refs, val.Interface().(types.ManagedObjectReference))
+			continue
+		}
+
+		if len(follow) != 0 && follow[0] {
+			if ftype.Kind() == reflect.Struct && val.CanSet() {
+				refs = append(refs, References(val.Interface(), follow...)...)
+			}
+		}
+	}
+
+	return refs
 }

--- a/vendor/github.com/vmware/govmomi/vim25/types/types.go
+++ b/vendor/github.com/vmware/govmomi/vim25/types/types.go
@@ -8231,7 +8231,7 @@ func init() {
 type ClusterDasAdmissionControlPolicy struct {
 	DynamicData
 
-	ResourceReductionToToleratePercent int32 `xml:"resourceReductionToToleratePercent,omitempty"`
+	ResourceReductionToToleratePercent *int32 `xml:"resourceReductionToToleratePercent"`
 }
 
 func init() {
@@ -49025,6 +49025,17 @@ func init() {
 
 type VStorageObjectCreateSnapshot_TaskResponse struct {
 	Returnval ManagedObjectReference `xml:"returnval"`
+}
+
+type VStorageObjectSnapshotDetails struct {
+	DynamicData
+
+	Path                   string `xml:"path,omitempty"`
+	ChangedBlockTrackingId string `xml:"changedBlockTrackingId,omitempty"`
+}
+
+func init() {
+	t["VStorageObjectSnapshotDetails"] = reflect.TypeOf((*VStorageObjectSnapshotDetails)(nil)).Elem()
 }
 
 type VStorageObjectSnapshotInfo struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -217,7 +217,7 @@ github.com/spf13/cobra
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.4.0
 github.com/stretchr/testify/assert
-# github.com/vmware/govmomi v0.21.0
+# github.com/vmware/govmomi v0.22.2
 github.com/vmware/govmomi
 github.com/vmware/govmomi/find
 github.com/vmware/govmomi/list
@@ -232,8 +232,12 @@ github.com/vmware/govmomi/simulator/internal
 github.com/vmware/govmomi/simulator/vpx
 github.com/vmware/govmomi/task
 github.com/vmware/govmomi/vapi/internal
+github.com/vmware/govmomi/vapi/library
 github.com/vmware/govmomi/vapi/rest
+github.com/vmware/govmomi/vapi/simulator
 github.com/vmware/govmomi/vapi/tags
+github.com/vmware/govmomi/vapi/vcenter
+github.com/vmware/govmomi/view
 github.com/vmware/govmomi/vim25
 github.com/vmware/govmomi/vim25/debug
 github.com/vmware/govmomi/vim25/methods


### PR DESCRIPTION
Jira ticket description:
```
As a customer of the cloud team the installer team needs
the workers to be configured with a tag that was created during the IPI
installation process so that if destroy cluster is executed all the machines
created are deleted.

Exit criteria:

Workers that are created by MAO have a tag associated with the cluster that was provisioned.
See installer sections below for additional information:
https://github.com/openshift/installer/blob/master/pkg/destroy/vsphere/vsphere.go#L142-L158

https://github.com/openshift/installer/blob/master/data/data/vsphere/main.tf#L49-L65
```