### PR TITLE
Bug 1840665: [vSphere] Get insecure flag from provider config

### DIFF
--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -78,7 +78,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 	server := fmt.Sprintf("%s:%s", providerSpec.Workspace.Server, getPortFromConfig(vSphereConfig))
 	authSession, err := session.GetOrCreate(params.Context,
 		server, providerSpec.Workspace.Datacenter,
-		user, password)
+		user, password, getInsecureFlagFromConfig(vSphereConfig))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create vSphere session: %w", err)
 	}

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -67,7 +67,7 @@ func initSimulator(t *testing.T) (*simulator.Model, *session.Session, *simulator
 	authSession, err := session.GetOrCreate(
 		context.TODO(),
 		server.URL.Host, "",
-		server.URL.User.Username(), pass)
+		server.URL.User.Username(), pass, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,6 +88,7 @@ func TestClone(t *testing.T) {
 	model, session, server := initSimulator(t)
 	defer model.Remove()
 	defer server.Close()
+
 	credentialsSecretUsername := fmt.Sprintf("%s.username", server.URL.Host)
 	credentialsSecretPassword := fmt.Sprintf("%s.password", server.URL.Host)
 

--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -56,7 +56,7 @@ type Session struct {
 // already exist.
 func GetOrCreate(
 	ctx context.Context,
-	server, datacenter, username, password string) (*Session, error) {
+	server, datacenter, username, password string, insecure bool) (*Session, error) {
 
 	sessionMU.Lock()
 	defer sessionMU.Unlock()
@@ -78,8 +78,7 @@ func GetOrCreate(
 
 	soapURL.User = url.UserPassword(username, password)
 
-	// TODO: drop insecure flag
-	client, err := govmomi.NewClient(ctx, soapURL, true)
+	client, err := govmomi.NewClient(ctx, soapURL, insecure)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up new vSphere SOAP client: %w", err)
 	}

--- a/pkg/controller/vsphere/session/session_test.go
+++ b/pkg/controller/vsphere/session/session_test.go
@@ -40,7 +40,7 @@ func initSimulator(t *testing.T) (*simulator.Model, *Session, *simulator.Server)
 	authSession, err := GetOrCreate(
 		context.TODO(),
 		server.URL.Host, "",
-		server.URL.User.Username(), pass)
+		server.URL.User.Username(), pass, true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -44,7 +44,8 @@ type Global struct {
 	// Port is the port on which the vSphere endpoint is listening.
 	// Defaults to 443.
 	// Has string type because we need empty string value for formatting
-	Port string `gcfg:"port"`
+	Port         string `gcfg:"port"`
+	InsecureFlag string `gcfg:"insecure-flag"`
 }
 
 func getInfrastructure(c runtimeclient.Reader) (*configv1.Infrastructure, error) {
@@ -169,4 +170,12 @@ func getPortFromConfig(config *vSphereConfig) string {
 		return config.Global.Port
 	}
 	return ""
+}
+
+// getInsecureFlagFromConfig get insecure flag from config and default to false
+func getInsecureFlagFromConfig(config *vSphereConfig) bool {
+	if config != nil && config.Global.InsecureFlag == "1" {
+		return true
+	}
+	return false
 }

--- a/pkg/controller/vsphere/util_test.go
+++ b/pkg/controller/vsphere/util_test.go
@@ -12,15 +12,17 @@ import (
 )
 
 const (
-	testRegion    = "testRegion"
-	testZone      = "testZone"
-	testPort      = "443"
-	testConfigFmt = `
+	testRegion       = "testRegion"
+	testZone         = "testZone"
+	testPort         = "443"
+	testInsecureFlag = "1"
+	testConfigFmt    = `
     [Labels]
 		zone = "testZone"
 		region = "testRegion"
 		[Global]
 		port = %s
+		insecure-flag="1"
 `
 )
 
@@ -66,5 +68,9 @@ func TestGetVSphereConfig(t *testing.T) {
 
 	if vSphereConfig.Global.Port != testPort {
 		t.Errorf("Expected zone %s, got %s", testZone, vSphereConfig.Global.Port)
+	}
+
+	if vSphereConfig.Global.InsecureFlag != testInsecureFlag {
+		t.Errorf("Expected insecure flag %s, got %s", testInsecureFlag, vSphereConfig.Global.InsecureFlag)
 	}
 }


### PR DESCRIPTION
We should get the insecure flag from provider config and default to secure connection if flag is missing


https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/existing.html#single-vcenter 