### PR TITLE
Update default user data to be worker-user-data-managed

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -95,7 +95,7 @@ const (
 	defaultWebhookServiceName       = "machine-api-operator-webhook"
 	defaultWebhookServiceNamespace  = "openshift-machine-api"
 
-	defaultUserDataSecret  = "worker-user-data"
+	defaultUserDataSecret  = "worker-user-data-managed"
 	defaultSecretNamespace = "openshift-machine-api"
 
 	// AWS Defaults


### PR DESCRIPTION
This https://github.com/openshift/installer/pull/3730 changed the name of the userdata generated by the installer to satisfy MCO ign v2 -> v3 migration and let the new secret be under mco management. https://github.com/openshift/enhancements/pull/368.