### PR TITLE
BUG 1865779: Ensure MHC duration fields include units

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -73,7 +73,7 @@ spec:
                   unsigned duration string of decimal numbers each with optional fraction
                   and a unit suffix, eg "300ms", "1.5h" or "2h45m". Valid time units
                   are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)*)+$
+                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               selector:
                 description: 'Label selector to match machines whose health will be
@@ -139,7 +139,7 @@ spec:
                         numbers each with optional fraction and a unit suffix, eg
                         "300ms", "1.5h" or "2h45m". Valid time units are "ns", "us"
                         (or "µs"), "ms", "s", "m", "h".
-                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h)*)+$
+                      pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                       type: string
                     type:
                       minLength: 1

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -69,7 +69,7 @@ type MachineHealthCheckSpec struct {
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="10m"
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)*)+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	// +kubebuilder:validation:Type:=string
 	NodeStartupTimeout metav1.Duration `json:"nodeStartupTimeout,omitempty"`
 }
@@ -89,7 +89,7 @@ type UnhealthyCondition struct {
 	// Expects an unsigned duration string of decimal numbers each with optional
 	// fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h)*)+$"
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	// +kubebuilder:validation:Type:=string
 	Timeout metav1.Duration `json:"timeout"`
 }


### PR DESCRIPTION
Units are mandatory when a time.Duration is being parsed. The regex as it was allowed durations to be optional, this has been updated to force a unit to be included.