### PR TITLE
Add liveness/readiness probes

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -12,7 +12,9 @@ import (
 	"github.com/openshift/machine-api-operator/pkg/controller"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
@@ -24,8 +26,24 @@ func printVersion() {
 }
 
 func main() {
-	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
-	metricsAddress := flag.String("metrics-bind-address", metrics.DefaultHealthCheckMetricsAddress, "Address for hosting metrics")
+	watchNamespace := flag.String(
+		"namespace",
+		"",
+		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
+	)
+
+	metricsAddress := flag.String(
+		"metrics-bind-address",
+		metrics.DefaultHealthCheckMetricsAddress,
+		"Address for hosting metrics",
+	)
+
+	healthAddr := flag.String(
+		"health-addr",
+		":9442",
+		"The address for health checking.",
+	)
+
 	flag.Parse()
 	printVersion()
 
@@ -36,7 +54,8 @@ func main() {
 	}
 
 	opts := manager.Options{
-		MetricsBindAddress: *metricsAddress,
+		MetricsBindAddress:     *metricsAddress,
+		HealthProbeBindAddress: *healthAddr,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
@@ -61,6 +80,14 @@ func main() {
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, opts, machinehealthcheck.Add); err != nil {
 		glog.Fatal(err)
+	}
+
+	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+		klog.Fatal(err)
+	}
+
+	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+		klog.Fatal(err)
 	}
 
 	glog.Info("Starting the Cmd.")

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -40,9 +41,12 @@ func main() {
 	}
 
 	cfg := config.GetConfigOrDie()
+	syncPeriod := 10 * time.Minute
+
 	opts := manager.Options{
 		MetricsBindAddress:     *metricsAddress,
 		HealthProbeBindAddress: *healthAddr,
+		SyncPeriod:             &syncPeriod,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace


### PR DESCRIPTION
OCPCLOUD-785 - health checks for all machine API controllers

This introduce support for readinessProbe and livenessProbe [1] for the owned machine controllers deployment and its machineSet, MHC and machine controller containers.
This will let the kubelet to better acknowledge about these containers lifecycle and therefore letting us to be more robust to signal the operator degradability on the clusterOperator status.

This PR needs [2], [3] and [4] to work and pass CI so the probes included in the container spec here can get a 200 from the machine controllers. Also additionally [5], [6] and [7] must the same to not break or the probes included in the container spec here  will fail will and result in the containers getting restarted.

This also reverts accidental rebase and put back the `syncPeriod` which was dropped by [8].

[1] https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
[2] https://github.com/openshift/cluster-api-provider-aws/pull/329
[3] https://github.com/openshift/cluster-api-provider-azure/pull/139
[4] https://github.com/openshift/cluster-api-provider-gcp/pull/96
[5] https://github.com/openshift/cluster-api-provider-baremetal/pull/79
[6] https://github.com/openshift/cluster-api-provider-ovirt/pull/52
[7] https://github.com/openshift/cluster-api-provider-openstack/pull/105
[8] https://github.com/openshift/machine-api-operator/pull/590/files#diff-7417e4bc31a1bacc1a431704bee56978L41 
