### PR TITLE
update the baremetalhost crd for bootmode and rootdevicehints

### DIFF
--- a/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
@@ -90,6 +90,13 @@ spec:
                 types, but required for libvirt VMs driven by vbmc.
               pattern: '[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}'
               type: string
+            bootMode:
+              description: Select the method of initializing the hardware during boot
+                to override the value based on the BMC driver.
+              enum:
+              - UEFI
+              - legacy
+              type: string
             consumerRef:
               description: ConsumerRef can be used to store information about something
                 that is using a host. When it is not empty, the host is considered
@@ -149,6 +156,23 @@ spec:
                 checksum:
                   description: Checksum is the checksum for the image.
                   type: string
+                checksumType:
+                  description: ChecksumType is the checksum algorithm for the image.
+                    e.g md5, sha256, sha512
+                  enum:
+                  - md5
+                  - sha256
+                  - sha512
+                  type: string
+                format:
+                  description: DiskFormat contains the format of the image (raw, qcow2,
+                    ...) Needs to be set to raw for raw images streaming
+                  enum:
+                  - raw
+                  - qcow2
+                  - vdi
+                  - vmdk
+                  type: string
                 url:
                   description: URL is a location of an image to deploy.
                   type: string
@@ -156,9 +180,81 @@ spec:
               - checksum
               - url
               type: object
+            metaData:
+              description: MetaData holds the reference to the Secret containing host
+                metadata (e.g. meta_data.json which is passed to Config Drive).
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
+            networkData:
+              description: NetworkData holds the reference to the Secret containing
+                network configuration (e.g content of network_data.json which is passed
+                to Config Drive).
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
             online:
               description: Should the server be online?
               type: boolean
+            rootDeviceHints:
+              description: Provide guidance about how to choose the device for the
+                image being provisioned.
+              properties:
+                deviceName:
+                  description: A Linux device name like "/dev/vda". The hint must
+                    match the actual value exactly.
+                  type: string
+                hctl:
+                  description: A SCSI bus address like 0:0:0:0. The hint must match
+                    the actual value exactly.
+                  type: string
+                minSizeGigabytes:
+                  description: The minimum size of the device in Gigabytes.
+                  minimum: 0
+                  type: integer
+                model:
+                  description: A vendor-specific device identifier. The hint can be
+                    a substring of the actual value.
+                  type: string
+                rotational:
+                  description: True if the device should use spinning media, false
+                    otherwise.
+                  type: boolean
+                serialNumber:
+                  description: Device serial number. The hint must match the actual
+                    value exactly.
+                  type: string
+                vendor:
+                  description: The name of the vendor or manufacturer of the device.
+                    The hint can be a substring of the actual value.
+                  type: string
+                wwn:
+                  description: Unique storage identifier. The hint must match the
+                    actual value exactly.
+                  type: string
+                wwnVendorExtension:
+                  description: Unique vendor storage identifier. The hint must match
+                    the actual value exactly.
+                  type: string
+                wwnWithExtension:
+                  description: Unique storage identifier with the vendor extension
+                    appended. The hint must match the actual value exactly.
+                  type: string
+              type: object
             taints:
               description: Taints is the full, authoritative list of taints to apply
                 to the corresponding Machine. This list will overwrite any modifications
@@ -249,6 +345,7 @@ spec:
                       type: string
                     clockMegahertz:
                       description: ClockSpeed is a clock speed in MHz
+                      type: number
                     count:
                       type: integer
                     flags:
@@ -315,6 +412,8 @@ spec:
                       vlanId:
                         description: The untagged VLAN ID
                         format: int32
+                        maximum: 4094
+                        minimum: 0
                         type: integer
                       vlans:
                         description: The VLANs available
@@ -324,6 +423,8 @@ spec:
                             id:
                               description: VLANID is a 12-bit 802.1Q VLAN identifier
                               format: int32
+                              maximum: 4094
+                              minimum: 0
                               type: integer
                             name:
                               type: string
@@ -492,6 +593,13 @@ spec:
                   description: The machine's UUID from the underlying provisioning
                     tool
                   type: string
+                bootMode:
+                  description: BootMode indicates the boot mode used to provision
+                    the node
+                  enum:
+                  - UEFI
+                  - legacy
+                  type: string
                 image:
                   description: Image holds the details of the last image successfully
                     provisioned to the host.
@@ -499,12 +607,73 @@ spec:
                     checksum:
                       description: Checksum is the checksum for the image.
                       type: string
+                    checksumType:
+                      description: ChecksumType is the checksum algorithm for the
+                        image. e.g md5, sha256, sha512
+                      enum:
+                      - md5
+                      - sha256
+                      - sha512
+                      type: string
+                    format:
+                      description: DiskFormat contains the format of the image (raw,
+                        qcow2, ...) Needs to be set to raw for raw images streaming
+                      enum:
+                      - raw
+                      - qcow2
+                      - vdi
+                      - vmdk
+                      type: string
                     url:
                       description: URL is a location of an image to deploy.
                       type: string
                   required:
                   - checksum
                   - url
+                  type: object
+                rootDeviceHints:
+                  description: The RootDevicehints set by the user
+                  properties:
+                    deviceName:
+                      description: A Linux device name like "/dev/vda". The hint must
+                        match the actual value exactly.
+                      type: string
+                    hctl:
+                      description: A SCSI bus address like 0:0:0:0. The hint must
+                        match the actual value exactly.
+                      type: string
+                    minSizeGigabytes:
+                      description: The minimum size of the device in Gigabytes.
+                      minimum: 0
+                      type: integer
+                    model:
+                      description: A vendor-specific device identifier. The hint can
+                        be a substring of the actual value.
+                      type: string
+                    rotational:
+                      description: True if the device should use spinning media, false
+                        otherwise.
+                      type: boolean
+                    serialNumber:
+                      description: Device serial number. The hint must match the actual
+                        value exactly.
+                      type: string
+                    vendor:
+                      description: The name of the vendor or manufacturer of the device.
+                        The hint can be a substring of the actual value.
+                      type: string
+                    wwn:
+                      description: Unique storage identifier. The hint must match
+                        the actual value exactly.
+                      type: string
+                    wwnVendorExtension:
+                      description: Unique vendor storage identifier. The hint must
+                        match the actual value exactly.
+                      type: string
+                    wwnWithExtension:
+                      description: Unique storage identifier with the vendor extension
+                        appended. The hint must match the actual value exactly.
+                      type: string
                   type: object
                 state:
                   description: An indiciator for what the provisioner is doing with


### PR DESCRIPTION
Update the CRD for BareMetalHost to the version that includes bootMode
and rootDeviceHints, 2 features added for the 4.6 release.