### PR TITLE
Bug 1880110: Vsphere: fix clone task log

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -605,9 +605,9 @@ func clone(s *machineScope) (string, error) {
 		})
 		return "", err
 	}
-
-	klog.V(3).Infof("%v: running task: %+v", s.machine.GetName(), s.providerStatus.TaskRef)
-	return task.Reference().Value, nil
+	taskVal := task.Reference().Value
+	klog.V(3).Infof("%v: running task: %+v", s.machine.GetName(), taskVal)
+	return taskVal, nil
 }
 
 func getDiskSpec(s *machineScope, devices object.VirtualDeviceList) (types.BaseVirtualDeviceConfigSpec, error) {


### PR DESCRIPTION
Current log line does not display a task id because
it is not populated in status at this point.

This uses correct task id.