### PR TITLE
bug 1810443: Rephrase machine-with-no-running-phase alert

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -29,7 +29,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            message: "machine {{ $labels.name }} is in phase: {{ $labels.phase }}"
+            message: "machine {{ $labels.name }} is not in \"Running\" phase. {{ $labels.phase }}"
     - name: machine-api-operator-metrics-collector-up
       rules:
         - alert: MachineAPIOperatorMetricsCollectionFailing


### PR DESCRIPTION
Rephrase machine-with-no-running-phase alert to remove confusion when no phase has been set yet 