### PR TITLE
add a podman option to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,13 +19,19 @@ endif
 .PHONY: all
 all: check build test
 
+USE_PODMAN ?= 0
 NO_DOCKER ?= 0
 ifeq ($(NO_DOCKER), 1)
   DOCKER_CMD =
   IMAGE_BUILD_CMD = imagebuilder
 else
-  DOCKER_CMD := docker run --env GO111MODULE=$(GO111MODULE) --env GOFLAGS=$(GOFLAGS) --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-operator:Z -w /go/src/github.com/openshift/machine-api-operator golang:1.13
-  IMAGE_BUILD_CMD = docker build
+  ifeq ($(USE_PODMAN), 1)
+	OCI_BINARY = podman
+  else
+	OCI_BINARY = docker
+  endif
+  DOCKER_CMD := $(OCI_BINARY) run --env GO111MODULE=$(GO111MODULE) --env GOFLAGS=$(GOFLAGS) --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-operator:Z -w /go/src/github.com/openshift/machine-api-operator golang:1.13
+  IMAGE_BUILD_CMD = $(OCI_BINARY) build
 endif
 
 .PHONY: vendor

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ machine.openshift.io/cluster-api-machine-type: worker
   $ make image
   ```
 
+Please note that by default make will attempt to use the `docker` command
+to create binaries and images. If you would like to disable this behavior, set
+the environment variable `NO_DOCKER=1`. Alternatively if you woud like to use
+`podman`, set the environment variable `USE_PODMAN=1`.
+
 The Machine API Operator is designed to work in conjunction with the [Cluster Version Operator](https://github.com/openshift/cluster-version-operator).
 You can see it in action by running an [OpenShift Cluster deployed by the Installer](https://github.com/openshift/installer).
 


### PR DESCRIPTION
This change allows a user to set `USE_PODMAN=1` when running the make
command to force usage of podman instead of docker during the build and
image targets.

Also adds a note to the README about the `NO_DOCKER` and `USE_PODMAN`
options.