### PR TITLE
BUG 1862556: Ensure that negative values for maxUnhealthy do not produce events

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -238,6 +238,10 @@ func isAllowedRemediation(mhc *mapiv1.MachineHealthCheck) bool {
 		return false
 	}
 
+	if maxUnhealthy < 0 {
+		maxUnhealthy = 0
+	}
+
 	// if noHealthy are above maxUnhealthy we short circuit any farther remediation
 	noHealthy := derefInt(mhc.Status.ExpectedMachines) - derefInt(mhc.Status.CurrentHealthy)
 	return (maxUnhealthy - noHealthy) >= 0


### PR DESCRIPTION
Previously, we were producing a remediation restricted event every reconcile if a maxUnhealthy value is negative.
We can only validate the maxUnhealthy integer value by creating a webhook which is a substantial amount of work, this is a quicker fix that makes the behaviour of a negative value identical to that of a 0 value.