### PR TITLE
BUG 1858400: [Performance] Lease refresh period for machine-api-controllers is too high, causes heavy writes to etcd at idle

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -59,7 +59,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -75,7 +75,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -423,6 +423,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 		"--logtostderr=true",
 		"--v=3",
 		"--leader-elect=true",
+		"--leader-elect-lease-duration=90s",
 		fmt.Sprintf("--namespace=%s", config.TargetNamespace),
 	}
 


### PR DESCRIPTION
The machine-api-controller components are refreshing their lease more
than all other components combined. Bringing this to 90s each, will
decrease etcd writes at idle.

All relevant PRs:
- https://github.com/openshift/cluster-api-provider-aws/pull/339
- https://github.com/openshift/cluster-api-provider-azure/pull/152
- https://github.com/openshift/cluster-api-provider-baremetal/pull/88
- https://github.com/openshift/cluster-api-provider-gcp/pull/104
- https://github.com/openshift/cluster-api-provider-openstack/pull/109
- https://github.com/openshift/cluster-api-provider-ovirt/pull/56
- https://github.com/openshift/machine-api-operator/pull/649