### PR TITLE
Machine: Set ErrorReason when entering Failed phase

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -197,7 +197,7 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	if !m.ObjectMeta.DeletionTimestamp.IsZero() {
-		if err := r.setPhase(m, phaseDeleting, ""); err != nil {
+		if err := r.setPhase(m, phaseDeleting, nil); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -288,34 +288,34 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 
 		if !machineHasNode(m) {
 			// Requeue until we reach running phase
-			if err := r.setPhase(m, phaseProvisioned, ""); err != nil {
+			if err := r.setPhase(m, phaseProvisioned, nil); err != nil {
 				return reconcile.Result{}, err
 			}
 			klog.Infof("%v: has no node yet, requeuing", machineName)
 			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 
-		return reconcile.Result{}, r.setPhase(m, phaseRunning, "")
+		return reconcile.Result{}, r.setPhase(m, phaseRunning, nil)
 	}
 
 	// Instance does not exist but the machine has been given a providerID/address.
 	// This can only be reached if an instance was deleted outside the machine API
 	if machineIsProvisioned(m) {
-		if err := r.setPhase(m, phaseFailed, "Can't find created instance."); err != nil {
+		if err := r.setPhase(m, phaseFailed, errors.New("Can't find created instance.")); err != nil {
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil
 	}
 
 	// Machine resource created and instance does not exist yet.
-	if err := r.setPhase(m, phaseProvisioning, ""); err != nil {
+	if err := r.setPhase(m, phaseProvisioning, nil); err != nil {
 		return reconcile.Result{}, err
 	}
 	klog.Infof("%v: reconciling machine triggers idempotent create", machineName)
 	if err := r.actuator.Create(ctx, m); err != nil {
 		klog.Warningf("%v: failed to create machine: %v", machineName, err)
 		if isInvalidMachineConfigurationError(err) {
-			if err := r.setPhase(m, phaseFailed, err.Error()); err != nil {
+			if err := r.setPhase(m, phaseFailed, err); err != nil {
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
@@ -420,7 +420,7 @@ func isInvalidMachineConfigurationError(err error) bool {
 	return false
 }
 
-func (r *ReconcileMachine) setPhase(machine *machinev1.Machine, phase string, errorMessage string) error {
+func (r *ReconcileMachine) setPhase(machine *machinev1.Machine, phase string, failureCause error) error {
 	if stringPointerDeref(machine.Status.Phase) != phase {
 		klog.V(3).Infof("%v: going into phase %q", machine.GetName(), phase)
 		// A call to Patch will mutate our local copy of the machine to match what is stored in the API.
@@ -446,11 +446,19 @@ func (r *ReconcileMachine) setPhase(machine *machinev1.Machine, phase string, er
 		}
 
 		machine.Status.Phase = &phase
+		machine.Status.ErrorReason = nil
 		machine.Status.ErrorMessage = nil
 		now := metav1.Now()
 		machine.Status.LastUpdated = &now
-		if phase == phaseFailed && errorMessage != "" {
-			machine.Status.ErrorMessage = &errorMessage
+		if phase == phaseFailed && failureCause != nil {
+			var machineError *MachineError
+			if errors.As(failureCause, &machineError) {
+				machine.Status.ErrorReason = &machineError.Reason
+				machine.Status.ErrorMessage = &machineError.Message
+			} else {
+				errorMessage := failureCause.Error()
+				machine.Status.ErrorMessage = &errorMessage
+			}
 		}
 		if err := r.Client.Status().Patch(context.Background(), machine, baseToPatch); err != nil {
 			klog.Errorf("Failed to update machine status %q: %v", machine.GetName(), err)


### PR DESCRIPTION
When an error returned by the actuator causing the Machine to enter the
Failed phase is of a known type, record the type in the ErrorReason
field.

In the upstream cluster-api, permanent failures were signalled by the
actuator setting the ErrorMessage and ErrorReason fields. A separate
controller reads these fields and updates the Phase.

In the OpenShift implementation
(176084ee02b546e1750a70d392190b7134694dac) this is signalled by the
actuator returning a MachineError, which contains the message and the
reason. However, the Machine controller was ignoring the reason so it
was never set.