### PR TITLE
Bug 1804464: Relax timeout for metrics availability alerts

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -35,7 +35,7 @@ spec:
         - alert: MachineAPIOperatorMetricsCollectionFailing
           expr: |
              mapi_mao_collector_up == 0
-          for: 3m
+          for: 5m
           labels:
             severity: critical
           annotations:
@@ -45,7 +45,7 @@ spec:
         - alert: MachineAPIOperatorDown
           expr: |
              absent(up{job="machine-api-operator"} == 1)
-          for: 3m
+          for: 5m
           labels:
             severity: critical
           annotations:


### PR DESCRIPTION
There seems to be a race between mao and prometheus to be able to provide a valid bearer token. It seems to take up to 5 min based on the logs:
https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_cluster-etcd-operator/162/pull-ci-openshift-cluster-etcd-operator-master-e2e-aws/722/artifacts/e2e-aws/pods/openshift-machine-api_machine-api-operator-649f77c85d-k4nxj_kube-rbac-proxy.log

This relax the availability alerts.