### PR TITLE
[vSphere] Reduce sync period to 10 minutes

### DIFF
--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
@@ -32,10 +33,12 @@ func main() {
 	}
 
 	cfg := config.GetConfigOrDie()
+	syncPeriod := 10 * time.Minute
 
 	opts := manager.Options{
 		// Disable metrics serving
 		MetricsBindAddress: "0",
+		SyncPeriod:         &syncPeriod,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace


### PR DESCRIPTION
Reduce sync period to 10 minutes because the default value is 10 hours and it makes cloud provider changes ignored by the controller. 
We have similar sync time in other controllers.