### PR TITLE
[OCPCLOUD-937] Remove old termination handler RBAC

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -23,6 +23,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+autoMountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -213,31 +214,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: machine-api-termination-handler
-  namespace: openshift-machine-api
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-rules:
-  - apiGroups:
-      - machine.openshift.io
-    resources:
-      - machines
-    verbs:
-      - list
-      - delete
-  - apiGroups:
-      - security.openshift.io
-    resourceNames:
-      - hostnetwork
-    resources:
-      - securitycontextconstraints
-    verbs:
-      - use
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
   name: machine-api-operator
   namespace: openshift-machine-api
   annotations:
@@ -408,23 +384,6 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
-    namespace: openshift-machine-api
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: machine-api-termination-handler
-  namespace: openshift-machine-api
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: machine-api-termination-handler
-subjects:
-  - kind: ServiceAccount
-    name: machine-api-termination-handler
     namespace: openshift-machine-api
 
 ---


### PR DESCRIPTION
Now that the termination handlers have been migrated to the conditions approach this is no longer needed.

This is a follow up to #627 and can be merged once all of the provider implementations have been moved to the new implementation.