### PR TITLE
Bug 1861974: [vSphere] Improve vSphere webhook

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -108,6 +108,8 @@ const (
 	// Minimum vSphere values taken from vSphere reconciler
 	minVSphereCPU       = 2
 	minVSphereMemoryMiB = 2048
+	// https://docs.openshift.com/container-platform/4.1/installing/installing_vsphere/installing-vsphere.html#minimum-resource-requirements_installing-vsphere
+	minVSphereDiskGiB = 120
 )
 
 func getInfra() (*osconfigv1.Infrastructure, error) {
@@ -864,6 +866,9 @@ func validateVSphere(m *Machine, clusterID string) (bool, utilerrors.Aggregate) 
 	}
 	if providerSpec.MemoryMiB != 0 && providerSpec.MemoryMiB < minVSphereMemoryMiB {
 		errs = append(errs, field.Invalid(field.NewPath("providerSpec", "memoryMiB"), providerSpec.MemoryMiB, fmt.Sprintf("memoryMiB is below minimum value (%d)", minVSphereMemoryMiB)))
+	}
+	if providerSpec.DiskGiB != 0 && providerSpec.DiskGiB < minVSphereDiskGiB {
+		errs = append(errs, field.Invalid(field.NewPath("providerSpec", "diskGiB"), providerSpec.DiskGiB, fmt.Sprintf("diskGiB is below minimum value (%d)", minVSphereDiskGiB)))
 	}
 
 	if providerSpec.UserDataSecret == nil {

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -831,6 +831,20 @@ func defaultVSphere(m *Machine, clusterID string) (bool, utilerrors.Aggregate) {
 		providerSpec.CredentialsSecret = &corev1.LocalObjectReference{Name: defaultVSphereCredentialsSecret}
 	}
 
+	// Default values for number of cpu, memory and disk size come from installer
+	// https://github.com/openshift/installer/blob/0ceffc5c737b49ab59441e2fd02f51f997d54a53/pkg/asset/machines/worker.go#L134
+	if providerSpec.NumCPUs == 0 {
+		providerSpec.NumCPUs = minVSphereCPU
+	}
+
+	if providerSpec.MemoryMiB == 0 {
+		providerSpec.MemoryMiB = minVSphereMemoryMiB
+	}
+
+	if providerSpec.DiskGiB == 0 {
+		providerSpec.DiskGiB = minVSphereDiskGiB
+	}
+
 	rawBytes, err := json.Marshal(providerSpec)
 	if err != nil {
 		errs = append(errs, err)

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -1890,6 +1890,14 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.memoryMiB: Invalid value: 1024: memoryMiB is below minimum value (2048)",
 		},
 		{
+			testCase: "with too little disk size provided",
+			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
+				p.DiskGiB = 1
+			},
+			expectedOk:    false,
+			expectedError: "providerSpec.diskGiB: Invalid value: 1: diskGiB is below minimum value (120)",
+		},
+		{
 			testCase: "with no user data secret provided",
 			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
 				p.UserDataSecret = nil

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -2019,6 +2019,9 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: defaultVSphereCredentialsSecret,
 				},
+				NumCPUs:   minVSphereCPU,
+				MemoryMiB: minVSphereMemoryMiB,
+				DiskGiB:   minVSphereDiskGiB,
 			}
 			if tc.modifyDefault != nil {
 				tc.modifyDefault(defaultProviderSpec)


### PR DESCRIPTION
Add minimal disk value to webhook
https://docs.openshift.com/container-platform/4.1/installing/installing_vsphere/installing-vsphere.html#minimum-resource-requirements_installing-vsphere

Add default values for number of CPUs, memory and disk size
https://github.com/openshift/installer/blob/0ceffc5c737b49ab59441e2fd02f51f997d54a53/pkg/asset/machines/worker.go#L134