### PR TITLE
BUG 1831577: Allow Machine API to create Service Linked Role for Spot instances

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -32,6 +32,7 @@ spec:
       - elasticloadbalancing:RegisterInstancesWithLoadBalancer
       - elasticloadbalancing:RegisterTargets
       - iam:PassRole
+      - iam:CreateServiceLinkedRole
       resource: "*"
     - effect: Allow
       action:


### PR DESCRIPTION
If an AWS account has not had a spot instance run in it before, then a service-linked-role required for spot instances will not exist. Typically this would be created upon the first spot request being created, but it requires the user to have permission to create service linked roles.

This should resolve errors like:
```
Error launching instance: AuthFailure.ServiceLinkedRoleCreationNotPermitted: The provided credentials do not have permission to create the service-linked role for EC2 Spot Instances.
```

Ideally this service linked role would be independently but I don't think there's anything within Openshift that can create a service linked role as a one off apart from the installer, but that wouldn't help upgrades

Ref: https://confluence.atlassian.com/bamkb/bamboo-fails-to-lodge-spot-instance-request-since-the-provided-credentials-do-not-have-permission-to-create-the-service-linked-role-950809842.html