### PR TITLE
Bug 1873234: Manage ownership hand-off of metal3 between MAO and CBO for upgrade and downgrade

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -35,6 +35,10 @@ const (
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s, 10.2s, 20.4s, 41s, 82s
 	maxRetries         = 15
 	maoOwnedAnnotation = "machine.openshift.io/owned"
+	// Indicates that the metal3 deployment is being managed by cluster-baremetal-operator
+	cboOwnedAnnotation = "baremetal.openshift.io/owned"
+	// The name of the clusteroperator for cluster-baremetal-operator
+	cboClusterOperatorName = "baremetal"
 )
 
 // Operator defines machine api operator.


### PR DESCRIPTION
In an upgrade scenario, check if CBO is available to take ownership of the metal3 deployment. In that case, back off and let cluster-baremetal-operator (CBO) manage it.

In a downgrade/rollback scenario where the metal3 deployment is
annotated as being owned by cluster-baremetal-operator, but the CBO
has been removed, take back control of the metal3
deployment.