### PR TITLE
BUG 1826017: Switch to Go errors instead of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/library-go v0.0.0-20200324092245-db2a8546af81
 	github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/common v0.7.0 // indirect
 	github.com/prometheus/procfs v0.0.5 // indirect

--- a/pkg/controller/machineset/delete_policy.go
+++ b/pkg/controller/machineset/delete_policy.go
@@ -17,11 +17,11 @@ limitations under the License.
 package machineset
 
 import (
+	"fmt"
 	"math"
 	"sort"
 
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -129,6 +129,6 @@ func getDeletePriorityFunc(ms *v1beta1.MachineSet) (deletePriorityFunc, error) {
 	case "":
 		return randomDeletePolicy, nil
 	default:
-		return nil, errors.Errorf("Unsupported delete policy %s. Must be one of 'Random', 'Newest', or 'Oldest'", msdp)
+		return nil, fmt.Errorf("Unsupported delete policy %s. Must be one of 'Random', 'Newest', or 'Oldest'", msdp)
 	}
 }

--- a/pkg/controller/machineset/status.go
+++ b/pkg/controller/machineset/status.go
@@ -18,10 +18,10 @@ package machineset
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -2,13 +2,13 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	apivsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	machineapierros "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/openshift/machine-api-operator/pkg/controller/vsphere/session"
-	"github.com/pkg/errors"
 	apicorev1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog"
@@ -78,7 +78,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 		providerSpec.Workspace.Server, providerSpec.Workspace.Datacenter,
 		user, password)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create vSphere session")
+		return nil, fmt.Errorf("failed to create vSphere session: %w", err)
 	}
 
 	return &machineScope{

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -2,13 +2,13 @@ package vsphere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"gopkg.in/gcfg.v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	vspherev1 "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
Replace all `errors.Wrap(f)` with `fmt.Errorf` to drop the dependency on `github.com/pkg/errors`.

This ensures that the vSphere provider is compatible with the changes introduced in #559