### PR TITLE
add a link to the FAQ in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ The Machine API Operator manages the lifecycle of specific purpose CRDs, control
 This allows to convey desired state of machines in a cluster in a declarative fashion.
 
 See https://github.com/openshift/enhancements/tree/master/enhancements/machine-api for more details.
+
+Have a question? See our [Frequently Asked Questions](FAQ.md) for common inquiries.
+
 ## Architecture
 
 ![Machine API Operator overview](machine-api-operator.png)


### PR DESCRIPTION
this change helps to make the FAQ more discoverable.

although the FAQ document is in the root of the repository, i think it would be helpful to put a link front-and-center for people who navigate to this project repo.