### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,14 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+WORKDIR /go/src/github.com/openshift/machine-api-operator
+COPY . .
+RUN NO_DOCKER=1 make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install manifests
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-healthcheck .
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machineset ./machineset-controller
+COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/vsphere ./machine-controller-manager
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control builds that
target rhel. It is inspired by the automatically generated patches which
ensure that build files match what is in the
[ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the configuration files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/machine-api-operator/openshift-machine-api-operator-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/ose-machine-api-operator.yml
should be updated with the new dockerfile path.