### PR TITLE
Bug 1896704: Inject cluster-wide proxy configuration in to machine-api-controller deployment

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -129,6 +129,7 @@ func startControllers(ctx *ControllerContext) {
 		ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 		ctx.KubeNamespacedInformerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations(),
 		ctx.KubeNamespacedInformerFactory.Admissionregistration().V1().MutatingWebhookConfigurations(),
+		ctx.ConfigInformerFactory.Config().V1().Proxies(),
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.OpenshiftClientOrDie(componentName),
 		ctx.ClientBuilder.DynamicClientOrDie(componentName),

--- a/docs/user/cluster-wide-proxy.md
+++ b/docs/user/cluster-wide-proxy.md
@@ -1,0 +1,10 @@
+# Overview
+
+The [cluster-wide proxy](https://docs.openshift.com/container-platform/4.6/networking/enable-cluster-wide-proxy.html) is a configuration applied which communicates the need to perform outbound communication via an HTTP proxy.  Components are responsible for watching for changes to a `Proxy` resource named `cluster` and configuring applicable deployments to consume and honor the HTTP proxy configuration.  In some environments, such as installations in to some private networks, direct connections to external servers are not allowed and must flow through an HTTP proxy.
+
+Typically, the following environment variables are defined to communicate proxy configuration to processes:
+
+- HTTP_PROXY - The URL of the proxy server which handles HTTP requests
+- HTTPS_PROXY - The URL of the proxy server which handles HTTPS requests
+- NO_PROXY - comma-separated list of strings representing IP addresses and host names which should bypass the proxy and connect directly to the target server.  If the host name matches one of these strings, or the host is within the domain of one of these strings, transactions with that node will not be proxied. When a domain is used, it needs to start with a period. A user can specify that both www.example.com and foo.example.com should not use a proxy by setting NO_PROXY to .example.com. By including the full name you can exclude specific host names, so to make www.example.com not use a proxy but still have foo.example.com do it, set NO_PROXY to www.example.com.
+

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -325,6 +325,7 @@ rules:
     resources:
       - featuregates
       - featuregates/status
+      - proxies
     verbs:
       - get
       - list

--- a/pkg/operator/baremetal_test.go
+++ b/pkg/operator/baremetal_test.go
@@ -118,6 +118,7 @@ func newOperatorWithBaremetalConfig() *OperatorConfig {
 			"quay.io/openshift/origin-ironic-machine-os-downloader:v4.2.0",
 			"quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0",
 		},
+		&osconfigv1.Proxy{},
 	}
 }
 

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -23,6 +23,7 @@ type OperatorConfig struct {
 	TargetNamespace      string `json:"targetNamespace"`
 	Controllers          Controllers
 	BaremetalControllers BaremetalControllers
+	Proxy                *configv1.Proxy
 }
 
 type Controllers struct {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -61,6 +61,9 @@ type Operator struct {
 	daemonsetLister       appslisterv1.DaemonSetLister
 	daemonsetListerSynced cache.InformerSynced
 
+	proxyLister       configlistersv1.ProxyLister
+	proxyListerSynced cache.InformerSynced
+
 	validatingWebhookLister       admissionlisterv1.ValidatingWebhookConfigurationLister
 	validatingWebhookListerSynced cache.InformerSynced
 
@@ -89,7 +92,7 @@ func New(
 	featureGateInformer configinformersv1.FeatureGateInformer,
 	validatingWebhookInformer admissioninformersv1.ValidatingWebhookConfigurationInformer,
 	mutatingWebhookInformer admissioninformersv1.MutatingWebhookConfigurationInformer,
-
+	proxyInformer configinformersv1.ProxyInformer,
 	kubeClient kubernetes.Interface,
 	osClient osclientset.Interface,
 	dynamicClient dynamic.Interface,
@@ -130,6 +133,9 @@ func New(
 	optr.daemonsetLister = daemonsetInformer.Lister()
 	optr.daemonsetListerSynced = daemonsetInformer.Informer().HasSynced
 
+	optr.proxyLister = proxyInformer.Lister()
+	optr.proxyListerSynced = proxyInformer.Informer().HasSynced
+
 	optr.validatingWebhookLister = validatingWebhookInformer.Lister()
 	optr.validatingWebhookListerSynced = validatingWebhookInformer.Informer().HasSynced
 
@@ -155,6 +161,7 @@ func (optr *Operator) Run(workers int, stopCh <-chan struct{}) {
 		optr.validatingWebhookListerSynced,
 		optr.deployListerSynced,
 		optr.daemonsetListerSynced,
+		optr.proxyListerSynced,
 		optr.featureGateCacheSynced) {
 		klog.Error("Failed to sync caches")
 		return
@@ -358,8 +365,14 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		return nil, err
 	}
 
+	clusterWideProxy, err := optr.osClient.ConfigV1().Proxies().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	return &OperatorConfig{
 		TargetNamespace: optr.namespace,
+		Proxy:           clusterWideProxy,
 		Controllers: Controllers{
 			Provider:           providerControllerImage,
 			MachineSet:         machineAPIOperatorImage,


### PR DESCRIPTION
- What I did
Inject proxy environment variables in to the deployment for the machine-api-controller when a cluster-wide proxy is configured.

- How to verify it
1. Configure cluster-wide proxy
2. `machine-api-controller` deployment will be updated to inject HTTP_PROXY, HTTPS_PROXY, and NO_PROXY environment variables.
3. Check proxy logs to confirm requests are flowing through the proxy

- Description for changelog
Inject cluster-wide proxy configuration in to machine-api-controller deployment