### PR TITLE
Bug 1810443: Rephrase MachineWithNoRunningPhase message

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -29,7 +29,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            message: "machine {{ $labels.name }} is in {{ $labels.phase }} phase"
+            message: "machine {{ $labels.name }} is in phase: {{ $labels.phase }}"
     - name: machine-api-operator-metrics-collector-up
       rules:
         - alert: MachineAPIOperatorMetricsCollectionFailing


### PR DESCRIPTION
This is to make it more obvious that the phases is not even set for the edge case where this might happen if a machine controller was never run.