### PR TITLE
BUG 1875598: Ensure the Virtual Machine provider state is set to Unknown when Failed

### DIFF
--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -326,10 +326,12 @@ func TestReconcileRequest(t *testing.T) {
 
 func TestSetPhase(t *testing.T) {
 	testCases := []struct {
-		name         string
-		phase        string
-		errorMessage string
-		annotations  map[string]string
+		name                   string
+		phase                  string
+		errorMessage           string
+		annotations            map[string]string
+		existingProviderStatus string
+		expectedProviderStatus string
 	}{
 		{
 			name:         "when updating the phase to Running",
@@ -344,6 +346,36 @@ func TestSetPhase(t *testing.T) {
 			annotations: map[string]string{
 				MachineInstanceStateAnnotationName: unknownInstanceState,
 			},
+		},
+		{
+			name:         "when updating the phase to Failed with instanceState Set",
+			phase:        phaseFailed,
+			errorMessage: "test",
+			annotations: map[string]string{
+				MachineInstanceStateAnnotationName: unknownInstanceState,
+			},
+			existingProviderStatus: `{"instanceState":"Running"}`,
+			expectedProviderStatus: `{"instanceState":"Unknown"}`,
+		},
+		{
+			name:         "when updating the phase to Failed with vmState Set",
+			phase:        phaseFailed,
+			errorMessage: "test",
+			annotations: map[string]string{
+				MachineInstanceStateAnnotationName: unknownInstanceState,
+			},
+			existingProviderStatus: `{"vmState":"Running"}`,
+			expectedProviderStatus: `{"vmState":"Unknown"}`,
+		},
+		{
+			name:         "when updating the phase to Failed with state Set",
+			phase:        phaseFailed,
+			errorMessage: "test",
+			annotations: map[string]string{
+				MachineInstanceStateAnnotationName: unknownInstanceState,
+			},
+			existingProviderStatus: `{"state":"Running"}`,
+			expectedProviderStatus: `{"state":"Running"}`,
 		},
 	}
 
@@ -374,9 +406,17 @@ func TestSetPhase(t *testing.T) {
 					GenerateName: name,
 					Namespace:    namespace.Name,
 				},
-				Status: machinev1.MachineStatus{},
 			}
+
 			g.Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+
+			if tc.existingProviderStatus != "" {
+				machine.Status.ProviderStatus = &runtime.RawExtension{
+					Raw: []byte(tc.existingProviderStatus),
+				}
+			}
+
+			g.Expect(k8sClient.Status().Update(ctx, machine)).To(Succeed())
 
 			namespacedName := types.NamespacedName{
 				Namespace: machine.Namespace,
@@ -422,6 +462,11 @@ func TestSetPhase(t *testing.T) {
 
 			g.Expect(got.GetAnnotations()).To(Equal(tc.annotations))
 			g.Expect(machine.GetAnnotations()).To(Equal(tc.annotations))
+
+			if tc.existingProviderStatus != "" {
+				g.Expect(got.Status.ProviderStatus).ToNot(BeNil())
+				g.Expect(got.Status.ProviderStatus.Raw).To(BeEquivalentTo(tc.expectedProviderStatus))
+			}
 		})
 	}
 }

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -409,6 +409,7 @@ func TestSetPhase(t *testing.T) {
 			}
 
 			g.Expect(k8sClient.Create(ctx, machine)).To(Succeed())
+			defer k8sClient.Delete(ctx, machine)
 
 			if tc.existingProviderStatus != "" {
 				machine.Status.ProviderStatus = &runtime.RawExtension{


### PR DESCRIPTION
This ensures that if the Machine goes into a Failed state, and the provider has already set the providerStatus to include an instanceState or vmState, that we override this with the value `Unknown`.

This ensures consistency between the providerStatus and the instance state annotation.

Ref:
- AWS: https://github.com/openshift/cluster-api-provider-aws/blob/9d3a7be556787c235a964fd72fdaec31af7a16ad/pkg/apis/awsprovider/v1beta1/awsproviderstatus_types.go#L36
- Azure: https://github.com/openshift/cluster-api-provider-azure/blob/72169c58a81f33ac006e20c63f643c9d8bf16771/pkg/apis/azureprovider/v1beta1/azuremachineproviderstatus_types.go#L38
- GCP: https://github.com/openshift/cluster-api-provider-gcp/blob/9056dbc8c9b9725fe13e2268ac8b0699c057d315/pkg/apis/gcpprovider/v1beta1/gcpmachineproviderstatus_types.go#L24
- vSphere: https://github.com/openshift/machine-api-operator/blob/184fb7320af9cd1c9d4660dd15ed2038237a58c5/pkg/apis/vsphereprovider/v1beta1/vsphereproviderstatus_types.go#L64

The OpenStack and Baremetal providers do not have an equivalent field.