### PR TITLE
Allow the Azure UserDataSecret Namespace to be omitted

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -409,14 +409,9 @@ func defaultAzure(h *defaulterHandler, m *Machine) (bool, utilerrors.Aggregate) 
 	}
 
 	if providerSpec.UserDataSecret == nil {
-		providerSpec.UserDataSecret = &corev1.SecretReference{Name: defaultUserDataSecret, Namespace: defaultSecretNamespace}
-	} else {
-		if providerSpec.UserDataSecret.Namespace == "" {
-			providerSpec.UserDataSecret.Namespace = defaultSecretNamespace
-		}
-		if providerSpec.UserDataSecret.Name == "" {
-			providerSpec.UserDataSecret.Name = defaultUserDataSecret
-		}
+		providerSpec.UserDataSecret = &corev1.SecretReference{Name: defaultUserDataSecret}
+	} else if providerSpec.UserDataSecret.Name == "" {
+		providerSpec.UserDataSecret.Name = defaultUserDataSecret
 	}
 
 	if providerSpec.CredentialsSecret == nil {
@@ -498,13 +493,8 @@ func validateAzure(h *validatorHandler, m *Machine) (bool, utilerrors.Aggregate)
 
 	if providerSpec.UserDataSecret == nil {
 		errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret"), "userDataSecret must be provided"))
-	} else {
-		if providerSpec.UserDataSecret.Namespace == "" {
-			errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret", "namespace"), "namespace must be provided"))
-		}
-		if providerSpec.UserDataSecret.Name == "" {
-			errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret", "name"), "name must be provided"))
-		}
+	} else if providerSpec.UserDataSecret.Name == "" {
+		errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret", "name"), "name must be provided"))
 	}
 
 	if providerSpec.CredentialsSecret == nil {

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -326,21 +326,9 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.userDataSecret: Required value: userDataSecret must be provided",
 		},
 		{
-			testCase: "with no user data secret namespace it fails",
-			modifySpec: func(p *azure.AzureMachineProviderSpec) {
-				p.UserDataSecret = &corev1.SecretReference{
-					Name: "name",
-				}
-			},
-			expectedOk:    false,
-			expectedError: "providerSpec.userDataSecret.namespace: Required value: namespace must be provided",
-		},
-		{
 			testCase: "with no user data secret name it fails",
 			modifySpec: func(p *azure.AzureMachineProviderSpec) {
-				p.UserDataSecret = &corev1.SecretReference{
-					Namespace: "namespace",
-				}
+				p.UserDataSecret = &corev1.SecretReference{}
 			},
 			expectedOk:    false,
 			expectedError: "providerSpec.userDataSecret.name: Required value: name must be provided",
@@ -431,8 +419,7 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 				ManagedIdentity: "managedIdentity",
 				ResourceGroup:   "resourceGroup",
 				UserDataSecret: &corev1.SecretReference{
-					Name:      "name",
-					Namespace: "namespace",
+					Name: "name",
 				},
 				CredentialsSecret: &corev1.SecretReference{
 					Name:      "name",
@@ -503,17 +490,13 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			testCase: "does not overwrite the secret namespaces if they already exist",
+			testCase: "does not overwrite the credentials secret namespace if they already exist",
 			providerSpec: &azure.AzureMachineProviderSpec{
-				UserDataSecret: &corev1.SecretReference{
-					Namespace: "foo",
-				},
 				CredentialsSecret: &corev1.SecretReference{
 					Namespace: "foo",
 				},
 			},
 			modifyDefault: func(p *azure.AzureMachineProviderSpec) {
-				p.UserDataSecret.Namespace = "foo"
 				p.CredentialsSecret.Namespace = "foo"
 			},
 			expectedOk:    true,
@@ -553,8 +536,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 				ManagedIdentity: defaultAzureManagedIdentiy(clusterID),
 				ResourceGroup:   defaultAzureResourceGroup(clusterID),
 				UserDataSecret: &corev1.SecretReference{
-					Name:      defaultUserDataSecret,
-					Namespace: defaultSecretNamespace,
+					Name: defaultUserDataSecret,
 				},
 				CredentialsSecret: &corev1.SecretReference{
 					Name:      defaultAzureCredentialsSecret,


### PR DESCRIPTION
The namespace of the UserDataSecret Namespace was mistakenly required when Azure defaulting and validation was implemented.

In existing clusters, the UserDataSecret Namespace has been allowed to be emptied and has been inferred in the controller rather than requiring it to be set.

This PR fixes the logic to allow the field to be empty and restores the previous behaviour