### PR TITLE
bug 1878129: add CSRs for oc adm inspect

### DIFF
--- a/install/0000_30_machine-api-operator_12_clusteroperator.yaml
+++ b/install/0000_30_machine-api-operator_12_clusteroperator.yaml
@@ -9,3 +9,6 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: "certificates.k8s.io"
+      resource: "certificatesigningrequests"

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -205,6 +205,14 @@ func (optr *Operator) relatedObjects() []osconfigv1.ObjectReference {
 			Name:      "",
 			Namespace: optr.namespace,
 		},
+		{
+			// the machine-api-operator runs a machine-approver which approvers CSRs originated by nodes.  Some failure modes
+			// we have debugged result from these not being approved.  Gather the information about them (non-sensitive)
+			// for debuggging
+			Group: "certificates.k8s.io",
+			Resource: "certificatesigningrequests",
+		},
+
 	}
 }
 


### PR DESCRIPTION
The machine-api runs an approver for CSRs from nodes.  Some failure modes results in the CSRs not being approved.  This change ensures CSRs are collected for determining whether the CSR itself is malformed or whether the approver is malfunctioning.