### PR TITLE
Require region to be set on AWS ProviderSpec

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -213,7 +213,11 @@ func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID
 func getMachineDefaulterOperation(platformStatus *osconfigv1.PlatformStatus) machineAdmissionFn {
 	switch platformStatus.Type {
 	case osconfigv1.AWSPlatformType:
-		return defaultAWS
+		region := ""
+		if platformStatus.AWS != nil {
+			region = platformStatus.AWS.Region
+		}
+		return awsDefaulter{region: region}.defaultAWS
 	case osconfigv1.AzurePlatformType:
 		return defaultAzure
 	case osconfigv1.GCPPlatformType:
@@ -270,7 +274,11 @@ func (h *machineDefaulterHandler) Handle(ctx context.Context, req admission.Requ
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledMachine)
 }
 
-func defaultAWS(m *Machine, clusterID string) (bool, utilerrors.Aggregate) {
+type awsDefaulter struct {
+	region string
+}
+
+func (a awsDefaulter) defaultAWS(m *Machine, clusterID string) (bool, utilerrors.Aggregate) {
 	klog.V(3).Infof("Defaulting AWS providerSpec")
 
 	var errs []error
@@ -286,6 +294,11 @@ func defaultAWS(m *Machine, clusterID string) (bool, utilerrors.Aggregate) {
 	if providerSpec.IAMInstanceProfile == nil {
 		providerSpec.IAMInstanceProfile = &aws.AWSResourceReference{ID: defaultAWSIAMInstanceProfile(clusterID)}
 	}
+
+	if providerSpec.Placement.Region == "" {
+		providerSpec.Placement.Region = a.region
+	}
+
 	if providerSpec.UserDataSecret == nil {
 		providerSpec.UserDataSecret = &corev1.LocalObjectReference{Name: defaultUserDataSecret}
 	}

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -360,6 +360,16 @@ func validateAWS(m *Machine, clusterID string) (bool, utilerrors.Aggregate) {
 		)
 	}
 
+	if providerSpec.Placement.Region == "" {
+		errs = append(
+			errs,
+			field.Required(
+				field.NewPath("providerSpec", "placement", "region"),
+				"expected providerSpec.placement.region to be populated",
+			),
+		)
+	}
+
 	if providerSpec.InstanceType == "" {
 		errs = append(
 			errs,

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -320,7 +320,7 @@ func (a awsDefaulter) defaultAWS(m *Machine, clusterID string) (bool, utilerrors
 		}
 	}
 
-	if providerSpec.Subnet.ARN == nil && providerSpec.Subnet.ID == nil && providerSpec.Subnet.Filters == nil {
+	if providerSpec.Subnet.ARN == nil && providerSpec.Subnet.ID == nil && providerSpec.Subnet.Filters == nil && providerSpec.Placement.AvailabilityZone != "" {
 		providerSpec.Subnet.Filters = []aws.Filter{
 			{
 				Name:   "tag:Name",

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -67,16 +67,19 @@ func TestMachineCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "[providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated, providerSpec.placement.region: Required value: expected providerSpec.placement.region to be populated]",
 		},
 		{
-			name:         "with AWS and an AMI ID set",
+			name:         "with AWS, an AMI ID and the region set",
 			platformType: osconfigv1.AWSPlatformType,
 			clusterID:    "aws-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{
 					AMI: aws.AWSResourceReference{
 						ID: pointer.StringPtr("ami"),
+					},
+					Placement: aws.Placement{
+						Region: "region",
 					},
 				},
 			},
@@ -273,8 +276,7 @@ func TestMachineUpdate(t *testing.T) {
 			},
 		},
 		Placement: aws.Placement{
-			Region:           "region",
-			AvailabilityZone: "zone",
+			Region: "region",
 		},
 		Subnet: aws.AWSResourceReference{
 			Filters: []aws.Filter{
@@ -750,6 +752,14 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
 		},
 		{
+			testCase: "with no region values it fails",
+			modifySpec: func(p *aws.AWSMachineProviderConfig) {
+				p.Placement.Region = ""
+			},
+			expectedOk:    false,
+			expectedError: "providerSpec.placement.region: Required value: expected providerSpec.placement.region to be populated",
+		},
+		{
 			testCase: "with no instanceType it fails",
 			modifySpec: func(p *aws.AWSMachineProviderConfig) {
 				p.InstanceType = ""
@@ -798,6 +808,15 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.subnet: Required value: expected either providerSpec.subnet.arn or providerSpec.subnet.id or providerSpec.subnet.filters or providerSpec.placement.availabilityZone to be populated",
 		},
 		{
+			testCase: "with no subnet values but an availability zone set, it succeeds",
+			modifySpec: func(p *aws.AWSMachineProviderConfig) {
+				p.Subnet = aws.AWSResourceReference{}
+				p.Placement.AvailabilityZone = "availabilityZone"
+			},
+			expectedOk:    true,
+			expectedError: "",
+		},
+		{
 			testCase:      "with all required values it succeeds",
 			expectedOk:    true,
 			expectedError: "",
@@ -811,6 +830,9 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			providerSpec := &aws.AWSMachineProviderConfig{
 				AMI: aws.AWSResourceReference{
 					ID: pointer.StringPtr("ami"),
+				},
+				Placement: aws.Placement{
+					Region: "region",
 				},
 				InstanceType: "m4.large",
 				IAMInstanceProfile: &aws.AWSResourceReference{

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -64,16 +64,35 @@ func TestMachineSetCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "[providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated, providerSpec.subnet: Required value: expected either providerSpec.subnet.arn or providerSpec.subnet.id or providerSpec.subnet.filters or providerSpec.placement.availabilityZone to be populated]",
 		},
 		{
-			name:         "with AWS and an AMI ID set",
+			name:         "with AWS, an AMI ID and an AvailabilityZone set",
 			platformType: osconfigv1.AWSPlatformType,
 			clusterID:    "aws-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{
 					AMI: aws.AWSResourceReference{
 						ID: pointer.StringPtr("ami"),
+					},
+					Placement: aws.Placement{
+						AvailabilityZone: "availabilityZone",
+					},
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name:         "with AWS, an AMI ID and an Subnet ID set",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    "aws-cluster",
+			providerSpecValue: &runtime.RawExtension{
+				Object: &aws.AWSMachineProviderConfig{
+					AMI: aws.AWSResourceReference{
+						ID: pointer.StringPtr("ami"),
+					},
+					Subnet: aws.AWSResourceReference{
+						ID: pointer.StringPtr("subnetID"),
 					},
 				},
 			},

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -64,19 +64,16 @@ func TestMachineSetCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "[providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated, providerSpec.placement.region: Required value: expected providerSpec.placement.region to be populated]",
+			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
 		},
 		{
-			name:         "with AWS, an AMI ID and the placement set",
+			name:         "with AWS and an AMI ID set",
 			platformType: osconfigv1.AWSPlatformType,
 			clusterID:    "aws-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{
 					AMI: aws.AWSResourceReference{
 						ID: pointer.StringPtr("ami"),
-					},
-					Placement: aws.Placement{
-						Region: "region",
 					},
 				},
 			},
@@ -196,6 +193,9 @@ func TestMachineSetCreation(t *testing.T) {
 				GCP: &osconfigv1.GCPPlatformStatus{
 					ProjectID: "gcp-project-id",
 				},
+				AWS: &osconfigv1.AWSPlatformStatus{
+					Region: "region",
+				},
 			}
 
 			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
@@ -256,6 +256,7 @@ func TestMachineSetCreation(t *testing.T) {
 
 func TestMachineSetUpdate(t *testing.T) {
 	awsClusterID := "aws-cluster"
+	awsRegion := "region"
 	defaultAWSProviderSpec := &aws.AWSMachineProviderConfig{
 		AMI: aws.AWSResourceReference{
 			ID: pointer.StringPtr("ami"),
@@ -277,7 +278,7 @@ func TestMachineSetUpdate(t *testing.T) {
 			},
 		},
 		Placement: aws.Placement{
-			Region:           "region",
+			Region:           awsRegion,
 			AvailabilityZone: "zone",
 		},
 		Subnet: aws.AWSResourceReference{
@@ -681,6 +682,9 @@ func TestMachineSetUpdate(t *testing.T) {
 				Type: tc.platformType,
 				GCP: &osconfigv1.GCPPlatformStatus{
 					ProjectID: gcpProjectID,
+				},
+				AWS: &osconfigv1.AWSPlatformStatus{
+					Region: awsRegion,
 				},
 			}
 

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -64,16 +64,19 @@ func TestMachineSetCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "[providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated, providerSpec.placement.region: Required value: expected providerSpec.placement.region to be populated]",
 		},
 		{
-			name:         "with AWS and an AMI ID set",
+			name:         "with AWS, an AMI ID and the placement set",
 			platformType: osconfigv1.AWSPlatformType,
 			clusterID:    "aws-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{
 					AMI: aws.AWSResourceReference{
 						ID: pointer.StringPtr("ami"),
+					},
+					Placement: aws.Placement{
+						Region: "region",
 					},
 				},
 			},


### PR DESCRIPTION
When creating the webhook E2E tests I managed to create a MachineSet for AWS which just had the AMI ID set, other fields were defaulted as expected, but the region was not. Without a region set, the actuator fails to create a machine and as such, we should require that the region be set on the providerSpec when objects are created or updated.

```
E0702 10:52:02.388989       1 reconciler.go:200] ci-op-74pcs6y0-79b09-gdhds-webhook-2zmct: error getting existing instances: MissingRegion: could not find region configuration
E0702 10:52:02.389017       1 controller.go:280] ci-op-74pcs6y0-79b09-gdhds-webhook-2zmct: failed to check if machine exists: MissingRegion: could not find region configuration
E0702 10:52:02.389067       1 controller.go:258] controller-runtime/controller "msg"="Reconciler error" "error"="MissingRegion: could not find region configuration"  "controller"="machine_controller" "request"={"Namespace":"openshift-machine-api","Name":"ci-op-74pcs6y0-79b09-gdhds-webhook-2zmct"}
```

This PR sets the region on creation of the Machine/MachineSet to the region from the infrastructure platform status, adds a check to the validation such that it can't be removed later and also ensures the we do not default subnet filters if the availability zone is not set, as this can lead to invalid filters being created