### PR TITLE
Bug 1876680: Reduce influence of webhooks and convert some errors to non-fatal

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -3,6 +3,7 @@ package v1beta1
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -775,10 +776,11 @@ func TestMachineUpdate(t *testing.T) {
 func TestValidateAWSProviderSpec(t *testing.T) {
 
 	testCases := []struct {
-		testCase      string
-		modifySpec    func(*aws.AWSMachineProviderConfig)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		modifySpec       func(*aws.AWSMachineProviderConfig)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase: "with no ami values it fails",
@@ -901,7 +903,7 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -914,6 +916,10 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 				if err.Error() != tc.expectedError {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
+			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
 			}
 		})
 	}
@@ -929,6 +935,7 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 		expectedProviderSpec *aws.AWSMachineProviderConfig
 		expectedError        string
 		expectedOk           bool
+		expectedWarnings     []string
 	}{
 		{
 			testCase: "it defaults Region, InstanceType, IAMInstanceProfile, UserDataSecret, CredentialsSecret, SecurityGroups and Subnet when an AvailabilityZone is set",
@@ -1033,7 +1040,7 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -1055,6 +1062,10 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -1062,10 +1073,11 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 func TestValidateAzureProviderSpec(t *testing.T) {
 
 	testCases := []struct {
-		testCase      string
-		modifySpec    func(providerSpec *azure.AzureMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		modifySpec       func(providerSpec *azure.AzureMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase: "with no location it fails",
@@ -1335,7 +1347,7 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -1349,6 +1361,10 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -1357,11 +1373,12 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 
 	clusterID := "clusterID"
 	testCases := []struct {
-		testCase      string
-		providerSpec  *azure.AzureMachineProviderSpec
-		modifyDefault func(*azure.AzureMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		providerSpec     *azure.AzureMachineProviderSpec
+		modifyDefault    func(*azure.AzureMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase:      "it defaults defaultable fields",
@@ -1488,7 +1505,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -1510,6 +1527,10 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -1517,10 +1538,11 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 func TestValidateGCPProviderSpec(t *testing.T) {
 
 	testCases := []struct {
-		testCase      string
-		modifySpec    func(*gcp.GCPMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		modifySpec       func(*gcp.GCPMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase: "with no region",
@@ -1757,7 +1779,7 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -1771,6 +1793,10 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -1780,11 +1806,12 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 	clusterID := "clusterID"
 	projectID := "projectID"
 	testCases := []struct {
-		testCase      string
-		providerSpec  *gcp.GCPMachineProviderSpec
-		modifyDefault func(*gcp.GCPMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		providerSpec     *gcp.GCPMachineProviderSpec
+		modifyDefault    func(*gcp.GCPMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase:      "it defaults defaultable fields",
@@ -1866,7 +1893,7 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -1888,6 +1915,10 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -1895,10 +1926,11 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 func TestValidateVSphereProviderSpec(t *testing.T) {
 
 	testCases := []struct {
-		testCase      string
-		modifySpec    func(*vsphere.VSphereMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		modifySpec       func(*vsphere.VSphereMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase: "with no template provided",
@@ -2071,7 +2103,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -2085,6 +2117,10 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
 			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
+			}
 		})
 	}
 }
@@ -2093,11 +2129,12 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 
 	clusterID := "clusterID"
 	testCases := []struct {
-		testCase      string
-		providerSpec  *vsphere.VSphereMachineProviderSpec
-		modifyDefault func(*vsphere.VSphereMachineProviderSpec)
-		expectedError string
-		expectedOk    bool
+		testCase         string
+		providerSpec     *vsphere.VSphereMachineProviderSpec
+		modifyDefault    func(*vsphere.VSphereMachineProviderSpec)
+		expectedError    string
+		expectedOk       bool
+		expectedWarnings []string
 	}{
 		{
 			testCase:      "it defaults defaultable fields",
@@ -2134,7 +2171,7 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 			}
 			m.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: rawBytes}
 
-			ok, err := h.webhookOperations(m, h.clusterID)
+			ok, warnings, err := h.webhookOperations(m, h.clusterID)
 			if ok != tc.expectedOk {
 				t.Errorf("expected: %v, got: %v", tc.expectedOk, ok)
 			}
@@ -2155,6 +2192,10 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 				if err.Error() != tc.expectedError {
 					t.Errorf("expected: %q, got: %q", tc.expectedError, err.Error())
 				}
+			}
+
+			if !reflect.DeepEqual(warnings, tc.expectedWarnings) {
+				t.Errorf("expected: %q, got: %q", tc.expectedWarnings, warnings)
 			}
 		})
 	}

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -1762,8 +1762,9 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					Server: "server",
 				}
 			},
-			expectedOk:    false,
-			expectedError: "providerSpec.workspace.datacenter: Required value: datacenter must be provided",
+			expectedOk:       true,
+			expectedError:    "",
+			expectedWarnings: []string{"providerSpec.workspace.datacenter: datacenter is unset: if more than one datacenter is present, VMs cannot be created"},
 		},
 		{
 			testCase: "with a workspace folder outside of the current datacenter",
@@ -1807,24 +1808,27 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
 				p.NumCPUs = 1
 			},
-			expectedOk:    false,
-			expectedError: "providerSpec.numCPUs: Invalid value: 1: numCPUs is below minimum value (2)",
+			expectedOk:       true,
+			expectedError:    "",
+			expectedWarnings: []string{"providerSpec.numCPUs: 1 is less than the minimum value (2): the minimum value will be used instead"},
 		},
 		{
 			testCase: "with too little memory provided",
 			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
 				p.MemoryMiB = 1024
 			},
-			expectedOk:    false,
-			expectedError: "providerSpec.memoryMiB: Invalid value: 1024: memoryMiB is below minimum value (2048)",
+			expectedOk:       true,
+			expectedError:    "",
+			expectedWarnings: []string{"providerSpec.memoryMiB: 1024 is less than the recommended minimum value (2048): nodes may not boot correctly"},
 		},
 		{
 			testCase: "with too little disk size provided",
 			modifySpec: func(p *vsphere.VSphereMachineProviderSpec) {
 				p.DiskGiB = 1
 			},
-			expectedOk:    false,
-			expectedError: "providerSpec.diskGiB: Invalid value: 1: diskGiB is below minimum value (120)",
+			expectedOk:       true,
+			expectedError:    "",
+			expectedWarnings: []string{"providerSpec.diskGiB: 1 is less than the recommended minimum (120): nodes may fail to start if disk size is too low"},
 		},
 		{
 			testCase: "with no user data secret provided",
@@ -1888,6 +1892,9 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: "name",
 				},
+				NumCPUs:   minVSphereCPU,
+				MemoryMiB: minVSphereMemoryMiB,
+				DiskGiB:   minVSphereDiskGiB,
 			}
 			if tc.modifySpec != nil {
 				tc.modifySpec(providerSpec)
@@ -1953,9 +1960,6 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 				CredentialsSecret: &corev1.LocalObjectReference{
 					Name: defaultVSphereCredentialsSecret,
 				},
-				NumCPUs:   minVSphereCPU,
-				MemoryMiB: minVSphereMemoryMiB,
-				DiskGiB:   minVSphereDiskGiB,
 			}
 			if tc.modifyDefault != nil {
 				tc.modifyDefault(defaultProviderSpec)

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -300,7 +300,6 @@ func TestMachineSetUpdate(t *testing.T) {
 	}
 
 	gcpClusterID := "gcp-cluster"
-	gcpProjectID := "gcp-project-id"
 	defaultGCPProviderSpec := &gcp.GCPMachineProviderSpec{
 		Region:      "region",
 		Zone:        "region-zone",
@@ -320,8 +319,7 @@ func TestMachineSetUpdate(t *testing.T) {
 				Image:      defaultGCPDiskImage,
 			},
 		},
-		ServiceAccounts: defaultGCPServiceAccounts(gcpClusterID, gcpProjectID),
-		Tags:            defaultGCPTags(gcpClusterID),
+		Tags: defaultGCPTags(gcpClusterID),
 		UserDataSecret: &corev1.LocalObjectReference{
 			Name: defaultUserDataSecret,
 		},
@@ -567,7 +565,7 @@ func TestMachineSetUpdate(t *testing.T) {
 			expectedError: "providerSpec.disks: Required value: at least 1 disk is required",
 		},
 		{
-			name:         "with a GCP ProviderSpec, removing the service accounts",
+			name:         "with a GCP ProviderSpec, removing the network interfaces",
 			platformType: osconfigv1.GCPPlatformType,
 			clusterID:    gcpClusterID,
 			baseProviderSpecValue: &runtime.RawExtension{
@@ -575,12 +573,12 @@ func TestMachineSetUpdate(t *testing.T) {
 			},
 			updatedProviderSpecValue: func() *runtime.RawExtension {
 				object := defaultGCPProviderSpec.DeepCopy()
-				object.ServiceAccounts = nil
+				object.NetworkInterfaces = nil
 				return &runtime.RawExtension{
 					Object: object,
 				}
 			},
-			expectedError: "providerSpec.serviceAccounts: Invalid value: \"0 service accounts supplied\": exactly 1 service account must be supplied",
+			expectedError: "providerSpec.networkInterfaces: Required value: at least 1 network interface is required",
 		},
 		{
 			name:         "with a valid VSphere ProviderSpec",
@@ -659,9 +657,6 @@ func TestMachineSetUpdate(t *testing.T) {
 
 			platformStatus := &osconfigv1.PlatformStatus{
 				Type: tc.platformType,
-				GCP: &osconfigv1.GCPPlatformStatus{
-					ProjectID: gcpProjectID,
-				},
 				AWS: &osconfigv1.AWSPlatformStatus{
 					Region: awsRegion,
 				},

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -93,7 +93,7 @@ func TestMachineSetCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &azure.AzureMachineProviderSpec{},
 			},
-			expectedError: "[providerSpec.location: Required value: location should be set to one of the supported Azure regions, providerSpec.osDisk.diskSizeGB: Invalid value: 0: diskSizeGB must be greater than zero]",
+			expectedError: "providerSpec.osDisk.diskSizeGB: Invalid value: 0: diskSizeGB must be greater than zero and less than 32768",
 		},
 		{
 			name:         "with Azure and a location and disk size set",


### PR DESCRIPTION
This should allow our validation/defaulting webhooks to respond with some of their validations as warnings rather than errors.

The webhooks have been provided opinionated defaults and requiring these in validation. This may cause issues for existing users and as such, we need to reel back on these changes and ensure that we only error when a value is missing that would cause a Machine to not be created successfully.

This PR should reduce the opinionation and ensure that we don't break any existing installations