### PR TITLE
Drop clusterID defaulting label

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -197,11 +197,6 @@ func defaultAWS(h *defaulterHandler, m *Machine) (bool, utilerrors.Aggregate) {
 		return false, utilerrors.NewAggregate(errs)
 	}
 
-	if m.GetLabels() == nil {
-		m.Labels = make(map[string]string)
-	}
-	m.Labels["machine.openshift.io/cluster-api-cluster"] = h.clusterID
-
 	if providerSpec.InstanceType == "" {
 		providerSpec.InstanceType = defaultAWSInstanceType
 	}


### PR DESCRIPTION
The need for this label is mainly for AWS to be able use it to filter instances by name and clusterID when there's no an instanceID available yet https://github.com/openshift/cluster-api-provider-aws/blob/master/pkg/actuators/machine/reconciler.go#L358-L371

This is just a detail we as devs choose to implement this way, it's not a legitimately user input API field. The clusterID is by design implicit and available on the context and client that the machine is being created at any time. Therefore I don't think this should be exposed as user input at all or defaulted by a webhook at creation/updating time. The controller should be able to discover and pass the clusterID through with or without a webhook at the front. We could even eventually drop the label and use a different mechanism to pass the clusterID if we choose to and this should be transparent to machine creation validation/defaulting.
The burden for the user to set this label will be fixed by https://github.com/openshift/machine-api-operator/pull/608