### PR TITLE
add trusted ca bundle to machine-controllers

### DIFF
--- a/install/0000_30_machine-api-operator_01_trusted-ca-configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_trusted-ca-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    release.openshift.io/create-only: "true"
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: machine-api-operator-trusted-ca
+  namespace: openshift-machine-api

--- a/install/0000_30_machine-api-operator_01_trusted-ca-configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_trusted-ca-configmap.yaml
@@ -5,5 +5,5 @@ metadata:
     release.openshift.io/create-only: "true"
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
-  name: machine-api-operator-trusted-ca
+  name: mao-trusted-ca
   namespace: openshift-machine-api

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -392,6 +392,18 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 				},
 			},
 		},
+		{
+			Name: "trusted-ca",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					Items: []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "machine-api-operator-trusted-ca",
+					},
+					Optional: pointer.BoolPtr(true),
+				},
+			},
+		},
 	}
 
 	return &corev1.PodTemplateSpec{
@@ -501,6 +513,13 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 						Path: "/readyz",
 						Port: intstr.Parse("healthz"),
 					},
+				},
+			},
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					Name:      "trusted-ca",
+					ReadOnly:  true,
 				},
 			},
 		},

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -7,6 +7,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
+	"github.com/openshift/library-go/pkg/operator/resource/resourcehash"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
@@ -37,6 +38,7 @@ const (
 	defaultMachineHealthCheckHealthPort = 9442
 	kubeRBACConfigName                  = "config"
 	certStoreName                       = "machine-api-controllers-tls"
+	externalTrustBundleConfigMapName    = "mao-trusted-ca"
 )
 
 func (optr *Operator) syncAll(config *OperatorConfig) error {
@@ -101,6 +103,17 @@ func (optr *Operator) syncAll(config *OperatorConfig) error {
 
 func (optr *Operator) syncClusterAPIController(config *OperatorConfig) error {
 	controllersDeployment := newDeployment(config, nil)
+
+	// we watch some resources so that our deployment will redeploy without explicitly and carefully ordered resource creation
+	inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferences(
+		optr.kubeClient,
+		resourcehash.NewObjectRef().ForConfigMap().InNamespace(config.TargetNamespace).Named(externalTrustBundleConfigMapName),
+	)
+	if err != nil {
+		return fmt.Errorf("invalid dependency reference: %q", err)
+	}
+	ensureDependecyAnnotations(inputHashes, controllersDeployment)
+
 	expectedGeneration := resourcemerge.ExpectedDeploymentGeneration(controllersDeployment, optr.generations)
 	d, updated, err := resourceapply.ApplyDeployment(optr.kubeClient.AppsV1(),
 		events.NewLoggingEventRecorder(optr.name), controllersDeployment, expectedGeneration)
@@ -398,7 +411,7 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					Items: []corev1.KeyToPath{{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"}},
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "machine-api-operator-trusted-ca",
+						Name: externalTrustBundleConfigMapName,
 					},
 					Optional: pointer.BoolPtr(true),
 				},
@@ -691,5 +704,21 @@ func newTerminationContainers(config *OperatorConfig) []corev1.Container {
 				},
 			},
 		},
+	}
+}
+
+// ensureDependecyAnnotations uses inputHash map of external dependencies to force new generation of the deployment
+// triggering the Kubernetes rollout as defined when the inputHash changes by adding it annotation to the deployment object.
+func ensureDependecyAnnotations(inputHashes map[string]string, deployment *appsv1.Deployment) {
+	for k, v := range inputHashes {
+		annotationKey := fmt.Sprintf("operator.openshift.io/dep-%s", k)
+		if deployment.Annotations == nil {
+			deployment.Annotations = map[string]string{}
+		}
+		if deployment.Spec.Template.Annotations == nil {
+			deployment.Spec.Template.Annotations = map[string]string{}
+		}
+		deployment.Annotations[annotationKey] = v
+		deployment.Spec.Template.Annotations[annotationKey] = v
 	}
 }

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcehash/as_configmap.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcehash/as_configmap.go
@@ -1,0 +1,172 @@
+package resourcehash
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	v1 "k8s.io/client-go/listers/core/v1"
+)
+
+// GetConfigMapHash returns a hash of the configmap data
+func GetConfigMapHash(obj *corev1.ConfigMap) (string, error) {
+	hasher := fnv.New32()
+	if err := json.NewEncoder(hasher).Encode(obj.Data); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// GetSecretHash returns a hash of the secret data
+func GetSecretHash(obj *corev1.Secret) (string, error) {
+	hasher := fnv.New32()
+	if err := json.NewEncoder(hasher).Encode(obj.Data); err != nil {
+		return "", err
+	}
+	return base64.URLEncoding.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// MultipleObjectHashStringMap returns a map of key/hash pairs suitable for merging into a configmap
+func MultipleObjectHashStringMap(objs ...runtime.Object) (map[string]string, error) {
+	ret := map[string]string{}
+
+	for _, obj := range objs {
+		switch t := obj.(type) {
+		case *corev1.ConfigMap:
+			hash, err := GetConfigMapHash(t)
+			if err != nil {
+				return nil, err
+			}
+			// this string coercion is lossy, but it should be fairly controlled and must be an allowed name
+			ret[mapKeyFor("configmap", t.Namespace, t.Name)] = hash
+
+		case *corev1.Secret:
+			hash, err := GetSecretHash(t)
+			if err != nil {
+				return nil, err
+			}
+			// this string coercion is lossy, but it should be fairly controlled and must be an allowed name
+			ret[mapKeyFor("secret", t.Namespace, t.Name)] = hash
+
+		default:
+			return nil, fmt.Errorf("%T is not handled", t)
+		}
+	}
+
+	return ret, nil
+}
+
+func mapKeyFor(resource, namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", namespace, name, resource)
+}
+
+// ObjectReference can be used to reference a particular resource.  Not all group resources are respected by all methods.
+type ObjectReference struct {
+	Resource  schema.GroupResource
+	Namespace string
+	Name      string
+}
+
+// MultipleObjectHashStringMapForObjectReferences returns a map of key/hash pairs suitable for merging into a configmap
+func MultipleObjectHashStringMapForObjectReferences(client kubernetes.Interface, objRefs ...*ObjectReference) (map[string]string, error) {
+	objs := []runtime.Object{}
+
+	for _, objRef := range objRefs {
+		switch objRef.Resource {
+		case schema.GroupResource{Resource: "configmap"}, schema.GroupResource{Resource: "configmaps"}:
+			obj, err := client.CoreV1().ConfigMaps(objRef.Namespace).Get(context.TODO(), objRef.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				// don't error, just don't list the key. this is different than empty
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, obj)
+
+		case schema.GroupResource{Resource: "secret"}, schema.GroupResource{Resource: "secrets"}:
+			obj, err := client.CoreV1().Secrets(objRef.Namespace).Get(context.TODO(), objRef.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				// don't error, just don't list the key. this is different than empty
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, obj)
+
+		default:
+			return nil, fmt.Errorf("%v is not handled", objRef.Resource)
+		}
+	}
+
+	return MultipleObjectHashStringMap(objs...)
+}
+
+// MultipleObjectHashStringMapForObjectReferenceFromLister is MultipleObjectHashStringMapForObjectReferences using a lister for performance
+func MultipleObjectHashStringMapForObjectReferenceFromLister(configmapLister v1.ConfigMapLister, secretLister v1.SecretLister, objRefs ...*ObjectReference) (map[string]string, error) {
+	objs := []runtime.Object{}
+
+	for _, objRef := range objRefs {
+		switch objRef.Resource {
+		case schema.GroupResource{Resource: "configmap"}, schema.GroupResource{Resource: "configmaps"}:
+			obj, err := configmapLister.ConfigMaps(objRef.Namespace).Get(objRef.Name)
+			if apierrors.IsNotFound(err) {
+				// don't error, just don't list the key. this is different than empty
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, obj)
+
+		case schema.GroupResource{Resource: "secret"}, schema.GroupResource{Resource: "secrets"}:
+			obj, err := secretLister.Secrets(objRef.Namespace).Get(objRef.Name)
+			if apierrors.IsNotFound(err) {
+				// don't error, just don't list the key. this is different than empty
+				continue
+			}
+			if err != nil {
+				return nil, err
+			}
+			objs = append(objs, obj)
+
+		default:
+			return nil, fmt.Errorf("%v is not handled", objRef.Resource)
+		}
+	}
+
+	return MultipleObjectHashStringMap(objs...)
+}
+
+func NewObjectRef() *ObjectReference {
+	return &ObjectReference{}
+}
+
+func (r *ObjectReference) ForConfigMap() *ObjectReference {
+	r.Resource = schema.GroupResource{Resource: "configmaps"}
+	return r
+}
+
+func (r *ObjectReference) ForSecret() *ObjectReference {
+	r.Resource = schema.GroupResource{Resource: "secrets"}
+	return r
+}
+
+func (r *ObjectReference) Named(name string) *ObjectReference {
+	r.Name = name
+	return r
+}
+
+func (r *ObjectReference) InNamespace(namespace string) *ObjectReference {
+	r.Namespace = namespace
+	return r
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -209,6 +209,7 @@ github.com/openshift/cluster-api-provider-gcp/pkg/apis/gcpprovider/v1beta1
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/operator/events
 github.com/openshift/library-go/pkg/operator/resource/resourceapply
+github.com/openshift/library-go/pkg/operator/resource/resourcehash
 github.com/openshift/library-go/pkg/operator/resource/resourcehelper
 github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 github.com/openshift/library-go/pkg/operator/v1helpers


### PR DESCRIPTION
### Why

The installer team is investigating running CI for AWS GovCloud https://issues.redhat.com/browse/CORS-1315 . Because of various restrictions the team and DPP are working to enable Gov Cloud emulator from SHIFT https://issues.redhat.com/browse/DPP-4708 as our solution to testing these restricted environment on AWS.

The SHIFT emulator works almost like Man-In-Middle-Terminating SSL Proxy capturing and transporting all connections from the chosen VPC to their own backbone and then emulating the AWS calls to say GovCloud region onto the source VPC's region which can be any commercial region.

So the allow testing of ipi workflow in the above mentioned environment we need the machine-controller talking to aws apis like other operators and components pulling content from internet to trust the certificate of the mimt-ssl-proxy. 

### add trusted ca bundle to machine-controllers 

The machine-controllers communicate with AWS APIs that are outside the openshift cluster, therefore
it is possible that if the user has setup a Man-In-Middle-Terminating SSL Proxy for external traffic for reasons like auditing,
the machine-controllers will fail to communicate with AWS APIs as they do not trust the mimt-ssl-proxy's certificate.

The goal is to support just the case of mimt-proxy because this usually is applied using traffic shaping that directs all external traffic to it,
and therefore it makes sense to support it and still keep the previous stance that openshift expects to reach out to cloud APIs directly.

The implementation is very similar to the other cluster operators like cluster-ingress-operator in https://github.com/openshift/cluster-ingress-operator/pull/334/files

It creates a configmap in operator namespace with the annotation `config.openshift.io/inject-trusted-cabundle: "true"` which will include the complete trust for the container
and will be updated when user changes their configuration to add or change the user-defined trust for mimt-proxy.

### So the trust bundle is loaded into the machine-controller's deployment as a config map volume, so the contents of the file
will automatically be syned when the config map contents change due to external factors.

But all the http clients that have already been created by the machine-controller like the cloud SDK clients, these will not see the
new trust unless re-created. So therefore to reload the trust for these clients we have 2 options,

- update all the cluster-api-provider implementations to include an ability to reload/restart when a file changes on disk.
  This requires a lot of work in each of the implementations and also creates a lot of duplicated code when we cannot use the same
  code for the behavior because we use upstream-downstream patches.

- track external dependencies and update the deployment object to rollout the changes as part of management in the machine-api-operator itself.
  This keeps the code to track this and others if we do end up extending it in one place in the operator. This method is extensively used
  by various other library-go based operators like openshift-apiserver-oeprator here https://github.com/openshift/cluster-openshift-apiserver-operator/blob/master/pkg/operator/workload/workload_openshiftapiserver_v311_00_sync.go#L340-L351
  and many others for similar behavior.
Here I have decided to use the latter option.