### PR TITLE
Bug 1827593: Check if tag is already attached to vm

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -778,9 +778,17 @@ func (vm *virtualMachine) reconcileTags(ctx context.Context, session *session.Se
 
 		clusterID := machine.Labels[machinev1.MachineClusterIDLabel]
 
-		// the tag should already be created by installer
-		if err := m.AttachTag(ctx, clusterID, vm.Ref); err != nil {
+		attached, err := vm.checkAttachedTag(ctx, clusterID, m)
+		if err != nil {
 			return err
+		}
+
+		if !attached {
+			klog.Infof("%v: Attaching %s tag to vm", machine.GetName(), clusterID)
+			// the tag should already be created by installer
+			if err := m.AttachTag(ctx, clusterID, vm.Ref); err != nil {
+				return err
+			}
 		}
 
 		return nil
@@ -789,6 +797,22 @@ func (vm *virtualMachine) reconcileTags(ctx context.Context, session *session.Se
 	}
 
 	return nil
+}
+
+// checkAttachedTag returns true if tag is already attached to a vm
+func (vm *virtualMachine) checkAttachedTag(ctx context.Context, tagName string, m *tags.Manager) (bool, error) {
+	tags, err := m.GetAttachedTags(ctx, vm.Ref)
+	if err != nil {
+		return false, err
+	}
+
+	for _, tag := range tags {
+		if tag.Name == tagName {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 type NetworkStatus struct {


### PR DESCRIPTION
Attaching a tag to VM takes about 20-30 seconds and waiting for it becomes a bit annoying. We should check if the tag was already attached to VM and skip attaching it for multiple times.