### PR TITLE
vSphere: Enter Failed phase on invalid configuration

### DIFF
--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -70,7 +70,7 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 
 	user, password, err := getCredentialsSecret(params.client, params.machine.GetNamespace(), *providerSpec)
 	if err != nil {
-		return nil, fmt.Errorf("%v: error getting credentials: %v", params.machine.GetName(), err)
+		return nil, fmt.Errorf("%v: error getting credentials: %w", params.machine.GetName(), err)
 	}
 	if providerSpec.Workspace == nil {
 		return nil, fmt.Errorf("%v: no workspace provided", params.machine.GetName())

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -182,7 +182,7 @@ func getCredentialsSecret(client runtimeclient.Client, namespace string, spec ap
 		&credentialsSecret); err != nil {
 
 		if apimachineryerrors.IsNotFound(err) {
-			machineapierros.InvalidMachineConfiguration("credentials secret %v/%v not found: %v", namespace, spec.CredentialsSecret.Name, err.Error())
+			return "", "", machineapierros.InvalidMachineConfiguration("credentials secret %v/%v not found: %v", namespace, spec.CredentialsSecret.Name, err.Error())
 		}
 		return "", "", fmt.Errorf("error getting credentials secret %v/%v: %v", namespace, spec.CredentialsSecret.Name, err)
 	}

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -59,7 +59,7 @@ func newReconciler(scope *machineScope) *Reconciler {
 // create creates machine if it does not exists.
 func (r *Reconciler) create() error {
 	if err := validateMachine(*r.machine); err != nil {
-		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
+		return fmt.Errorf("%v: failed validating machine provider spec: %w", r.machine.GetName(), err)
 	}
 
 	// We only clone the VM template if we have no taskRef.
@@ -115,7 +115,7 @@ func (r *Reconciler) create() error {
 // update finds a vm and reconciles the machine resource status against it.
 func (r *Reconciler) update() error {
 	if err := validateMachine(*r.machine); err != nil {
-		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
+		return fmt.Errorf("%v: failed validating machine provider spec: %w", r.machine.GetName(), err)
 	}
 
 	if r.providerStatus.TaskRef != "" {
@@ -166,7 +166,7 @@ func (r *Reconciler) update() error {
 // exists returns true if machine exists.
 func (r *Reconciler) exists() (bool, error) {
 	if err := validateMachine(*r.machine); err != nil {
-		return false, fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
+		return false, fmt.Errorf("%v: failed validating machine provider spec: %w", r.machine.GetName(), err)
 	}
 
 	if _, err := findVM(r.machineScope); err != nil {
@@ -241,7 +241,7 @@ func (r *Reconciler) delete() error {
 			Namespace: r.machine.Namespace,
 			Reason:    err.Error(),
 		})
-		return fmt.Errorf("%v: failed to destroy vm: %v", r.machine.GetName(), err)
+		return fmt.Errorf("%v: failed to destroy vm: %w", r.machine.GetName(), err)
 	}
 
 	if err := setProviderStatus(task.Reference().Value, conditionSuccess(), r.machineScope, vm); err != nil {


### PR DESCRIPTION
[According to the enhancement proposal](https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/machine-instance-lifecycle.md#failed), Machine API providers should put the Machine into the `Failed` phase if the configuration is invalid. This was not working for the vSphere provider, due to the correct error being dropped in the error handling chain. This change ensures that the vSphere provider will behave consistently with the other providers in the event of invalid configuration.