### PR TITLE
Bug 1875939: vsphere - cloning a Windows 2019 (1909) template fails with Invalid operation for device '0'.

### DIFF
--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -260,6 +260,7 @@ func TestMachineEvents(t *testing.T) {
 				UserDataSecret: &corev1.LocalObjectReference{
 					Name: userDataSecretName,
 				},
+				DiskGiB: 1,
 			})
 			gs.Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -705,7 +705,7 @@ func taskIsFinished(task *mo.Task) (bool, error) {
 	case types.TaskInfoStateSuccess:
 		return true, nil
 	case types.TaskInfoStateError:
-		return true, nil
+		return true, errors.New(task.Info.Error.LocalizedMessage)
 	default:
 		return false, fmt.Errorf("task: %v, unknown state %v", task.Reference().Value, task.Info.State)
 	}

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	vspherev1 "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
+	machineapierros "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/openshift/machine-api-operator/pkg/controller/vsphere/session"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
@@ -616,7 +617,13 @@ func getDiskSpec(s *machineScope, devices object.VirtualDeviceList) (types.BaseV
 	}
 
 	disk := disks[0].(*types.VirtualDisk)
-	disk.CapacityInKB = int64(s.providerSpec.DiskGiB) * 1024 * 1024
+	cloneCapacityKB := int64(s.providerSpec.DiskGiB) * 1024 * 1024
+	if disk.CapacityInKB > cloneCapacityKB {
+		return nil, machineapierros.InvalidMachineConfiguration(
+			"can't resize template disk down, initial capacity is larger: %dKiB > %dKiB",
+			disk.CapacityInKB, cloneCapacityKB)
+	}
+	disk.CapacityInKB = cloneCapacityKB
 
 	return &types.VirtualDeviceConfigSpec{
 		Operation: types.VirtualDeviceConfigSpecOperationEdit,


### PR DESCRIPTION
Add check for template disk size with tests.

Prevents user from hitting an undescriptive error message `invalid operation for device '0'`,
while attempting to create a machine from a template with a specified disk size larger
then the `machine.spec.diskGB` is requiring.