### PR TITLE
BUG 1827307: Default MachineSet replicas to 1

### DIFF
--- a/hack/fetch_ext_bins.sh
+++ b/hack/fetch_ext_bins.sh
@@ -26,7 +26,8 @@ if [ -n "$TRACE" ]; then
   set -x
 fi
 
-k8s_version=1.16.4
+k8s_version=1.18.8
+etcd_version=3.4.10
 goarch=amd64
 goos="unknown"
 
@@ -92,14 +93,26 @@ function fetch_tools {
   fi
 
   header_text "fetching tools"
-  kb_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
-  kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$kb_tools_archive_name"
 
-  kb_tools_archive_path="$tmp_root/$kb_tools_archive_name"
-  if [ ! -f $kb_tools_archive_path ]; then
-    curl -fsL ${kb_tools_download_url} -o "$kb_tools_archive_path"
-  fi
-  tar -zvxf "$kb_tools_archive_path" -C "$tmp_root/"
+  mkdir -p "${kb_root_dir}/bin"
+
+  k8s_download_root="https://dl.k8s.io/v${k8s_version}/bin/${goos}/${goarch}"
+
+  curl -fsL "${k8s_download_root}/kubectl" -o "${kb_root_dir}/bin/kubectl"
+  chmod +x "${kb_root_dir}/bin/kubectl"
+
+  curl -fsL "${k8s_download_root}/kube-apiserver" -o "${kb_root_dir}/bin/kube-apiserver"
+  chmod +x "${kb_root_dir}/bin/kube-apiserver"
+
+  etcd_os_version="etcd-v${etcd_version}-${goos}-${goarch}"
+  etcd_archive="${etcd_os_version}.tar.gz"
+  etcd_download_url="https://github.com/etcd-io/etcd/releases/download/v${etcd_version}/${etcd_archive}"
+  curl -fsL "${etcd_download_url}" -o "${kb_root_dir}/${etcd_archive}"
+
+  tar -zvxf "${kb_root_dir}/${etcd_archive}" -o "${etcd_os_version}/etcd"
+  mv "${etcd_os_version}/etcd" "${kb_root_dir}/bin/etcd"
+  rm "${kb_root_dir}/${etcd_archive}"
+  rm -rf "${etcd_os_version}"
 }
 
 function setup_envs {

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -75,6 +75,7 @@ spec:
                 format: int32
                 type: integer
               replicas:
+                default: 1
                 description: Replicas is the number of desired replicas. This is a
                   pointer to distinguish between explicit zero and unspecified. Defaults
                   to 1.

--- a/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/pkg/apis/machine/v1beta1/machineset_types.go
@@ -55,7 +55,7 @@ type MachineSetSpec struct {
 	// Replicas is the number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.
 	// Defaults to 1.
-	// +optional
+	// +kubebuilder:default=1
 	Replicas *int32 `json:"replicas,omitempty"`
 
 	// MinReadySeconds is the minimum number of seconds for which a newly created machine should be ready.


### PR DESCRIPTION
The docs say that this should be defaulted to 1. The controller expects it to be non nil and errors if the value is nil. By defaulting to 1 we may break a small number of users who may have been using a nil value to prevent the machineset controller from working, but this is not an intended behaviour anyway.

I have manually tested this on an openshift 4.6 cluster build from 2020-08-03 and it works as expected.