### PR TITLE
Fix terminationhandler sync

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -112,6 +112,7 @@ func New(
 	}
 
 	deployInformer.Informer().AddEventHandler(optr.eventHandlerDeployments())
+	daemonsetInformer.Informer().AddEventHandler(optr.eventHandler())
 	validatingWebhookInformer.Informer().AddEventHandler(optr.eventHandlerSingleton(isMachineWebhook))
 	mutatingWebhookInformer.Informer().AddEventHandler(optr.eventHandlerSingleton(isMachineWebhook))
 	featureGateInformer.Informer().AddEventHandler(optr.eventHandler())


### PR DESCRIPTION
This #535 introduced support to manage a damonSet which runs termination handler for spot intances.
As an event handler is not passed to the damonSet informer changes to the resource won't trigger a reconcile.
This PR fixes that by passing the event handler to the daemonSet namespaced informer.
This will be e2e tested by openshift/cluster-api-actuator-pkg#177