### PR TITLE
[OCPCLOUD-910] Add HistogramVector to track transition into different Machine phases

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -24,6 +24,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"github.com/openshift/machine-api-operator/pkg/metrics"
 	"github.com/openshift/machine-api-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -430,6 +431,7 @@ func isInvalidMachineConfigurationError(err error) bool {
 func (r *ReconcileMachine) setPhase(machine *machinev1.Machine, phase string, errorMessage string) error {
 	if stringPointerDeref(machine.Status.Phase) != phase {
 		klog.V(3).Infof("%v: going into phase %q", machine.GetName(), phase)
+
 		// A call to Patch will mutate our local copy of the machine to match what is stored in the API.
 		// Before we make any changes to the status subresource on our local copy, we need to patch the object first,
 		// otherwise our local changes to the status subresource will be lost.
@@ -453,6 +455,15 @@ func (r *ReconcileMachine) setPhase(machine *machinev1.Machine, phase string, er
 		if err := r.Client.Status().Patch(context.Background(), machine, baseToPatch); err != nil {
 			klog.Errorf("Failed to update machine status %q: %v", machine.GetName(), err)
 			return err
+		}
+
+		// Update the metric after everything else has succeeded to prevent duplicate
+		// entries when there are failures
+		if phase != phaseDeleting {
+			// Apart from deleting, update the transition metric
+			// Deleting would always end up in the infinite bucket
+			timeElapsed := time.Now().Sub(machine.GetCreationTimestamp().Time).Seconds()
+			metrics.MachinePhaseTransitionSeconds.With(map[string]string{"phase": phase}).Observe(timeElapsed)
 		}
 	}
 	return nil

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -63,8 +63,21 @@ var (
 	)
 )
 
+// Metrics for use in the Machine controller
+var (
+	// MachinePhaseTransitionSeconds is a metric to capute the time between a Machine being created and entering a particular phase
+	MachinePhaseTransitionSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "mapi_machine_phase_transition_seconds",
+			Help:    "Number of seconds between Machine creation and Machine transition to a phase.",
+			Buckets: []float64{5, 10, 20, 30, 60, 90, 120, 180, 240, 300, 360, 480, 600},
+		}, []string{"phase"},
+	)
+)
+
 func init() {
 	prometheus.MustRegister(MachineCollectorUp)
+	metrics.Registry.MustRegister(MachinePhaseTransitionSeconds)
 	metrics.Registry.MustRegister(
 		failedInstanceCreateCount,
 		failedInstanceUpdateCount,


### PR DESCRIPTION
This PR adds a metric which tracks the phase transitions for Machines as they are transitioning to `Provisioning`, `Provisioned`, `Running` or `Failed`. This will allow us to calculate, for example, what the average creation time for a Machine is and see which phases are particularly slow.

Eg, the average time it took for a machine to enter each of these phases:

![Screenshot 2020-07-20 at 13 37 11](https://user-images.githubusercontent.com/9232216/87938783-fc94d300-ca8e-11ea-805d-f31d3023e7af.png)

Since this is a histogram, we should be able to create some interesting graphs in Grafana once this is merged to allow customers to track how long different phases are taking

Potential future work: If we could get the MCS to serve the same metric and set an imaginary phase for `IgnitionFetched`, we could also see how long the Machine took to get to fetching ignition config.