### PR TITLE
Bug 1864352: Add leader election mechanism to release 4.5

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -17,6 +17,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func printVersion() {
 	glog.Infof("Go Version: %s", runtime.Version())
 	glog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -64,6 +70,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-healthcheck-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {

--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -19,8 +19,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -50,7 +51,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"runtime"
+	"time"
 
 	"github.com/openshift/machine-api-operator/pkg/controller/machinehealthcheck"
 
@@ -23,7 +24,30 @@ func printVersion() {
 }
 
 func main() {
-	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
+	watchNamespace := flag.String(
+		"namespace",
+		"",
+		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
+	)
+
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
+
 	flag.Parse()
 	printVersion()
 
@@ -35,8 +59,13 @@ func main() {
 
 	opts := manager.Options{
 		// Disable metrics serving
-		MetricsBindAddress: "0",
+		MetricsBindAddress:      "0",
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-healthcheck-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
 	}
+
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace
 		glog.Infof("Watching machine-api objects only in namespace %q for reconciliation.", opts.Namespace)

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -37,6 +37,24 @@ func main() {
 	watchNamespace := flag.String("namespace", "",
 		"Namespace that the controller watches to reconcile cluster-api objects. If unspecified, the controller watches for cluster-api objects across all namespaces.")
 
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
+
 	flag.Parse()
 	if *watchNamespace != "" {
 		log.Printf("Watching cluster-api objects only in namespace %q for reconciliation.", *watchNamespace)
@@ -52,9 +70,13 @@ func main() {
 	syncPeriod := 10 * time.Minute
 	opts := manager.Options{
 		// Disable metrics serving
-		MetricsBindAddress: "0",
-		SyncPeriod:         &syncPeriod,
-		Namespace:          *watchNamespace,
+		MetricsBindAddress:      "0",
+		SyncPeriod:              &syncPeriod,
+		Namespace:               *watchNamespace,
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-machineset-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
 	}
 	mgr, err := manager.New(cfg, opts)
 	if err != nil {

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -33,8 +33,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func main() {
@@ -57,7 +58,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -31,6 +31,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func main() {
 	flag.Set("logtostderr", "true")
 	klog.InitFlags(nil)
@@ -77,6 +83,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-machineset-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 	mgr, err := manager.New(cfg, opts)
 	if err != nil {

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"runtime"
+	"time"
 
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
@@ -23,7 +24,30 @@ func printVersion() {
 func main() {
 	printVersion()
 
-	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
+	watchNamespace := flag.String(
+		"namespace",
+		"",
+		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
+	)
+
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
+
 	klog.InitFlags(nil)
 	flag.Set("logtostderr", "true")
 	flag.Parse()
@@ -36,7 +60,11 @@ func main() {
 
 	opts := manager.Options{
 		// Disable metrics serving
-		MetricsBindAddress: "0",
+		MetricsBindAddress:      "0",
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-nodelink-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -15,6 +15,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func printVersion() {
 	klog.Infof("Go Version: %s", runtime.Version())
 	klog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -65,6 +71,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-nodelink-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -17,8 +17,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -50,7 +51,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -20,8 +20,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func main() {
@@ -49,7 +50,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -18,6 +18,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func main() {
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
@@ -64,6 +70,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-vsphere-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -314,6 +314,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 		"--logtostderr=true",
 		"--v=3",
 		"--leader-elect=true",
+		"--leader-elect-lease-duration=90s",
 		fmt.Sprintf("--namespace=%s", config.TargetNamespace),
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -314,7 +314,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 		"--logtostderr=true",
 		"--v=3",
 		"--leader-elect=true",
-		"--leader-elect-lease-duration=90s",
+		"--leader-elect-lease-duration=120s",
 		fmt.Sprintf("--namespace=%s", config.TargetNamespace),
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -313,6 +313,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 	args := []string{
 		"--logtostderr=true",
 		"--v=3",
+		"--leader-elect=true",
 		fmt.Sprintf("--namespace=%s", config.TargetNamespace),
 	}
 


### PR DESCRIPTION
This change brings in several cherry picks for the leader election mechanisms for all the controllers in this repo.

3d3b575168713c08cc803e41b2b60a6848e41ae9
c939c9208557c35a446d4217e5a4d3ea7de9caf7
5fdd6efbccb119d4805c373c959330242bbd6e67
48d9cce5d878be8b45f1d4b6df0345cee0d7593b
fe7cbdc445c681292859752904012bebdd2c2a98
495f3e78
0a561840
3f124196
a52a7ec8
91251df9
303f931e
644ed9ae
d6ec8b6c
a72ad436
fda33fd1

because this merge request will change the way that the controllers are deployed (adding leader election command line flags), we should make sure all the providers have the change in place first.

aws: https://github.com/openshift/cluster-api-provider-aws/pull/342
azure: https://github.com/openshift/cluster-api-provider-azure/pull/156
baremetal: https://github.com/openshift/cluster-api-provider-baremetal/pull/106
gcp: https://github.com/openshift/cluster-api-provider-gcp/pull/114
openstack: https://github.com/openshift/cluster-api-provider-openstack/pull/117
ovirt:
vsphere: https://github.com/openshift/machine-api-operator/pull/664
