### PR TITLE
OWNERS: Add a component link for BZ

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,3 +5,5 @@ approvers:
   - elmiko
   - Danil-Grigorev
   - alexander-demichev
+
+component: "Cloud Compute"


### PR DESCRIPTION
There is apparently tooling that uses this, came up in chat.
See e.g. the MCO:
https://github.com/openshift/machine-config-operator/blob/master/OWNERS#L12