### PR TITLE
RegisterFailedInstanceUpdate should update failedInstanceUpdateCount

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -201,7 +201,7 @@ func RegisterFailedInstanceCreate(labels *MachineLabels) {
 }
 
 func RegisterFailedInstanceUpdate(labels *MachineLabels) {
-	failedInstanceCreateCount.With(prometheus.Labels{
+	failedInstanceUpdateCount.With(prometheus.Labels{
 		"name":      labels.Name,
 		"namespace": labels.Namespace,
 		"reason":    labels.Reason,


### PR DESCRIPTION
While reading through a bug that involved metrics, I noticed that this was updating the wrong metric variable.
There are no tests around this as far as I can tell, so I haven't updated any.

We should add some tests around the prometheus metrics, though I assume that would be in the E2E suite rather than here.