### PR TITLE
bug 1857175: Let webhook only set clusterID label if it does not exist

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -452,7 +452,9 @@ func (h *machineDefaulterHandler) Handle(ctx context.Context, req admission.Requ
 	if m.Labels == nil {
 		m.Labels = make(map[string]string)
 	}
-	m.Labels[MachineClusterIDLabel] = h.clusterID
+	if _, ok := m.Labels[MachineClusterIDLabel]; !ok {
+		m.Labels[MachineClusterIDLabel] = h.clusterID
+	}
 
 	if ok, err := h.webhookOperations(m, h.clusterID); !ok {
 		return admission.Denied(err.Error())

--- a/pkg/apis/machine/v1beta1/machineset_webhook.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook.go
@@ -131,12 +131,16 @@ func (h *machineSetDefaulterHandler) defaultMachineSet(ms *MachineSet) (bool, ut
 		if ms.Spec.Selector.MatchLabels == nil {
 			ms.Spec.Selector.MatchLabels = make(map[string]string)
 		}
-		ms.Spec.Selector.MatchLabels[MachineClusterIDLabel] = h.clusterID
+		if _, ok := ms.Spec.Selector.MatchLabels[MachineClusterIDLabel]; !ok {
+			ms.Spec.Selector.MatchLabels[MachineClusterIDLabel] = h.clusterID
+		}
 
 		if ms.Spec.Template.Labels == nil {
 			ms.Spec.Template.Labels = make(map[string]string)
 		}
-		ms.Spec.Template.Labels[MachineClusterIDLabel] = h.clusterID
+		if _, ok := ms.Spec.Template.Labels[MachineClusterIDLabel]; !ok {
+			ms.Spec.Template.Labels[MachineClusterIDLabel] = h.clusterID
+		}
 
 		// Restore the defaulted template
 		ms.Spec.Template.Spec = m.Spec


### PR DESCRIPTION
This enabled webhooks to enforce the clusterID labels on machineSet/machine creation https://github.com/openshift/machine-api-operator/pull/644.
To avoid any difficult to predict side effect we want to honour any existing value that is already set on existing resources.