### PR TITLE
[OCPCLOUD-937] Update resources to allow termination handler to apply conditions

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -23,6 +23,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+autoMountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -213,31 +214,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: machine-api-termination-handler
-  namespace: openshift-machine-api
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-rules:
-  - apiGroups:
-      - machine.openshift.io
-    resources:
-      - machines
-    verbs:
-      - list
-      - delete
-  - apiGroups:
-      - security.openshift.io
-    resourceNames:
-      - hostnetwork
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - use
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
   annotations:
@@ -408,23 +384,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
-    namespace: openshift-machine-api
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: machine-api-termination-handler
-  namespace: openshift-machine-api
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: machine-api-termination-handler
-subjects:
-  - kind: ServiceAccount
-    name: machine-api-termination-handler
     namespace: openshift-machine-api
 
 ---

--- a/install/0000_30_machine-api-operator_09_security_context_constraint.yaml
+++ b/install/0000_30_machine-api-operator_09_security_context_constraint.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'machine-api-termination-handler allows the
+      machine-api-termination-handler service account to run as root, access host
+      paths and access the host network. This SCC is limited and should not be used
+      for any other service.'
+  name: machine-api-termination-handler
+allowHostDirVolumePlugin: true
+allowHostNetwork: true
+allowHostIPC: false
+allowHostPorts: false
+allowHostPID: false
+allowPrivilegedContainer: false
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+fsGroup:
+  type: MustRunAs
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: MustRunAs
+users:
+- system:serviceaccount:openshift-machine-api:machine-api-termination-handler
+groups: []
+volumes:
+- downwardAPI
+- hostPath

--- a/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
+++ b/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+  labels:
+    api: clsuterapi
+    k8s-app: termination-handler
+spec:
+  selector:
+    matchLabels:
+      machine.openshift.io/interruptible-instance: ""
+  maxUnhealthy: 100%
+  unhealthyConditions:
+  - type: Terminating
+    status: "True"
+    timeout: 0s

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -42,6 +42,8 @@ const (
 	kubeRBACConfigName                  = "config"
 	certStoreName                       = "machine-api-controllers-tls"
 	externalTrustBundleConfigMapName    = "mao-trusted-ca"
+	hostKubeConfigPath                  = "/var/lib/kubelet/kubeconfig"
+	hostKubePKIPath                     = "/var/lib/kubelet/pki"
 )
 
 func (optr *Operator) syncAll(config *OperatorConfig) error {
@@ -779,6 +781,24 @@ func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSp
 			NodeSelector:       map[string]string{machinecontroller.MachineInterruptibleInstanceLabelName: ""},
 			ServiceAccountName: machineAPITerminationHandler,
 			HostNetwork:        true,
+			Volumes: []corev1.Volume{
+				{
+					Name: "kubeconfig",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: hostKubeConfigPath,
+						},
+					},
+				},
+				{
+					Name: "pki",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: hostKubePKIPath,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -806,12 +826,28 @@ func newTerminationContainers(config *OperatorConfig) []corev1.Container {
 			Resources: resources,
 			Env: []corev1.EnvVar{
 				{
+					Name:  "KUBECONFIG",
+					Value: hostKubeConfigPath,
+				},
+				{
 					Name: "NODE_NAME",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{
 							FieldPath: "spec.nodeName",
 						},
 					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      "kubeconfig",
+					MountPath: hostKubeConfigPath,
+					ReadOnly:  true,
+				},
+				{
+					Name:      "pki",
+					MountPath: hostKubePKIPath,
+					ReadOnly:  true,
 				},
 			},
 		},


### PR DESCRIPTION
This PR switches the spot termination handler to use conditions instead of deleting machines directly.

This will require counter PRs in each provider repository to update the termination handler there as well.

Considerations:
- This deploys a MachineHealthCheck that will be present on all clusters going forward that explicitly allows spot instances to be deleted immediately when the terminating condition is applied. This means it will potentially conflict with autoscaling as described [here](https://github.com/openshift/enhancements/pull/330/files#diff-0dd209ee156555586b5e7700cb4bacf9R95-R107)
- This deploys a new SCC to all clusters, this may not be desirable. The alternative is to use the `privileged` SCC but this gives us far more permission that we need
- This will now use Kubelet permissions so it is going to be more secure, but the pod must now run as root which it didn't need to do before otherwise it cannot load the kubelet's credentials
