### PR TITLE
vsphere ipi: replace .Name() with .ObjectName()

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -301,9 +301,18 @@ func (r *Reconciler) reconcileNetwork(vm *virtualMachine) error {
 		}
 	}
 
+	// Using Name() if InventoryPath is empty will return empty name
+	// see: https://github.com/vmware/govmomi/blob/master/object/common.go#L66-L75
+	// Using ObjectName() as it will query from VirtualMachine properties
+
+	vmName, err := vm.Obj.ObjectName(vm.Context)
+	if err != nil {
+		return fmt.Errorf("error getting virtual machine name: %v", err)
+	}
+
 	ipAddrs = append(ipAddrs, corev1.NodeAddress{
 		Type:    corev1.NodeInternalDNS,
-		Address: vm.Obj.Name(),
+		Address: vmName,
 	})
 
 	klog.V(3).Infof("%v: reconciling network: IP addresses: %v", r.machine.GetName(), ipAddrs)

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -521,6 +521,11 @@ func TestReconcileNetwork(t *testing.T) {
 		Ref:     managedObjRef,
 	}
 
+	vmName, err := vm.Obj.ObjectName(vm.Context)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	expectedAddresses := []corev1.NodeAddress{
 		{
 			Type:    corev1.NodeInternalIP,
@@ -528,7 +533,7 @@ func TestReconcileNetwork(t *testing.T) {
 		},
 		{
 			Type:    corev1.NodeInternalDNS,
-			Address: vm.Obj.Name(),
+			Address: vmName,
 		},
 	}
 	r := &Reconciler{


### PR DESCRIPTION
After testing with latest MAO I noticed that InternalDNS was an empty string.
I have tested this and the `ObjectName()` method functions as expected.  

The Name method returns an empty string instead of the VirtualMachine
name.  ObjectName uses VirtualMachine propertie `name` to return
the name.

Update tests

