### PR TITLE
Set clusterID label on machine

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -196,13 +194,8 @@ type LastOperation struct {
 func (m *Machine) Validate() field.ErrorList {
 	errors := field.ErrorList{}
 
-	// validate spec.labels
-	fldPath := field.NewPath("spec")
-	if m.Labels[MachineClusterIDLabel] == "" {
-		errors = append(errors, field.Invalid(fldPath.Child("labels"), m.Labels, fmt.Sprintf("missing %v label.", MachineClusterIDLabel)))
-	}
-
 	// validate provider config is set
+	fldPath := field.NewPath("spec")
 	if m.Spec.ProviderSpec.Value == nil {
 		errors = append(errors, field.Invalid(fldPath.Child("spec").Child("providerspec"), m.Spec.ProviderSpec, "value field must be set"))
 	}

--- a/pkg/controller/machine/machine_controller_suite_test.go
+++ b/pkg/controller/machine/machine_controller_suite_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -37,9 +38,12 @@ var (
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "install")},
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "install"),
+			filepath.Join("..", "..", "..", "vendor", "github.com", "openshift", "api", "config", "v1")},
 	}
 	v1beta1.AddToScheme(scheme.Scheme)
+	configv1.AddToScheme(scheme.Scheme)
 
 	var err error
 	if cfg, err = t.Start(); err != nil {

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,6 +53,15 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	infra := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: globalInfrastuctureName,
+		},
+		Status: configv1.InfrastructureStatus{
+			InfrastructureName: "test-id",
+		},
+	}
+
 	// Setup the Manager and Controller.  Wrap the Controller Reconcile function so it writes each request to a
 	// channel when it is finished.
 	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
@@ -73,6 +83,11 @@ func TestReconcile(t *testing.T) {
 			t.Fatalf("error starting test manager: %v", err)
 		}
 	}()
+
+	if err := c.Create(context.TODO(), infra); err != nil {
+		t.Fatalf("error creating instance: %v", err)
+	}
+	defer c.Delete(context.TODO(), infra)
 
 	// Create the Machine object and expect Reconcile and the actuator to be called
 	if err := c.Create(context.TODO(), instance); err != nil {


### PR DESCRIPTION
Set clusterID label on the machine using controller. Currently, we require the user to set clusterID label manually, this PR introduces usage of infrastructure resource for setting label.