### PR TITLE
Bug 1805639: Validate credentialsSecret

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -66,13 +66,21 @@ func TestMachineCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -458,13 +466,21 @@ func TestMachineUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -1384,7 +1400,13 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			c := fake.NewFakeClientWithScheme(scheme.Scheme)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "name",
+					Namespace: "namespace",
+				},
+			}
+			c := fake.NewFakeClientWithScheme(scheme.Scheme, secret)
 			ok, err := h.webhookOperations(m, h.clusterID, &c)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -54,9 +54,17 @@ func TestMachineCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -430,9 +438,17 @@ func TestMachineUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -2082,7 +2098,12 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			c := fake.NewFakeClientWithScheme(scheme.Scheme)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+			}
+			c := fake.NewFakeClientWithScheme(scheme.Scheme, secret)
 			ok, err := h.webhookOperations(m, h.clusterID, &c)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -60,11 +60,19 @@ func TestMachineCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -444,11 +452,19 @@ func TestMachineUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -1791,7 +1807,12 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			c := fake.NewFakeClientWithScheme(scheme.Scheme)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "name",
+				},
+			}
+			c := fake.NewFakeClientWithScheme(scheme.Scheme, secret)
 			ok, err := h.webhookOperations(m, h.clusterID, &c)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -55,11 +55,19 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -445,11 +453,19 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -43,6 +43,17 @@ func TestMachineSetCreation(t *testing.T) {
 		g.Expect(c.Delete(ctx, namespace)).To(Succeed())
 	}()
 
+	awsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAWSCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
+	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	defer func() {
+		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+	}()
+
 	testCases := []struct {
 		name              string
 		platformType      osconfigv1.PlatformType
@@ -218,7 +229,7 @@ func TestMachineSetCreation(t *testing.T) {
 			}
 
 			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
-			machineSetValidator := createMachineSetValidator(platformStatus.Type, tc.clusterID)
+			machineSetValidator := createMachineSetValidator(platformStatus.Type, tc.clusterID, &c)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
 
@@ -412,6 +423,17 @@ func TestMachineSetUpdate(t *testing.T) {
 	g.Expect(c.Create(ctx, namespace)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, namespace)).To(Succeed())
+	}()
+
+	awsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAWSCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
+	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	defer func() {
+		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -710,7 +732,7 @@ func TestMachineSetUpdate(t *testing.T) {
 			}
 
 			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
-			machineSetValidator := createMachineSetValidator(platformStatus.Type, tc.clusterID)
+			machineSetValidator := createMachineSetValidator(platformStatus.Type, tc.clusterID, &c)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
 

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -49,9 +49,17 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -431,9 +439,17 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -61,13 +61,21 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -459,13 +467,21 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/machine/v1beta1/v1beta1_suite_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fuzz "github.com/google/gofuzz"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +80,17 @@ func TestMain(m *testing.M) {
 	}
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Azure credentialsSecret is a secretRef defaulting to defaultSecretNamespace instead of a localObjectRef.
+	// This is so the tests can assume this namespace exists.
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultSecretNamespace,
+		},
+	}
+	if err = c.Create(ctx, namespace); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
This let the webhook to validate the credentialsSecret existence before creating the machine resource.
Additionally we should probably reflect any unexpected error to use the credentialsSecret as providerStatus conditions https://issues.redhat.com/browse/OCPCLOUD-931