### PR TITLE
pkg/operator/status: Change ReasonEmpty to ReasonAsExpected

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -21,9 +21,10 @@ type StatusReason string
 
 // The default set of status change reasons.
 const (
-	ReasonEmpty      StatusReason = ""
-	ReasonSyncing    StatusReason = "SyncingResources"
-	ReasonSyncFailed StatusReason = "SyncingFailed"
+	ReasonAsExpected   StatusReason = "AsExpected"
+	ReasonInitializing StatusReason = "Initializing"
+	ReasonSyncing      StatusReason = "SyncingResources"
+	ReasonSyncFailed   StatusReason = "SyncingFailed"
 )
 
 const (
@@ -81,10 +82,10 @@ func (optr *Operator) statusProgressing() error {
 // and message, and sets both the Progressing and Degraded conditions to False.
 func (optr *Operator) statusAvailable() error {
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonEmpty),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonAsExpected),
 			fmt.Sprintf("Cluster Machine API Operator is available at %s", optr.printOperandVersions())),
-		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, "", ""),
-		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, "", ""),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(ReasonAsExpected), ""),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, string(ReasonAsExpected), ""),
 		operatorUpgradeable,
 	}
 
@@ -197,22 +198,23 @@ func (optr *Operator) relatedObjects() []osconfigv1.ObjectReference {
 // defaultStatusConditions returns the default set of status conditions for the
 // ClusterOperator resource used on first creation of the ClusterOperator.
 func (optr *Operator) defaultStatusConditions() []osconfigv1.ClusterOperatorStatusCondition {
-	// All conditions default to False with no message.
 	return []osconfigv1.ClusterOperatorStatusCondition{
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorProgressing,
-			osconfigv1.ConditionFalse,
-			"", "",
+			osconfigv1.ConditionTrue,
+			string(ReasonInitializing),
+			"Operator is initializing",
 		),
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorDegraded,
 			osconfigv1.ConditionFalse,
-			"", "",
+			string(ReasonAsExpected), "",
 		),
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorAvailable,
 			osconfigv1.ConditionFalse,
-			"", "",
+			string(ReasonInitializing),
+			"Operator is initializing",
 		),
 	}
 }

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -149,18 +149,20 @@ func TestGetOrCreateClusterOperator(t *testing.T) {
 	var defaultConditions = []osconfigv1.ClusterOperatorStatusCondition{
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorProgressing,
-			osconfigv1.ConditionFalse,
-			"", "",
+			osconfigv1.ConditionTrue,
+			string(ReasonInitializing),
+			"Operator is initializing",
 		),
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorDegraded,
 			osconfigv1.ConditionFalse,
-			"", "",
+			string(ReasonAsExpected), "",
 		),
 		newClusterOperatorStatusCondition(
 			osconfigv1.OperatorAvailable,
 			osconfigv1.ConditionFalse,
-			"", "",
+			string(ReasonInitializing),
+			"Operator is initializing",
 		),
 	}
 


### PR DESCRIPTION
We've used `ReasonEmpty` since 4000ff88f0 (#174).  But if we feel like we have a message we want to set to help humans understand the condition, we should be setting a reason string for machines too.  `AsExpected` follows [the library-go precedent][1].

Also use `AsExpected` for some message-less but expected conditions, like `Progressing=False` and `Degraded=False`.  Having a reason makes it easier for folks skimming logs to see that the condition is in its happy state, and doesn't cost us any effort to set.

Also shuffle `defaultStatusConditions` a bit:

* `Progressing=False` didn't make sense to me as an initial condition.  It is now:

        Progressing=True Initializing: Operator is initializing

    to show that the operator is working on getting itself ready.

* `Available=False` is a surprising condition and needs an explaination. Now we explain it with the same:

        Initializing: Operator is initializing

    reason/message pair I'm using for `Progressing`.

[1]: https://github.com/openshift/library-go/blob/94c59dec54be25c8527e51e8c0a885712aeb01b5/pkg/operator/status/condition.go#L67