### PR TITLE
Bug 1827601: vSphere - Return error on empty task reference

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -60,17 +60,19 @@ func (r *Reconciler) create() error {
 		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
 	}
 
-	moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
-	if err != nil {
-		if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+	if r.providerStatus.TaskRef != "" {
+		moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
+		if err != nil {
+			if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+				return err
+			}
+		}
+		if taskIsFinished, err := taskIsFinished(moTask); err != nil || !taskIsFinished {
+			if !taskIsFinished {
+				return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+			}
 			return err
 		}
-	}
-	if taskIsFinished, err := taskIsFinished(moTask); err != nil || !taskIsFinished {
-		if !taskIsFinished {
-			return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
-		}
-		return err
 	}
 
 	if _, err := findVM(r.machineScope); err != nil {
@@ -104,17 +106,19 @@ func (r *Reconciler) update() error {
 		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
 	}
 
-	motask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
-	if err != nil {
-		if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+	if r.providerStatus.TaskRef != "" {
+		motask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
+		if err != nil {
+			if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+				return err
+			}
+		}
+		if taskIsFinished, err := taskIsFinished(motask); err != nil || !taskIsFinished {
+			if !taskIsFinished {
+				return fmt.Errorf("task %v has not finished", motask.Reference().Value)
+			}
 			return err
 		}
-	}
-	if taskIsFinished, err := taskIsFinished(motask); err != nil || !taskIsFinished {
-		if !taskIsFinished {
-			return fmt.Errorf("task %v has not finished", motask.Reference().Value)
-		}
-		return err
 	}
 
 	vmRef, err := findVM(r.machineScope)
@@ -163,17 +167,19 @@ func (r *Reconciler) exists() (bool, error) {
 }
 
 func (r *Reconciler) delete() error {
-	moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
-	if err != nil {
-		if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+	if r.providerStatus.TaskRef != "" {
+		moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
+		if err != nil {
+			if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+				return err
+			}
+		}
+		if taskIsFinished, err := taskIsFinished(moTask); err != nil || !taskIsFinished {
+			if !taskIsFinished {
+				return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+			}
 			return err
 		}
-	}
-	if taskIsFinished, err := taskIsFinished(moTask); err != nil || !taskIsFinished {
-		if !taskIsFinished {
-			return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
-		}
-		return err
 	}
 
 	vmRef, err := findVM(r.machineScope)

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1014,12 +1014,6 @@ func TestCreate(t *testing.T) {
 		},
 	}
 
-	vmObj := object.NewVirtualMachine(session.Client.Client, vm.Reference())
-	task, err := vmObj.PowerOn(context.TODO())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		name                  string
 		expectedError         error
@@ -1076,17 +1070,15 @@ func TestCreate(t *testing.T) {
 						Labels:    labels,
 					},
 				},
-				providerSpec: &tc.providerSpec,
-				session:      session,
-				providerStatus: &vsphereapi.VSphereMachineProviderStatus{
-					TaskRef: task.Reference().Value,
-				},
-				client: fake.NewFakeClientWithScheme(scheme.Scheme, &credentialsSecret),
+				providerSpec:   &tc.providerSpec,
+				session:        session,
+				providerStatus: &vsphereapi.VSphereMachineProviderStatus{},
+				client:         fake.NewFakeClientWithScheme(scheme.Scheme, &credentialsSecret),
 			}
 
 			reconciler := newReconciler(&machineScope)
 
-			err = reconciler.create()
+			err := reconciler.create()
 
 			if tc.expectedError != nil {
 				if err == nil {
@@ -1126,12 +1118,6 @@ func TestUpdate(t *testing.T) {
 			credentialsSecretUsername: []byte(server.URL.User.Username()),
 			credentialsSecretPassword: []byte(password),
 		},
-	}
-
-	vmObj := object.NewVirtualMachine(session.Client.Client, vm.Reference())
-	task, err := vmObj.PowerOn(context.TODO())
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	if err := session.WithRestClient(context.TODO(), func(c *rest.Client) error {
@@ -1217,12 +1203,10 @@ func TestUpdate(t *testing.T) {
 						UID:       apimachinerytypes.UID(instanceUUID),
 					},
 				},
-				providerSpec: &tc.providerSpec,
-				session:      session,
-				providerStatus: &vsphereapi.VSphereMachineProviderStatus{
-					TaskRef: task.Reference().Value,
-				},
-				client: fake.NewFakeClientWithScheme(scheme.Scheme, &credentialsSecret),
+				providerSpec:   &tc.providerSpec,
+				session:        session,
+				providerStatus: &vsphereapi.VSphereMachineProviderStatus{},
+				client:         fake.NewFakeClientWithScheme(scheme.Scheme, &credentialsSecret),
 			}
 
 			reconciler := newReconciler(&machineScope)

--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -166,7 +166,7 @@ func isValidUUID(str string) bool {
 
 func (s *Session) GetTask(ctx context.Context, taskRef string) (*mo.Task, error) {
 	if taskRef == "" {
-		return nil, nil
+		return nil, errors.New("taskRef can't be empty")
 	}
 	var obj mo.Task
 	moRef := types.ManagedObjectReference{

--- a/pkg/controller/vsphere/session/session_test.go
+++ b/pkg/controller/vsphere/session/session_test.go
@@ -219,9 +219,9 @@ func TestGetTask(t *testing.T) {
 			found:       true,
 		},
 		{
-			testCase:    "empty string",
+			testCase:    "fail on empty string",
 			taskRef:     "",
-			expectError: false,
+			expectError: true,
 			found:       false,
 		},
 		{


### PR DESCRIPTION
It's better to return an error on empty task reference. Returning `nil` without any error means we need to check the returned task for `nil` every time and it also brings a bit of confusion to code.