### PR TITLE
BUG 1825851: Ensure malformed IntOrPercent returns error

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -692,9 +692,9 @@ func getIntOrPercentValue(intOrStr *intstr.IntOrString) (int, bool, error) {
 	case intstr.String:
 		isPercent := false
 		s := intOrStr.StrVal
-		if strings.Contains(s, "%") {
+		if strings.HasSuffix(s, "%") {
 			isPercent = true
-			s = strings.Replace(intOrStr.StrVal, "%", "", -1)
+			s = strings.TrimSuffix(intOrStr.StrVal, "%")
 		}
 		v, err := strconv.Atoi(s)
 		if err != nil {

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -2648,6 +2648,7 @@ func TestGetIntOrPercentValue(t *testing.T) {
 	intInString30 := intstr.FromString("30")
 	invalidStringA := intstr.FromString("a")
 	invalidStringAPercent := intstr.FromString("a%")
+	invalidStringNumericPercent := intstr.FromString("1%0")
 
 	testCases := []struct {
 		name            string
@@ -2690,6 +2691,13 @@ func TestGetIntOrPercentValue(t *testing.T) {
 			expectedValue:   0,
 			expectedPercent: true,
 			expectedError:   fmt.Errorf("invalid value \"a%%\": strconv.Atoi: parsing \"a\": invalid syntax"),
+		},
+		{
+			name:            "with an '1%0' string",
+			in:              &invalidStringNumericPercent,
+			expectedValue:   0,
+			expectedPercent: false,
+			expectedError:   fmt.Errorf("invalid value \"1%%0\": strconv.Atoi: parsing \"1%%0\": invalid syntax"),
 		},
 	}
 


### PR DESCRIPTION
A [new case](https://github.com/kubernetes/kubernetes/pull/89482#issuecomment-604102034) of malformed IntOrPercent was brought to my attention, I have added a test case and fixed the behaviour of our implementation