### PR TITLE
Move to context driven reconcile thread for MAO

### DIFF
--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -1,7 +1,6 @@
 package operator
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -120,7 +119,7 @@ func TestOperatorStatusProgressing(t *testing.T) {
 		}
 
 		optr.statusProgressing()
-		gotCO, _ = optr.osClient.ConfigV1().ClusterOperators().Get(context.Background(), clusterOperatorName, metav1.GetOptions{})
+		gotCO, _ = optr.osClient.ConfigV1().ClusterOperators().Get(optr.context, clusterOperatorName, metav1.GetOptions{})
 		var conditionAfterAnotherSync osconfigv1.ClusterOperatorStatusCondition
 		for _, coCondition := range gotCO.Status.Conditions {
 			if coCondition.Type == osconfigv1.OperatorProgressing {

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -113,9 +113,11 @@ func TestWaitForDeploymentRollout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			var cancel context.CancelFunc
 			optr := newFakeOperator([]runtime.Object{tc.deployment}, nil, make(<-chan struct{}))
-
-			got := optr.waitForDeploymentRollout(tc.deployment, 1*time.Second, 3*time.Second)
+			optr.context, cancel = context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+			got := optr.waitForDeploymentRollout(tc.deployment)
 			if tc.expected != nil {
 				if tc.expected.Error() != got.Error() {
 					t.Errorf("Got: %v, expected: %v", got, tc.expected)


### PR DESCRIPTION
Refactor MAO to be non-blocking, and process each event as it appears.
Previous thread would be canceled, and a new one started once a new
event enters the queue.

Previous 5 minutes timeouts on Deployment and DaemonSet rollout are
now merged into global 10 minute context timeout, accounting for both.

The main difference is that there is no longer a soft lock on changes, if
the operator is currently busy processing previous event, while not knowing
about anything for a period ~10 minutes in the worst case.