### PR TITLE
Don't use external remediation on failed Machines

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -435,10 +435,11 @@ func (r *ReconcileMachineHealthCheck) mhcRequestsFromMachine(o handler.MapObject
 func (t *target) remediate(r *ReconcileMachineHealthCheck) error {
 	glog.Infof(" %s: start remediation logic", t.string())
 
-	remediationStrategy, ok := t.MHC.Annotations[remediationStrategyAnnotation]
-	if ok {
-		if mapiv1.RemediationStrategyType(remediationStrategy) == remediationStrategyExternal {
-			return t.remediationStrategyExternal(r)
+	if derefStringPointer(t.Machine.Status.Phase) != machinePhaseFailed {
+		if remediationStrategy, ok := t.MHC.Annotations[remediationStrategyAnnotation]; ok {
+			if mapiv1.RemediationStrategyType(remediationStrategy) == remediationStrategyExternal {
+				return t.remediationStrategyExternal(r)
+			}
 		}
 	}
 


### PR DESCRIPTION
When Machines go into the Failed phase, this is permanent. Their actuators' `Update()` methods are never called again, and the actuator doesn't get another chance to run until the Machine is deleted. Therefore Machines in this phase cannot be externally remediated by the Machine actuator.

Currently baremetal Machines are the only ones using external remediation, and currently they never go into the Failed phase, but in the future we would like to use this phase to handle unrecoverable errors (invalid config, underlying Host was deleted, &c.)

In these cases, rebooting will not help, and the actuator does not get called to enable it do try anyway, so always remediate them by
deleting the Machine.