### PR TITLE
Bug 1881703: Revert "Update default user data to be worker-user-data-managed"

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -72,7 +72,7 @@ const (
 	defaultWebhookServiceNamespace  = "openshift-machine-api"
 	defaultWebhookServicePort       = 443
 
-	defaultUserDataSecret  = "worker-user-data-managed"
+	defaultUserDataSecret  = "worker-user-data"
 	defaultSecretNamespace = "openshift-machine-api"
 
 	// AWS Defaults


### PR DESCRIPTION
This reverts commit 765b29ba00be5db02673bbb5e22e0229a94c43ff following findings in https://docs.google.com/document/d/1TnnfPgFim-e895MD0msOGN9tyPBk3CM8cmSewFmgzDQ/edit# and https://bugzilla.redhat.com/show_bug.cgi?id=1881703