### PR TITLE
Bug 1833256: [vSphere] Fail machine if multiple resource pools found

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -442,6 +442,17 @@ func clone(s *machineScope) (string, error) {
 
 	resourcepool, err := s.GetSession().Finder.ResourcePoolOrDefault(s, resourcepoolPath)
 	if err != nil {
+		// TODO: move error checks to provider spec validation
+		var multipleFoundError *find.MultipleFoundError
+		if errors.As(err, &multipleFoundError) {
+			return "", machinecontroller.InvalidMachineConfiguration("multiple resource pools found, specify one in config")
+		}
+
+		var notFoundError *find.NotFoundError
+		if errors.As(err, &notFoundError) {
+			return "", machinecontroller.InvalidMachineConfiguration("resource pool not found, specify valid value")
+		}
+
 		return "", fmt.Errorf("unable to get resource pool for %q: %w", resourcepool, err)
 	}
 


### PR DESCRIPTION
Our current implementation allows users to either specify `resourcePool` in provider spec or leave it empty and fallback to default one. In case when more than one resource pools found lookup fails and the machine is stuck in `Provisioning` phase. In order to avoid machine getting stuck, this PR introduces machine failure on lookup error. 

I have issues with creating additional resource pools in the mocked environment so tests will come later.