### PR TITLE
Bug 1866719: Keep machine.nodeRef even if node was marked for deletion

### DIFF
--- a/pkg/controller/nodelink/nodelink_controller.go
+++ b/pkg/controller/nodelink/nodelink_controller.go
@@ -259,10 +259,6 @@ func (r *ReconcileNodeLink) updateNodeRef(machine *mapiv1beta1.Machine, node *co
 	machine.Status.LastUpdated = &now
 
 	if !node.DeletionTimestamp.IsZero() {
-		machine.Status.NodeRef = nil
-		if err := r.client.Status().Update(context.Background(), machine); err != nil {
-			return fmt.Errorf("error updating machine %q: %v", machine.GetName(), err)
-		}
 		delete(r.nodeReadinessCache, node.GetName())
 		return nil
 	}


### PR DESCRIPTION
If node get deleted, nodelink controller will [remove the nodeRef](https://github.com/openshift/machine-api-operator/blob/master/pkg/controller/nodelink/nodelink_controller.go#L261-L262) from the machine.
It will happen only if there's something that delays the deletion, such as node finalizer. Otherwise, nodelink controller won't be notified that the node was deleted.

It means that we could reach different outcome, depends on the time taken for a node to be deleted.
If node was deleted immediately - nodeRef will stay on the machine.
If there's some delay (e.g. due to finalizer) - nodeRef will be deleted

It can also create a race with providers who put finalizer on the node, then can't determine which machine was associated with that node (see https://bugzilla.redhat.com/show_bug.cgi?id=1866719 )

Moreover, Machine in its lifecycle should have only one node. Thus, there's no reason to remove that nodeRef.
