### PR TITLE
Bug 1878204: Adjust alert timing and severity

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -15,9 +15,9 @@ spec:
         - alert: MachineWithoutValidNode
           expr: |
              (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
-          for: 10m
+          for: 60m
           labels:
-            severity: critical
+            severity: warning
           annotations:
             message: "machine {{ $labels.name }} does not have valid node reference"
     - name: machine-with-no-running-phase
@@ -25,9 +25,9 @@ spec:
         - alert: MachineWithNoRunningPhase
           expr: |
             (mapi_machine_created_timestamp_seconds{phase!="Running"}) > 0
-          for: 10m
+          for: 60m
           labels:
-            severity: critical
+            severity: warning
           annotations:
             message: "machine {{ $labels.name }} is in phase: {{ $labels.phase }}"
     - name: machine-api-operator-metrics-collector-up


### PR DESCRIPTION
Currently, the alert timing is too aggressive and
severity is too high.  An individual machine being
down is not critical, any critical components already
have alerting configured (such as etcd).

We're choosing 60m here to allow for MachineHealthChecks and
ClusterAutoscaler to clean up any failed machines prior to setting
an alarm for an individual machine.  This will prevent flapping
alerts on clusters.  Bare metal clusters may take up to 45 minutes
to provision machines depending on environment, so 60M should
cover those users as well.

Related Issue: https://issues.redhat.com/browse/OCPCLOUD-842
Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1829138#c5