### PR TITLE
Bug 1840552: Ensure status patch is after annotation patch when setting phase

### DIFF
--- a/pkg/controller/machine/machine_controller_suite_test.go
+++ b/pkg/controller/machine/machine_controller_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package machine
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -30,7 +31,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var cfg *rest.Config
+var (
+	cfg *rest.Config
+	ctx = context.Background()
+)
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{

--- a/pkg/controller/machine/machine_controller_suite_test.go
+++ b/pkg/controller/machine/machine_controller_suite_test.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -50,18 +49,6 @@ func TestMain(m *testing.M) {
 	code := m.Run()
 	t.Stop()
 	os.Exit(code)
-}
-
-// SetupTestReconcile returns a reconcile.Reconcile implementation that delegates to inner and
-// writes the request to requests after Reconcile is finished.
-func SetupTestReconcile(inner reconcile.Reconciler) (reconcile.Reconciler, chan reconcile.Request) {
-	requests := make(chan reconcile.Request)
-	fn := reconcile.Func(func(req reconcile.Request) (reconcile.Result, error) {
-		result, err := inner.Reconcile(req)
-		requests <- req
-		return result, err
-	})
-	return fn, requests
 }
 
 // StartTestManager adds recFn

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -20,24 +20,36 @@ import (
 	"testing"
 	"time"
 
+	. "github.com/onsi/gomega"
 	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
+
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var c client.Client
-
-var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 
 const timeout = time.Second * 5
 
 func TestReconcile(t *testing.T) {
 	instance := &machinev1beta1.Machine{
-		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+			Labels: map[string]string{
+				machinev1beta1.MachineClusterIDLabel: "foo",
+			},
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					Raw: []byte("{}"),
+				},
+			},
+		},
 	}
 
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
@@ -49,7 +61,7 @@ func TestReconcile(t *testing.T) {
 	c = mgr.GetClient()
 
 	a := newTestActuator()
-	recFn, requests := SetupTestReconcile(newReconciler(mgr, a))
+	recFn := newReconciler(mgr, a)
 	if err := add(mgr, recFn); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}
@@ -67,14 +79,16 @@ func TestReconcile(t *testing.T) {
 		t.Fatalf("error creating instance: %v", err)
 	}
 	defer c.Delete(context.TODO(), instance)
-	select {
-	case recv := <-requests:
-		if recv != expectedRequest {
-			t.Error("received request does not match expected request")
+	g := NewWithT(t)
+	g.Eventually(func() (machinev1beta1.MachineStatus, error) {
+		machine := &machinev1beta1.Machine{}
+		namespacedName := client.ObjectKey{Namespace: instance.Namespace, Name: instance.Name}
+		err := c.Get(ctx, namespacedName, machine)
+		if err != nil {
+			return machinev1beta1.MachineStatus{}, err
 		}
-	case <-time.After(timeout):
-		t.Error("timed out waiting for request")
-	}
+		return machine.Status, nil
+	}, timeout).ShouldNot(Equal(machinev1beta1.MachineStatus{}))
 
 	// TODO: Verify that the actuator is called correctly on Create
 }


### PR DESCRIPTION
By calling `Patch`, the client overwrites the `machine` with the state on the API server. This meant that all changes to subresources before the patch (eg Status fields) get wiped out.
Therefore, the call to `Status.Patch` had no effect as the status had been reset.

I've rewritten the tests to use testenv as the fakeclient doesn't exhibit this behaviour, so the tests weren't catching this problem