### PR TITLE
BUG 1874861: Ensure an event is emitted when remediation is skipped

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -50,10 +50,9 @@ const (
 	// EventDetectedUnhealthy is emitted in case a node asociated with a
 	// machine was detected unhealthy
 	EventDetectedUnhealthy string = "DetectedUnhealthy"
-	// EventSkippedMaster is emitted in case an unhealthy node (or a machine
-	// associated with the node) has Master role and external remediation strategy
-	// is not enabled
-	EventSkippedMaster string = "SkippedMaster"
+	// EventSkippedNoController is emitted in case an unhealthy node (or a machine
+	// associated with the node) has no controller owner
+	EventSkippedNoController string = "SkippedNoController"
 	// EventMachineDeletionFailed is emitted in case remediation of a machine
 	// is required but deletion of its Machine object failed
 	EventMachineDeletionFailed string = "MachineDeletionFailed"
@@ -443,6 +442,13 @@ func (t *target) remediate(r *ReconcileMachineHealthCheck) error {
 	}
 
 	if !t.hasControllerOwner() {
+		r.recorder.Eventf(
+			&t.Machine,
+			corev1.EventTypeNormal,
+			EventSkippedNoController,
+			"Machine %v has no controller owner, skipping remediation",
+			t.string(),
+		)
 		glog.Infof("%s: no controller owner, skipping remediation", t.string())
 		return nil
 	}

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -213,7 +213,7 @@ func TestReconcile(t *testing.T) {
 	nodeAnnotatedWithNoExistentMachine.Annotations[machineAnnotationKey] = "annotatedWithNoExistentMachine"
 
 	// node annotated with machine without owner reference
-	nodeAnnotatedWithMachineWithoutOwnerReference := maotesting.NewNode("annotatedWithMachineWithoutOwnerReference", true)
+	nodeAnnotatedWithMachineWithoutOwnerReference := maotesting.NewNode("annotatedWithMachineWithoutOwnerReference", false)
 	nodeAnnotatedWithMachineWithoutOwnerReference.Annotations = map[string]string{
 		machineAnnotationKey: fmt.Sprintf("%s/%s", namespace, "machineWithoutOwnerController"),
 	}
@@ -325,7 +325,7 @@ func TestReconcile(t *testing.T) {
 				result: reconcile.Result{},
 				error:  false,
 			},
-			expectedEvents: []string{},
+			expectedEvents: []string{EventSkippedNoController},
 		},
 		{
 			testCase: "machine no noderef",


### PR DESCRIPTION
To improve the user experience of the MHC, we should always emit an event when we are skipping remediation.

We used to have this for master Machines, though this was removed when we migrated to the controller owner check (#543). This restores the behaviour, but with a new event that is more agnostic of the type of Machine.