### PR TITLE
bug 1816398: Let MHC to remediate any machine owned by a controller

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -447,17 +447,6 @@ func (t *target) remediate(r *ReconcileMachineHealthCheck) error {
 			return t.remediationStrategyExternal(r)
 		}
 	}
-	if t.isMaster() {
-		r.recorder.Eventf(
-			&t.Machine,
-			corev1.EventTypeNormal,
-			EventSkippedMaster,
-			"Machine %v is a master node, skipping remediation",
-			t.string(),
-		)
-		glog.Infof("%s: master node, skipping remediation", t.string())
-		return nil
-	}
 
 	glog.Infof("%s: deleting", t.string())
 	if err := r.client.Delete(context.TODO(), &t.Machine); err != nil {
@@ -542,21 +531,6 @@ func (t *target) nodeName() string {
 		return t.Node.GetName()
 	}
 	return ""
-}
-
-func (t *target) isMaster() bool {
-	if t.Node != nil {
-		if labels.Set(t.Node.Labels).Has(nodeMasterLabel) {
-			return true
-		}
-	}
-
-	// if the node is not found we fallback to check the machine
-	if labels.Set(t.Machine.Labels).Get(machineRoleLabel) == machineMasterRole {
-		return true
-	}
-
-	return false
 }
 
 func (t *target) needsRemediation(timeoutForMachineToHaveNode time.Duration) (bool, time.Duration, error) {

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -1752,112 +1752,6 @@ func TestNeedsRemediation(t *testing.T) {
 	}
 }
 
-func TestIsMaster(t *testing.T) {
-	testCases := []struct {
-		testCase string
-		target   *target
-		expected bool
-	}{
-		{
-			testCase: "no master",
-			target: &target{
-				Machine: mapiv1beta1.Machine{
-					TypeMeta: metav1.TypeMeta{Kind: "Machine"},
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations:     make(map[string]string),
-						Name:            "test",
-						Namespace:       namespace,
-						Labels:          map[string]string{"foo": "bar"},
-						OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
-					},
-					Spec:   mapiv1beta1.MachineSpec{},
-					Status: mapiv1beta1.MachineStatus{},
-				},
-				Node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: metav1.NamespaceNone,
-						Annotations: map[string]string{
-							machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machine"),
-						},
-						Labels: map[string]string{},
-					},
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Node",
-					},
-					Status: corev1.NodeStatus{},
-				},
-				MHC: mapiv1beta1.MachineHealthCheck{},
-			},
-		},
-		{
-			testCase: "node master",
-			target: &target{
-				Machine: mapiv1beta1.Machine{
-					TypeMeta: metav1.TypeMeta{Kind: "Machine"},
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations:     make(map[string]string),
-						Name:            "test",
-						Namespace:       namespace,
-						Labels:          map[string]string{"foo": "bar"},
-						OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
-					},
-					Spec:   mapiv1beta1.MachineSpec{},
-					Status: mapiv1beta1.MachineStatus{},
-				},
-				Node: &corev1.Node{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: metav1.NamespaceNone,
-						Annotations: map[string]string{
-							machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machine"),
-						},
-						Labels: map[string]string{
-							nodeMasterLabel: "",
-						},
-					},
-					TypeMeta: metav1.TypeMeta{
-						Kind: "Node",
-					},
-					Status: corev1.NodeStatus{},
-				},
-				MHC: mapiv1beta1.MachineHealthCheck{},
-			},
-			expected: true,
-		},
-		{
-			testCase: "machine master",
-			target: &target{
-				Machine: mapiv1beta1.Machine{
-					TypeMeta: metav1.TypeMeta{Kind: "Machine"},
-					ObjectMeta: metav1.ObjectMeta{
-						Annotations: make(map[string]string),
-						Name:        "test",
-						Namespace:   namespace,
-						Labels: map[string]string{
-							machineRoleLabel: machineMasterRole,
-						},
-						OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
-					},
-					Spec:   mapiv1beta1.MachineSpec{},
-					Status: mapiv1beta1.MachineStatus{},
-				},
-				Node: &corev1.Node{},
-				MHC:  mapiv1beta1.MachineHealthCheck{},
-			},
-			expected: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.testCase, func(t *testing.T) {
-			if got := tc.target.isMaster(); got != tc.expected {
-				t.Errorf("Case: %v. Got: %v, expected error: %v", tc.testCase, got, tc.expected)
-			}
-		})
-	}
-}
-
 func TestMinDuration(t *testing.T) {
 	testCases := []struct {
 		testCase  string
@@ -1992,9 +1886,9 @@ func TestRemediate(t *testing.T) {
 				},
 				MHC: mapiv1beta1.MachineHealthCheck{},
 			},
-			deletion:       false,
+			deletion:       true,
 			expectedError:  false,
-			expectedEvents: []string{EventSkippedMaster},
+			expectedEvents: []string{EventMachineDeleted},
 		},
 		{
 			testCase: "machine master",
@@ -2019,9 +1913,9 @@ func TestRemediate(t *testing.T) {
 				Node: &corev1.Node{},
 				MHC:  mapiv1beta1.MachineHealthCheck{},
 			},
-			deletion:       false,
+			deletion:       true,
 			expectedError:  false,
-			expectedEvents: []string{EventSkippedMaster},
+			expectedEvents: []string{EventMachineDeleted},
 		},
 	}
 

--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -8,6 +8,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -74,12 +75,17 @@ func NewMachine(name string, nodeName string) *mapiv1.Machine {
 	m := &mapiv1.Machine{
 		TypeMeta: metav1.TypeMeta{Kind: "Machine"},
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations:     make(map[string]string),
-			Name:            name,
-			Namespace:       Namespace,
-			Labels:          FooBar(),
-			UID:             uuid.NewUUID(),
-			OwnerReferences: []metav1.OwnerReference{{Kind: "MachineSet"}},
+			Annotations: make(map[string]string),
+			Name:        name,
+			Namespace:   Namespace,
+			Labels:      FooBar(),
+			UID:         uuid.NewUUID(),
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       "MachineSet",
+					Controller: pointer.BoolPtr(true),
+				},
+			},
 		},
 		Spec: mapiv1.MachineSpec{},
 	}


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1816398
We want to relax the hard dependency on machineSets and let remediation to happen for machines that are owned by any controller.
This will enable a possible integration for a self healing control plane.