### PR TITLE
Bug 1805639: Validate credentialsSecret

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -1113,6 +1113,8 @@ func validateVSphere(m *Machine, config *admissionConfig) (bool, []string, utile
 	} else {
 		if providerSpec.CredentialsSecret.Name == "" {
 			errs = append(errs, field.Required(field.NewPath("providerSpec", "credentialsSecret", "name"), "name must be provided"))
+		} else {
+			errs = append(errs, credentialsSecretExists(config.client, providerSpec.CredentialsSecret.Name, m.GetNamespace())...)
 		}
 	}
 

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -959,6 +959,8 @@ func validateGCP(m *Machine, config *admissionConfig) (bool, []string, utilerror
 	} else {
 		if providerSpec.CredentialsSecret.Name == "" {
 			errs = append(errs, field.Required(field.NewPath("providerSpec", "credentialsSecret", "name"), "name must be provided"))
+		} else {
+			errs = append(errs, credentialsSecretExists(config.client, providerSpec.CredentialsSecret.Name, m.GetNamespace())...)
 		}
 	}
 

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -793,6 +793,9 @@ func validateAzure(m *Machine, config *admissionConfig) (bool, []string, utilerr
 		if providerSpec.CredentialsSecret.Name == "" {
 			errs = append(errs, field.Required(field.NewPath("providerSpec", "credentialsSecret", "name"), "name must be provided"))
 		}
+		if providerSpec.CredentialsSecret.Name != "" && providerSpec.CredentialsSecret.Namespace != "" {
+			errs = append(errs, credentialsSecretExists(config.client, providerSpec.CredentialsSecret.Name, providerSpec.CredentialsSecret.Namespace)...)
+		}
 	}
 
 	if providerSpec.OSDisk.DiskSizeGB <= 0 || providerSpec.OSDisk.DiskSizeGB >= azureMaxDiskSizeGB {

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -14,6 +14,7 @@ import (
 	vsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -24,6 +25,7 @@ import (
 	aws "sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1beta1"
 	azure "sigs.k8s.io/cluster-api-provider-azure/pkg/apis/azureprovider/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	yaml "sigs.k8s.io/yaml"
 )
@@ -112,6 +114,47 @@ var (
 	webhookSideEffects   = admissionregistrationv1.SideEffectClassNone
 )
 
+func secretExists(c client.Client, name, namespace string) (bool, error) {
+	key := client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+	obj := &corev1.Secret{}
+
+	if err := c.Get(context.Background(), key, obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func credentialsSecretExists(c client.Client, name, namespace string) []error {
+	secretExists, err := secretExists(c, name, namespace)
+	if err != nil {
+		return []error{
+			field.Invalid(
+				field.NewPath("providerSpec", "credentialsSecret"),
+				name,
+				fmt.Sprintf("failed to get credentialsSecret: %v", err),
+			),
+		}
+	}
+
+	if !secretExists {
+		return []error{
+			field.Invalid(
+				field.NewPath("providerSpec", "credentialsSecret"),
+				name,
+				"not found. Expected CredentialsSecret to exist",
+			),
+		}
+	}
+
+	return []error{}
+}
+
 func getInfra() (*osconfigv1.Infrastructure, error) {
 	cfg, err := ctrl.GetConfig()
 	if err != nil {
@@ -151,6 +194,7 @@ type admissionConfig struct {
 	clusterID       string
 	platformStatus  *osconfigv1.PlatformStatus
 	dnsDisconnected bool
+	client          client.Client
 }
 
 type admissionHandler struct {
@@ -186,19 +230,29 @@ func NewMachineValidator() (*machineValidatorHandler, error) {
 		return nil, err
 	}
 
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubernetes client: %v", err)
+	}
+
 	dns, err := getDNS()
 	if err != nil {
 		return nil, err
 	}
 
-	return createMachineValidator(infra, dns), nil
+	return createMachineValidator(infra, c, dns), nil
 }
 
-func createMachineValidator(infra *osconfigv1.Infrastructure, dns *osconfigv1.DNS) *machineValidatorHandler {
+func createMachineValidator(infra *osconfigv1.Infrastructure, client client.Client, dns *osconfigv1.DNS) *machineValidatorHandler {
 	admissionConfig := &admissionConfig{
 		dnsDisconnected: dns.Spec.PublicZone == nil,
 		clusterID:       infra.Status.InfrastructureName,
 		platformStatus:  infra.Status.PlatformStatus,
+		client:          client,
 	}
 	return &machineValidatorHandler{
 		admissionHandler: &admissionHandler{
@@ -605,6 +659,8 @@ func validateAWS(m *Machine, config *admissionConfig) (bool, []string, utilerror
 				"expected providerSpec.credentialsSecret to be populated",
 			),
 		)
+	} else {
+		errs = append(errs, credentialsSecretExists(config.client, providerSpec.CredentialsSecret.Name, m.GetNamespace())...)
 	}
 
 	if providerSpec.Subnet.ARN == nil && providerSpec.Subnet.ID == nil && providerSpec.Subnet.Filters == nil {

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -905,6 +905,14 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.credentialsSecret: Required value: expected providerSpec.credentialsSecret to be populated",
 		},
 		{
+			testCase: "when the credentials secret does not exist",
+			modifySpec: func(p *aws.AWSMachineProviderConfig) {
+				p.CredentialsSecret.Name = "does-not-exist"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"providerSpec.credentialsSecret: Invalid value: \"does-not-exist\": not found. Expected CredentialsSecret to exist"},
+		},
+		{
 			testCase: "with no subnet values it fails",
 			modifySpec: func(p *aws.AWSMachineProviderConfig) {
 				p.Subnet = aws.AWSResourceReference{}
@@ -1256,6 +1264,14 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			},
 			expectedOk:    false,
 			expectedError: "providerSpec.credentialsSecret.namespace: Required value: namespace must be provided",
+		},
+		{
+			testCase: "when the credentials secret does not exist",
+			modifySpec: func(p *azure.AzureMachineProviderSpec) {
+				p.CredentialsSecret.Name = "does-not-exist"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"providerSpec.credentialsSecret: Invalid value: \"does-not-exist\": not found. Expected CredentialsSecret to exist"},
 		},
 		{
 			testCase: "with no credentials secret name it fails",
@@ -1735,6 +1751,14 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.credentialsSecret: Required value: credentialsSecret must be provided",
 		},
 		{
+			testCase: "when the credentials secret does not exist",
+			modifySpec: func(p *gcp.GCPMachineProviderSpec) {
+				p.CredentialsSecret.Name = "does-not-exist"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"providerSpec.credentialsSecret: Invalid value: \"does-not-exist\": not found. Expected CredentialsSecret to exist"},
+		},
+		{
 			testCase: "with no user data secret name",
 			modifySpec: func(p *gcp.GCPMachineProviderSpec) {
 				p.CredentialsSecret = &corev1.LocalObjectReference{}
@@ -2088,6 +2112,14 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			},
 			expectedOk:    false,
 			expectedError: "providerSpec.credentialsSecret: Required value: credentialsSecret must be provided",
+		},
+		{
+			testCase: "when the credentials secret does not exist",
+			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
+				p.CredentialsSecret.Name = "does-not-exist"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"providerSpec.credentialsSecret: Invalid value: \"does-not-exist\": not found. Expected CredentialsSecret to exist"},
 		},
 		{
 			testCase: "with no credentials secret name provided",

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -61,13 +61,21 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -452,13 +460,21 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	azureSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAzureCredentialsSecret,
+			Namespace: defaultSecretNamespace,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, azureSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, azureSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -49,9 +49,17 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -424,9 +432,17 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	vSphereSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultVSphereCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -55,11 +55,19 @@ func TestMachineSetCreation(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -438,11 +446,19 @@ func TestMachineSetUpdate(t *testing.T) {
 			Namespace: namespace.Name,
 		},
 	}
+	GCPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultGCPCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
 	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
 	g.Expect(c.Create(ctx, vSphereSecret)).To(Succeed())
+	g.Expect(c.Create(ctx, GCPSecret)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 		g.Expect(c.Delete(ctx, vSphereSecret)).To(Succeed())
+		g.Expect(c.Delete(ctx, GCPSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -43,6 +43,17 @@ func TestMachineSetCreation(t *testing.T) {
 		g.Expect(c.Delete(ctx, namespace)).To(Succeed())
 	}()
 
+	awsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAWSCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
+	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	defer func() {
+		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
+	}()
+
 	testCases := []struct {
 		name              string
 		platformType      osconfigv1.PlatformType
@@ -236,7 +247,7 @@ func TestMachineSetCreation(t *testing.T) {
 				dns.Spec.PublicZone = &osconfigv1.DNSZone{}
 			}
 			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
-			machineSetValidator := createMachineSetValidator(infra, dns)
+			machineSetValidator := createMachineSetValidator(infra, c, dns)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
 
@@ -405,6 +416,17 @@ func TestMachineSetUpdate(t *testing.T) {
 	g.Expect(c.Create(ctx, namespace)).To(Succeed())
 	defer func() {
 		g.Expect(c.Delete(ctx, namespace)).To(Succeed())
+	}()
+
+	awsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultAWSCredentialsSecret,
+			Namespace: namespace.Name,
+		},
+	}
+	g.Expect(c.Create(ctx, awsSecret)).To(Succeed())
+	defer func() {
+		g.Expect(c.Delete(ctx, awsSecret)).To(Succeed())
 	}()
 
 	testCases := []struct {
@@ -704,7 +726,7 @@ func TestMachineSetUpdate(t *testing.T) {
 			infra.Status.PlatformStatus = platformStatus
 
 			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
-			machineSetValidator := createMachineSetValidator(infra, plainDNS)
+			machineSetValidator := createMachineSetValidator(infra, c, plainDNS)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
 

--- a/pkg/apis/machine/v1beta1/v1beta1_suite_test.go
+++ b/pkg/apis/machine/v1beta1/v1beta1_suite_test.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+
 	fuzz "github.com/google/gofuzz"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -78,6 +80,17 @@ func TestMain(m *testing.M) {
 	}
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
+		log.Fatal(err)
+	}
+
+	// Azure credentialsSecret is a secretRef defaulting to defaultSecretNamespace instead of a localObjectRef.
+	// This is so the tests can assume this namespace exists.
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultSecretNamespace,
+		},
+	}
+	if err = c.Create(ctx, namespace); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
This let the webhook to validate the credentialsSecret existence before creating the machine resource.
Additionally we should probably reflect any unexpected error to use the credentialsSecret as providerStatus conditions https://issues.redhat.com/browse/OCPCLOUD-931

I'm taking over this bug from @enxebre as he is away for three weeks. I've applied all of my suggestions from the original PR #660 and am happy for this to merge once it has undergone some manual testing.