### PR TITLE
[OCPCLOUD-815] Use MachineSet controller from MAO image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install ma
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-healthcheck .
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./manager
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./machineset-controller
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/vsphere ./machine-controller-manager
 
 LABEL io.openshift.release.operator true

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -8,7 +8,7 @@ COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install ma
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-healthcheck .
-COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./manager
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./machineset-controller
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/vsphere ./machine-controller-manager
 
 LABEL io.openshift.release.operator true

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
+	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v0.0.0-20200323095748-e7041f8762a3
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81

--- a/pkg/operator/baremetal_test.go
+++ b/pkg/operator/baremetal_test.go
@@ -54,6 +54,7 @@ func newOperatorWithBaremetalConfig() *OperatorConfig {
 			"docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
 			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
 			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
+			"docker.io/openshift/origin-machine-api-operator:v4.0.0",
 			"docker.io/openshift/origin-aws-machine-controllers:v4.0.0",
 		},
 		BaremetalControllers{

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -27,6 +27,7 @@ type OperatorConfig struct {
 
 type Controllers struct {
 	Provider           string
+	MachineSet         string
 	NodeLink           string
 	MachineHealthCheck string
 	TerminationHandler string

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -298,6 +298,7 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		TargetNamespace: optr.namespace,
 		Controllers: Controllers{
 			Provider:           providerControllerImage,
+			MachineSet:         machineAPIOperatorImage,
 			NodeLink:           machineAPIOperatorImage,
 			MachineHealthCheck: machineAPIOperatorImage,
 			TerminationHandler: terminationHandlerImage,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -297,7 +297,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 	containers := []corev1.Container{
 		{
 			Name:      "controller-manager",
-			Image:     config.Controllers.Provider,
+			Image:     config.Controllers.MachineSet,
 			Command:   []string{"/manager"},
 			Args:      args,
 			Resources: resources,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -296,9 +296,9 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 
 	containers := []corev1.Container{
 		{
-			Name:      "controller-manager",
+			Name:      "machineset-controller",
 			Image:     config.Controllers.MachineSet,
-			Command:   []string{"/manager"},
+			Command:   []string{"/machineset-controller"},
 			Args:      args,
 			Resources: resources,
 		},


### PR DESCRIPTION
This changes the image for the MachineSet controller deployed in the `machine-api-controllers` deployment to use the `machine-api-operator` image instead of the `provider` image.

Also adds tests to check the output of `maoConfigFromInfrastructure` as this was not previously tested