### PR TITLE
BUG 1815219: Allow machines to have encrypted EBS volumes with non-default key

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -32,6 +32,24 @@ spec:
       - elasticloadbalancing:RegisterTargets
       - iam:PassRole
       resource: "*"
+    - effect: Allow
+      action:
+      - kms:Decrypt
+      - kms:Encrypt
+      - kms:GenerateDataKey
+      - kms:GenerateDataKeyWithoutPlainText
+      - kms:DescribeKey
+      resource: '*'
+    - effect: Allow
+      action:
+      - kms:RevokeGrant
+      - kms:CreateGrant
+      - kms:ListGrants
+      resource: '*'
+      policyCondition:
+        "Bool":
+          "kms:GrantIsForAWSResource": true
+
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
This relies on https://github.com/openshift/cloud-credential-operator/pull/181 merging first, but I have manually tested the IAM credentials will allow using Customer Manager Keys for encrypting EBS volumes