### PR TITLE
Bug 1824943: check minimum available time in waitForDeploymentRollout

### DIFF
--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -25,7 +25,7 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
 	fakekube "k8s.io/client-go/kubernetes/fake"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -40,7 +40,7 @@ const (
 func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, stopCh <-chan struct{}) *Operator {
 	kubeClient := fakekube.NewSimpleClientset(kubeObjects...)
 	osClient := fakeos.NewSimpleClientset(osObjects...)
-	dynamicClient := fakedynamic.NewSimpleDynamicClient(clientgoscheme.Scheme, kubeObjects...)
+	dynamicClient := fakedynamic.NewSimpleDynamicClient(scheme.Scheme, kubeObjects...)
 	kubeNamespacedSharedInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 2*time.Minute, informers.WithNamespace(targetNamespace))
 	configSharedInformer := configinformersv1.NewSharedInformerFactoryWithOptions(osClient, 2*time.Minute)
 	featureGateInformer := configSharedInformer.Config().V1().FeatureGates()

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -25,6 +25,7 @@ import (
 	fakedynamic "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/informers"
 	fakekube "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 )
@@ -39,7 +40,7 @@ const (
 func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, stopCh <-chan struct{}) *Operator {
 	kubeClient := fakekube.NewSimpleClientset(kubeObjects...)
 	osClient := fakeos.NewSimpleClientset(osObjects...)
-	dynamicClient := fakedynamic.NewSimpleDynamicClient(runtime.NewScheme(), kubeObjects...)
+	dynamicClient := fakedynamic.NewSimpleDynamicClient(clientgoscheme.Scheme, kubeObjects...)
 	kubeNamespacedSharedInformer := informers.NewSharedInformerFactoryWithOptions(kubeClient, 2*time.Minute, informers.WithNamespace(targetNamespace))
 	configSharedInformer := configinformersv1.NewSharedInformerFactoryWithOptions(osClient, 2*time.Minute)
 	featureGateInformer := configSharedInformer.Config().V1().FeatureGates()

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -1,0 +1,120 @@
+package operator
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestWaitForDeploymentRollout(t *testing.T) {
+	testCases := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		expected   error
+	}{
+		{
+			name: "Deployment is available for more than deploymentMinimumAvailabilityTime min",
+			deployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: targetNamespace,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					UpdatedReplicas:     1,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentAvailable,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: time.Now().Add(-deploymentMinimumAvailabilityTime - 1*time.Second)},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "Deployment is available for less than deploymentMinimumAvailabilityTime min",
+			deployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: targetNamespace,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					UpdatedReplicas:     1,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 0,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentAvailable,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: time.Now().Add(-10 * time.Second)},
+						},
+					},
+				},
+			},
+			expected: fmt.Errorf("deployment test has been available for less than 3 min"),
+		},
+		{
+			name: "Deployment has unavailable replicas",
+			deployment: &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Deployment",
+					APIVersion: "apps/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: targetNamespace,
+				},
+				Status: appsv1.DeploymentStatus{
+					Replicas:            1,
+					UpdatedReplicas:     1,
+					ReadyReplicas:       1,
+					AvailableReplicas:   1,
+					UnavailableReplicas: 1,
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:               appsv1.DeploymentAvailable,
+							Status:             corev1.ConditionTrue,
+							LastTransitionTime: metav1.Time{Time: time.Now().Add(-10 * time.Second)},
+						},
+					},
+				},
+			},
+			expected: fmt.Errorf("deployment test is not ready. status: (replicas: 1, updated: 1, ready: 1, unavailable: 1)"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			optr := newFakeOperator([]runtime.Object{tc.deployment}, nil, make(<-chan struct{}))
+
+			got := optr.waitForDeploymentRollout(tc.deployment, 1*time.Second, 3*time.Second)
+			if tc.expected != nil {
+				if tc.expected.Error() != got.Error() {
+					t.Errorf("Got: %v, expected: %v", got, tc.expected)
+				}
+			} else if tc.expected != got {
+				t.Errorf("Got: %v, expected: %v", got, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/util/conditions/conditions.go
+++ b/pkg/util/conditions/conditions.go
@@ -1,12 +1,23 @@
 package conditions
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
 // GetNodeCondition returns node condition by type
 func GetNodeCondition(node *corev1.Node, conditionType corev1.NodeConditionType) *corev1.NodeCondition {
 	for _, cond := range node.Status.Conditions {
+		if cond.Type == conditionType {
+			return &cond
+		}
+	}
+	return nil
+}
+
+// GetDeploymentCondition returns node condition by type
+func GetDeploymentCondition(deployment *appsv1.Deployment, conditionType appsv1.DeploymentConditionType) *appsv1.DeploymentCondition {
+	for _, cond := range deployment.Status.Conditions {
 		if cond.Type == conditionType {
 			return &cond
 		}


### PR DESCRIPTION
There might be scenarios where the operator flips between degraded false/true. 
E.g the managed deployment rolls out successfully. A particular business logic path makes one container to panic consistently. Go to 1.

https://github.com/openshift/api/blob/2ea89d203c53704f1fcfeb55c13ededab14fd020/config/v1/types_cluster_operator.go#L168
This results in a lower quality of service and Degraded should not oscillate but rather should remain true until the persistent observation of the problematic condition is fixed.

This PR cover this scenario by raising the expectation for the managed deployments to be available for a minimum duration, i.e 3 min.