### PR TITLE
Bug 1826983: Fix External DHCP range values for Baremetal configuration

### DIFF
--- a/pkg/operator/baremetal_config.go
+++ b/pkg/operator/baremetal_config.go
@@ -132,7 +132,11 @@ func getIronicInspectorEndpoint(baremetalConfig BaremetalProvisioningConfig) *st
 }
 
 func getProvisioningDHCPRange(baremetalConfig BaremetalProvisioningConfig) *string {
+	// When the DHCP server is external, it is OK for the DHCP range in the CR
+	// to be empty.
 	if baremetalConfig.ProvisioningDHCPRange != "" {
+		return &(baremetalConfig.ProvisioningDHCPRange)
+	} else if baremetalConfig.ProvisioningDHCPExternal {
 		return &(baremetalConfig.ProvisioningDHCPRange)
 	}
 	return nil


### PR DESCRIPTION
Allow an empty string to be passed in as DHCP range when the DHCP
server is external in a Baremetal IPI installation.