### PR TITLE
Bug 1844986: Do not send Machine deletion event if the Machine has already been deleted

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -239,6 +239,13 @@ func TestReconcile(t *testing.T) {
 	}
 	machineUnhealthyForTooLong := maotesting.NewMachine("machineUnhealthyForTooLong", nodeUnhealthyForTooLong.Name)
 
+	nodeAlreadyDeleted := maotesting.NewNode("nodeAlreadyDelete", false)
+	nodeUnhealthyForTooLong.Annotations = map[string]string{
+		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineAlreadyDeleted"),
+	}
+	machineAlreadyDeleted := maotesting.NewMachine("machineAlreadyDeleted", nodeAlreadyDeleted.Name)
+	machineAlreadyDeleted.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
+
 	testCases := []struct {
 		testCase       string
 		machine        *mapiv1beta1.Machine
@@ -320,6 +327,16 @@ func TestReconcile(t *testing.T) {
 				error: false,
 			},
 			expectedEvents: []string{EventDetectedUnhealthy},
+		},
+		{
+			testCase: "machine already deleted",
+			machine:  machineAlreadyDeleted,
+			node:     nodeAlreadyDeleted,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+			expectedEvents: []string{},
 		},
 	}
 


### PR DESCRIPTION
If the Machine has already been deleted, we do not need to delete it again. Nor do we need to send an event to say that we have deleted it a second (or third...) time.

This PR fetches the Machine as we attempt to remediate and checks if the Machine has already been deleted before attempting to delete the Machine and sending the event.