### PR TITLE
add modular document templates

### DIFF
--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,12 @@
+# Documentation Templates
+
+This directory contains templates for creating new documentation. These
+templates are inspired by the
+[Modular Documentation Project](https://github.com/redhat-documentation/modular-docs).
+There are templates for assemblies, concepts, procedures, and references.
+
+To begin a new document, choose an appropriate template, copy the template
+to your new file location, and begin editing. For more information about which
+template to use, please see the templates themselves and the modular documentation
+project's advice on
+[Writing Modular Documentation](https://redhat-documentation.github.io/modular-docs/#writing-mod-docs).

--- a/docs/templates/TEMPLATE_ASSEMBLY_a-collection-of-modules.md
+++ b/docs/templates/TEMPLATE_ASSEMBLY_a-collection-of-modules.md
@@ -1,0 +1,27 @@
+# A collection of modules
+
+{% comment %}
+If the assembly covers a task, start the title with a verb in the gerund form, such as Creating or Configuring.
+{% endcomment %}
+
+This paragraph is the assembly introduction. It explains what the user will accomplish by working through the modules in the assembly and sets the context for the user story the assembly is based on. Can include more than one paragraph. Consider using the information from the user story.
+
+## Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this assembly.
+* You can also link to other modules or assemblies the user must follow before starting this assembly.
+* Delete the section title and bullets if the assembly has no prerequisites.
+
+{% comment %}
+The following include statements pull in the module files that comprise the assembly. Include any combination of concept, procedure, or reference modules required to cover the user story. You can also include other assemblies.
+{% endcomment %}
+
+{% include_relative TEMPLATE_CONCEPT_concept_explanation.md %}
+
+{% include relative TEMPLATE_PROCEDURE_doing_one_procedure.md %}
+
+## Additional resources (or Next steps)
+
+* A bulleted list of links to other material closely related to the contents of the assembly, including xref links to other assemblies in your collection.
+* For more details on writing assemblies, see the [Modular Documentation Reference Guide](https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide).
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in [Modular Documentation Reference Guide](https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide).

--- a/docs/templates/TEMPLATE_CONCEPT_concept-explanation.md
+++ b/docs/templates/TEMPLATE_CONCEPT_concept-explanation.md
@@ -1,0 +1,22 @@
+# Concept explanation
+
+{% comment %}
+In the title of concept modules, include nouns or noun phrases that are used in the body text. This helps readers and search engines find the information quickly.
+Do not start the title of concept modules with a verb.
+{% endcomment %}
+
+A short introductory paragraph is required for the concept module.
+It will provide an overview of the module.
+
+The contents of a concept module give the user descriptions and explanations needed to understand and use a product.
+
+* Look at nouns and noun phrases in related procedure modules and assemblies to find the concepts to explain to users.
+* Explain only things that are visible to users. Even if a concept is interesting, it probably does not require explanation if it is not visible to users.
+* Do not include any instructions to perform an action, such as executing a command. Action items belong in procedure modules.
+
+## Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the concept module.
+* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
+* For more details on writing concept modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in [Modular Documentation Reference Guide](https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide).

--- a/docs/templates/TEMPLATE_PROCEDURE_doing-one-procedure.md
+++ b/docs/templates/TEMPLATE_PROCEDURE_doing-one-procedure.md
@@ -1,0 +1,32 @@
+# Doing one procedure
+
+{% comment %}
+// Start the title of a procedure module with a verb, such as Creating or Create.
+{% endcomment %}
+
+This paragraph is the procedure module introduction: a short description of the procedure.
+
+## Prerequisites
+
+* A bulleted list of conditions that must be satisfied before the user starts following this module.
+* You can also link to other modules or assemblies the user must follow before starting this module.
+* Delete the section title and bullets if the module has no prerequisites.
+
+## .Procedure
+
+. Start each step with an active verb.
+
+. Include one command or action per step.
+
+. Use an unnumbered bullet (*) if the procedure includes only one step.
+
+## Verification steps
+
+(Optional) Provide the user with verification method(s) for the procedure, such as expected output or commands that can be used to check for success or failure.
+
+## Additional resources
+
+* A bulleted list of links to other material closely related to the contents of the procedure module.
+* Currently, modules cannot include xrefs, so you cannot include links to other content in your collection. If you need to link to another assembly, add the xref to the assembly that includes this module.
+* For more details on writing procedure modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles. For tips, see _Anchor Names and File Names_ in [Modular Documentation Reference Guide](https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide).

--- a/docs/templates/TEMPLATE_REFERENCE_reference-material.md
+++ b/docs/templates/TEMPLATE_REFERENCE_reference-material.md
@@ -1,0 +1,31 @@
+# Reference material
+
+{% comment %}
+In the title of a reference module, include nouns that are used in the body text. For example, "Keyboard shortcuts for ___" or "Command options for ___." This helps readers and search engines find the information quickly.
+{% endcomment %}
+
+A short introductory paragraph is required for the reference module.
+It will provide an overview of the module.
+
+A reference module provides data that users might want to look up, but do not need to remember.
+It has a very strict structure, often in the form of a list or a table.
+A well-organized reference module enables users to scan it quickly to find the details they want.
+AsciiDoc markup to consider for reference data:
+
+* For more details on writing reference modules, see the link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+* Use a consistent system for file names, IDs, and titles.
+For tips, see _Anchor Names and File Names_ in link:https://github.com/redhat-documentation/modular-docs#modular-documentation-reference-guide[Modular Documentation Reference Guide].
+
+**Labeled list**
+
+* **Term 1**
+  Definition
+* **Term 2**
+  Definition
+
+**Table**
+
+|Column 1 | Column 2 | Column 3 |
+|---------|----------|----------|
+|Row 1, column 1 | Row 1, column 2 |Row 1, column 3 |
+|Row 2, column 1 | Row 2, column 2 | Row 2, column 3 |


### PR DESCRIPTION
This change add markdown documents to be used as templates when creating
new docs. It also includes a readme file with a brief description of
usage and links to external resources. It's worth noting that although
these templates are in markdown format, they contain some liquid[0] and
jekyll[1] references which will be used with a static content generator.

[0] https://shopify.github.io/liquid/
[1] https://jekyllrb.com/