### PR TITLE
Bug 1829333: vSphere - Don't reconcile power state

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -135,14 +135,7 @@ func (r *Reconciler) update() error {
 		return fmt.Errorf("failed to reconcile tags: %w", err)
 	}
 
-	// TODO: we won't always want to reconcile power state
-	//  but as per comment in clone() function, powering on right on creation might be problematic
-	ok, task, err := vm.reconcilePowerState()
-	if err != nil || !ok {
-		return err
-	}
-
-	return r.reconcileMachineWithCloudState(vm, task)
+	return r.reconcileMachineWithCloudState(vm, r.providerStatus.TaskRef)
 }
 
 // exists returns true if machine exists.
@@ -512,11 +505,7 @@ func clone(s *machineScope) (string, error) {
 			Pool:         types.NewReference(resourcepool.Reference()),
 			DiskMoveType: diskMoveType,
 		},
-		// This is implicit, but making it explicit as it is important to not
-		// power the VM on before its virtual hardware is created and the MAC
-		// address(es) used to build and inject the VM with cloud-init metadata
-		// are generated.
-		PowerOn:  false,
+		PowerOn:  true,
 		Snapshot: snapshotRef,
 	}
 
@@ -716,29 +705,6 @@ func (vm *virtualMachine) getRegionAndZone(c *rest.Client, regionLabel, zoneLabe
 	}
 
 	return result, nil
-}
-
-func (vm *virtualMachine) reconcilePowerState() (bool, string, error) {
-	powerState, err := vm.getPowerState()
-	if err != nil {
-		return false, "", err
-	}
-	switch powerState {
-	case types.VirtualMachinePowerStatePoweredOff:
-		klog.Infof("%v: powering on", vm.Obj.Reference().Value)
-		task, err := vm.powerOnVM()
-		if err != nil {
-			return false, "", fmt.Errorf("failed to trigger power on op for vm %q: %w", vm, err)
-		}
-
-		klog.Infof("%v: requeue to wait for power on state", vm.Obj.Reference().Value)
-		return false, task, nil
-	case types.VirtualMachinePowerStatePoweredOn:
-		klog.Infof("%v: powered on", vm.Obj.Reference().Value)
-		return true, "", nil
-	default:
-		return false, "", fmt.Errorf("unexpected power state %q for vm %q", powerState, vm)
-	}
 }
 
 func (vm *virtualMachine) powerOnVM() (string, error) {


### PR DESCRIPTION
We should support the ability to switch off VM but current implementation turns on VM in every machine update. 
I removed the reconciliation of power state and set `PowerOn:  true` on machine creation. We have this part copied from upstream and powerOn set to true shouldn't be an issue for us.