### PR TITLE
BUG 1858400: [Performance] Lease refresh period for machine-api-controllers is too high, causes heavy writes to etcd at idle

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -20,6 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func printVersion() {
 	glog.Infof("Go Version: %s", runtime.Version())
 	glog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -79,6 +85,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-healthcheck-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {

--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -22,8 +22,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -65,7 +66,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -39,6 +39,12 @@ const (
 	defaultWebhookCertdir = "/etc/machine-api-operator/tls"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func main() {
 	flag.Set("logtostderr", "true")
 	klog.InitFlags(nil)
@@ -102,6 +108,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-machineset-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	mgr, err := manager.New(cfg, opts)

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -41,8 +41,9 @@ const (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func main() {
@@ -81,7 +82,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -15,6 +15,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func printVersion() {
 	klog.Infof("Go Version: %s", runtime.Version())
 	klog.Infof("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -65,6 +71,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-nodelink-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -17,8 +17,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -50,7 +51,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -22,8 +22,9 @@ import (
 
 // The default durations for the leader electrion operations.
 var (
-	retryPeriod  = 30 * time.Second
-	renewDealine = 90 * time.Second
+	leaseDuration = 120 * time.Second
+	renewDealine  = 110 * time.Second
+	retryPeriod   = 90 * time.Second
 )
 
 func main() {
@@ -51,7 +52,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -20,6 +20,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader electrion operations.
+var (
+	retryPeriod  = 30 * time.Second
+	renewDealine = 90 * time.Second
+)
+
 func main() {
 	var printVersion bool
 	flag.BoolVar(&printVersion, "version", false, "print version and exit")
@@ -79,6 +85,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-vsphere-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDealine,
 	}
 
 	if *watchNamespace != "" {

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -446,7 +446,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 		"--logtostderr=true",
 		"--v=3",
 		"--leader-elect=true",
-		"--leader-elect-lease-duration=90s",
+		"--leader-elect-lease-duration=120s",
 		fmt.Sprintf("--namespace=%s", config.TargetNamespace),
 	}
 


### PR DESCRIPTION
Reduce default lease retry rate on `30s` which will prevent from heavy writes into etcd at idle, and constrain renew deadline on `90s`.

Inspired by https://github.com/openshift/cloud-credential-operator/pull/231