### PR TITLE
Bug 1876469: Fix link on MachineSet Spec Metadata description

### DIFF
--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -103,7 +103,7 @@ spec:
                 description: Template is the object that describes the machine that will be created if insufficient replicas are detected.
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     properties:
                       annotations:
                         additionalProperties:

--- a/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/pkg/apis/machine/v1beta1/machineset_types.go
@@ -110,7 +110,7 @@ const (
 // MachineTemplateSpec describes the data needed to create a Machine from a template
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	ObjectMeta `json:"metadata,omitempty"`
 


### PR DESCRIPTION
Fix a broken link in the description so that `oc explain` gives users a helpful description