### PR TITLE
Bug 1839694: [vSphere] Add ability to read port from provider config

### DIFF
--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -74,8 +74,10 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 	if providerSpec.Workspace == nil {
 		return nil, fmt.Errorf("%v: no workspace provided", params.machine.GetName())
 	}
-	authSession, err := session.GetOrCreate(context.TODO(),
-		providerSpec.Workspace.Server, providerSpec.Workspace.Datacenter,
+
+	server := fmt.Sprintf("%s:%s", providerSpec.Workspace.Server, getPortFromConfig(vSphereConfig))
+	authSession, err := session.GetOrCreate(params.Context,
+		server, providerSpec.Workspace.Datacenter,
 		user, password)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create vSphere session: %w", err)

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -25,10 +25,26 @@ const (
 // duplicating part of the type and parsing it ourselves using the same gcfg
 // library for now.
 type vSphereConfig struct {
-	Labels struct {
-		Zone   string `gcfg:"zone"`
-		Region string `gcfg:"region"`
-	}
+	// Global is the vSphere cloud provider's global configuration.
+	Labels Labels `gcfg:"Labels"`
+	// Global is the vSphere cloud provider's global configuration.
+	Global Global `gcfg:"Global"`
+}
+
+// Labels is the vSphere cloud provider's zone and region configuration.
+type Labels struct {
+	// Zone is the zone in which VMs are created/located.
+	Zone string `gcfg:"zone"`
+	// Region is the region in which VMs are created/located.
+	Region string `gcfg:"region"`
+}
+
+// Global is the vSphere cloud provider's global configuration.
+type Global struct {
+	// Port is the port on which the vSphere endpoint is listening.
+	// Defaults to 443.
+	// Has string type because we need empty string value for formatting
+	Port string `gcfg:"port"`
 }
 
 func getInfrastructure(c runtimeclient.Reader) (*configv1.Infrastructure, error) {
@@ -146,4 +162,11 @@ func conditionFailed() vspherev1.VSphereMachineProviderCondition {
 		Status: corev1.ConditionFalse,
 		Reason: vspherev1.MachineCreationFailed,
 	}
+}
+
+func getPortFromConfig(config *vSphereConfig) string {
+	if config != nil {
+		return config.Global.Port
+	}
+	return ""
 }

--- a/pkg/controller/vsphere/util_test.go
+++ b/pkg/controller/vsphere/util_test.go
@@ -1,6 +1,7 @@
 package vsphere
 
 import (
+	"fmt"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -11,17 +12,20 @@ import (
 )
 
 const (
-	testRegion = "testRegion"
-	testZone   = "testZone"
-)
-
-func TestGetVSphereConfig(t *testing.T) {
-	testConfig := `
+	testRegion    = "testRegion"
+	testZone      = "testZone"
+	testPort      = "443"
+	testConfigFmt = `
     [Labels]
 		zone = "testZone"
 		region = "testRegion"
+		[Global]
+		port = %s
 `
+)
 
+func TestGetVSphereConfig(t *testing.T) {
+	testConfig := fmt.Sprintf(testConfigFmt, "443")
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testName",
@@ -58,5 +62,9 @@ func TestGetVSphereConfig(t *testing.T) {
 
 	if vSphereConfig.Labels.Zone != testZone {
 		t.Errorf("Expected zone %s, got %s", testZone, vSphereConfig.Labels.Zone)
+	}
+
+	if vSphereConfig.Global.Port != testPort {
+		t.Errorf("Expected zone %s, got %s", testZone, vSphereConfig.Global.Port)
 	}
 }


### PR DESCRIPTION
This PR adds the ability to read port from provider config. We should be able to append port to the server's address.
https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/k8s-secret.html#create-a-k8s-secret.
https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html