### PR TITLE
Give friendly hint when not starting in-cluster

### DIFF
--- a/cmd/machine-api-operator/client_builder.go
+++ b/cmd/machine-api-operator/client_builder.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/golang/glog"
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	mapiclientset "github.com/openshift/machine-api-operator/pkg/generated/clientset/versioned"
@@ -57,6 +59,9 @@ func getRestConfig(kubeconfig string) (*rest.Config, error) {
 	} else {
 		glog.V(4).Infof("Using in-cluster kube client config")
 		config, err = rest.InClusterConfig()
+		if err == rest.ErrNotInCluster {
+			return nil, errors.New("Not running in-cluster? Try using --kubeconfig")
+		}
 	}
 	return config, err
 }


### PR DESCRIPTION
Currently we do this:

```
./bin/machine-api-operator start --images-json ./images.json --alsologtostderr --v=3
I0328 16:34:18.688008   36609 start.go:58] Version: 0.1.0-780-g4e3ac1e2-dirty
F0328 16:34:18.688396   36609 start.go:66] error creating clients: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
```

Make us a bit friendlier:

```
./bin/machine-api-operator start --images-json ./images.json --alsologtostderr --v=3
I0328 16:35:50.846740   10863 start.go:58] Version: 0.1.0-780-g4e3ac1e2-dirty
F0328 16:35:50.846808   10863 start.go:66] error creating clients: Not running in-cluster? Try using --kubeconfig
```