### PR TITLE
Properly apply updates to MAO-managed workloads

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/glog"
 	osconfigv1 "github.com/openshift/api/config/v1"
+	osoperatorv1 "github.com/openshift/api/operator/v1"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
@@ -59,6 +60,8 @@ type Operator struct {
 	// queue only ever has one item, but it has nice error handling backoff/retry semantics
 	queue           workqueue.RateLimitingInterface
 	operandVersions []osconfigv1.OperandVersion
+
+	generations []osoperatorv1.GenerationStatus
 }
 
 // New returns a new machine config operator.


### PR DESCRIPTION
In commit 69986ee5, we moved from using the CVO variant of the resourceapply library to the openshift/library-go variant. The CVO variant, a deep comparison is performed of the expected state with the current state to decide whether to apply an update. In the library-go variant, this decision is based on an objectMeta comparison, particularly whether the current generation of the resource matches the "expected generation".

Currently we use the resources reported observedGeneration as this "expected generation" input. This doesn't make sense, since this will only differ from the current generation when the deployment controller hasn't yet reconciled an update. You can see this issue by scaling down the machine-api-controllers deployment and observing that MAO happily leaves it that way. Worse, if we now released MAO updates with changes to these resources, we wouldn't actually update them.

The idea with "expected generation" is that we should record the current generation any time we apply an update, and use the last recorded generation as our "expected generation" to know when to re-sync.

The operators.openshift.io API provides a GenerationStatus construct to persist the last generations in a CR for an operator. The MAO doesn't currently have such a CR, but we can still use this internally - and the associated resourcemerge helpers - to at least track the last generation in memory to ensure resourceapply makes updates when necessary.