### PR TITLE
BUG 1823308: Allow machine-api-termination-handler to use hostnetwork SCC

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -198,6 +198,14 @@ rules:
     verbs:
       - list
       - delete
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - hostnetwork
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
This allows the machine-api-temrmination-handler service account to use hostnetwork, fixing the DaemonSet that was unable to deploy due to SCC constraints