### PR TITLE
Bug 1855839: Ensure Progressing condition is stable when no updates to apply

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -58,20 +58,21 @@ func (optr *Operator) statusProgressing() error {
 		return err
 	}
 
-	var message string
+	var message, reason string
 	if !reflect.DeepEqual(desiredVersions, currentVersions) {
 		glog.V(2).Info("Syncing status: progressing")
 		message = fmt.Sprintf("Progressing towards %s", optr.printOperandVersions())
 		optr.eventRecorder.Eventf(co, v1.EventTypeNormal, "Status upgrade", message)
 		isProgressing = osconfigv1.ConditionTrue
+		reason = string(ReasonSyncing)
 	} else {
 		glog.V(2).Info("Syncing status: re-syncing")
-		message = fmt.Sprintf("Running resync for %s", optr.printOperandVersions())
+		reason = string(ReasonAsExpected)
 		isProgressing = osconfigv1.ConditionFalse
 	}
 
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, isProgressing, string(ReasonSyncing), message),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, isProgressing, reason, message),
 		operatorUpgradeable,
 	}
 


### PR DESCRIPTION
The progressing condition is intedned to imply that a new version of the operator's resources are being rolled out. Currently we set it to resync on every reconcile which leads to constant updates and the value of the condiiton being unstable.

This change ensures that the status is stable when a version upgrade is not progressing and that we don't update the status every time we sync.