### PR TITLE
BUG 1859221: Wait for resources to roll out on every sync

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -109,10 +109,10 @@ func (optr *Operator) syncClusterAPIController(config *OperatorConfig) error {
 	}
 	if updated {
 		resourcemerge.SetDeploymentGeneration(&optr.generations, d)
-		err := optr.waitForDeploymentRollout(controllersDeployment, deploymentRolloutPollInterval, deploymentRolloutTimeout)
-		if err != nil {
-			return err
-		}
+	}
+
+	if err := optr.waitForDeploymentRollout(controllersDeployment, deploymentRolloutPollInterval, deploymentRolloutTimeout); err != nil {
+		return err
 	}
 
 	// Sync Termination Handler DaemonSet if supported
@@ -135,9 +135,8 @@ func (optr *Operator) syncTerminationHandler(config *OperatorConfig) error {
 	}
 	if updated {
 		resourcemerge.SetDaemonSetGeneration(&optr.generations, ds)
-		return optr.waitForDaemonSetRollout(terminationDaemonSet)
 	}
-	return nil
+	return optr.waitForDaemonSetRollout(terminationDaemonSet)
 }
 
 func (optr *Operator) syncWebhookConfiguration() error {


### PR DESCRIPTION
Currently the mao only validate the expected pods are available if there happens to be a deployment resource update https://github.com/openshift/machine-api-operator/blob/master/pkg/operator/sync.go#L110-L116.

This prevents the operator from going degraded for any scenario where the expected pods are not available and "ApplyDeployment" is not returning "updated=true".
E.g an induced pod crash looping.

Intead we want to wait to roll out the expected replicas every sync loop.

This was realised by https://bugzilla.redhat.com/show_bug.cgi?id=1856597