### PR TITLE
Add Kubevirt provider

### DIFF
--- a/hack/push-updates.sh
+++ b/hack/push-updates.sh
@@ -48,6 +48,7 @@ cluster-api-provider-azure
 cluster-api-provider-baremetal
 cluster-api-provider-gcp
 cluster-api-provider-openstack
+cluster-api-provider-kubevirt
 "
 TITLE=""
 SHA=""

--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -151,3 +151,18 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: VSphereProviderSpec
 ---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-machine-api-kubevirt
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    namespace: openshift-machine-api
+    name: kubevirt-credentials
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: KubevirtProviderSpec
+---

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -18,6 +18,7 @@ data:
       "clusterAPIControllerAzure": "registry.svc.ci.openshift.org/openshift:azure-machine-controllers",
       "clusterAPIControllerGCP": "registry.svc.ci.openshift.org/openshift:gcp-machine-controllers",
       "clusterAPIControllerOvirt": "registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers",
+      "clusterAPIControllerKubevirt": "registry.svc.ci.openshift.org/openshift:kubevirt-machine-controllers",
       "clusterAPIControllerVSphere": "registry.svc.ci.openshift.org/openshift:machine-api-operator",
       "baremetalOperator": "registry.svc.ci.openshift.org/openshift:baremetal-operator",
       "baremetalIronic": "registry.svc.ci.openshift.org/openshift:ironic",

--- a/install/image-references
+++ b/install/image-references
@@ -62,3 +62,7 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers
+  - name: kubevirt-machine-controllers
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:kubevirt-machine-controllers

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -55,6 +55,7 @@ type Images struct {
 	ClusterAPIControllerGCP       string `json:"clusterAPIControllerGCP"`
 	ClusterAPIControllerOvirt     string `json:"clusterAPIControllerOvirt"`
 	ClusterAPIControllerVSphere   string `json:"clusterAPIControllerVSphere"`
+	ClusterAPIControllerKubevirt  string `json:"clusterAPIControllerKubevirt"`
 	KubeRBACProxy                 string `json:"kubeRBACProxy"`
 	// Images required for the metal3 pod
 	BaremetalOperator            string `json:"baremetalOperator"`
@@ -103,6 +104,8 @@ func getProviderControllerFromImages(platform configv1.PlatformType, images Imag
 		return images.ClusterAPIControllerOvirt, nil
 	case configv1.VSpherePlatformType:
 		return images.ClusterAPIControllerVSphere, nil
+	case configv1.KubevirtPlatformType:
+		return images.ClusterAPIControllerKubevirt, nil
 	case kubemarkPlatform:
 		return clusterAPIControllerKubemark, nil
 	default:

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -24,6 +24,7 @@ var (
 	expectedIronicStaticIpManager     = "quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0"
 	expectedOvirtImage                = "quay.io/openshift/origin-ovirt-machine-controllers"
 	expectedVSphereImage              = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
+	expectedKubevirtImage             = "quay.io/openshift/origin-kubevirt-machine-controllers"
 )
 
 func TestGetProviderFromInfrastructure(t *testing.T) {
@@ -142,6 +143,9 @@ func TestGetImagesFromJSONFile(t *testing.T) {
 	if img.ClusterAPIControllerVSphere != expectedVSphereImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedVSphereImage, img.ClusterAPIControllerVSphere)
 	}
+	if img.ClusterAPIControllerKubevirt != expectedKubevirtImage {
+		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedKubevirtImage, img.ClusterAPIControllerKubevirt)
+	}
 }
 
 func TestGetProviderControllerFromImages(t *testing.T) {
@@ -187,6 +191,10 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 		{
 			provider:      configv1.OvirtPlatformType,
 			expectedImage: expectedOvirtImage,
+		},
+		{
+			provider:      configv1.KubevirtPlatformType,
+			expectedImage: expectedKubevirtImage,
 		},
 	}
 

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -8,6 +8,7 @@
   "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0",
   "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
   "clusterAPIControllerVSphere": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
+  "clusterAPIControllerKubevirt": "quay.io/openshift/origin-kubevirt-machine-controllers",
   "baremetalOperator": "quay.io/openshift/origin-baremetal-operator:v4.2.0",
   "baremetalIronic": "quay.io/openshift/origin-ironic:v4.2.0",
   "baremetalIronicInspector": "quay.io/openshift/origin-ironic-inspector:v4.2.0",


### PR DESCRIPTION
This PR is part of task done to add KubeVirt platform as infra provider for Openshift.

The change introduced in this PR purpose is to provide a way to install Openshift on KubeVirt infrastructure

For more information, please find the enhancement PR:
openshift/enhancements#417

Related PRs/changes done as part of this task:

1. Created openshift/cluster-api-provider-kubevirt repository, hosts an implementation of a provider for KubeVirt for the OpenShift machine-api: https://github.com/openshift/cluster-api-provider-kubevirt
Also adding this project's image to openshift is in progress
2. openshift/installer: https://github.com/openshift/installer/pull/4350
3. openshift/cloud-credential-operator: openshift/cloud-credential-operator#260
4. openshift/machine-config-operator: openshift/machine-config-operator#2098
5. openshift/api: openshift/api#734

Additional job is done to have tests and CI coverage (work in progress in github.com/openshift/release repository)