### PR TITLE
Enable prometheus metrics for controllers

### DIFF
--- a/install/0000_90_machine-api-operator_03_servicemonitor.yaml
+++ b/install/0000_90_machine-api-operator_03_servicemonitor.yaml
@@ -22,4 +22,42 @@ spec:
   selector:
     matchLabels:
       k8s-app: machine-api-operator
-
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  namespace: openshift-machine-api
+  name: machine-api-controllers
+  labels:
+    k8s-app: controller
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  namespaceSelector:
+    matchNames:
+      - openshift-machine-api
+  selector:
+    matchLabels:
+      k8s-app: controller
+  endpoints:
+  - port: machine-mtrc
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: machine-api-controllers.openshift-machine-api.svc
+  - port: machineset-mtrc
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: machine-api-controllers.openshift-machine-api.svc
+  - port: mhc-mtrc
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: machine-api-controllers.openshift-machine-api.svc


### PR DESCRIPTION
Enables functionality introduced in https://github.com/openshift/machine-api-operator/pull/590

Depends on 
- https://github.com/openshift/cluster-api-provider-baremetal/pull/77
- https://github.com/openshift/cluster-api-provider-openstack/pull/106
- openshift/cluster-api-provider-gcp#96
- openshift/cluster-api-provider-azure#136
- openshift/cluster-api-provider-aws#324

Demo:
![metrics-stuff](https://user-images.githubusercontent.com/32226600/87791648-e72b6900-c842-11ea-90b7-4967b0d06fb5.gif)
