### PR TITLE
add bound serviceaccount token to machine-controller

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -556,6 +556,21 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 				},
 			},
 		},
+		{
+			Name: "bound-sa-token",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					Sources: []corev1.VolumeProjection{
+						{
+							ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+								Audience: "openshift",
+								Path:     "token",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	volumes = append(volumes, newRBACConfigVolumes()...)
 
@@ -673,6 +688,11 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 				{
 					MountPath: "/etc/pki/ca-trust/extracted/pem",
 					Name:      "trusted-ca",
+					ReadOnly:  true,
+				},
+				{
+					MountPath: "/var/run/secrets/openshift/serviceaccount",
+					Name:      "bound-sa-token",
 					ReadOnly:  true,
 				},
 			},


### PR DESCRIPTION
@joelddiaz @michaelgugino 

Add a projected service account token to the machine-controller container in the machine-api-operator pod.  We will use this token to get STS creds when that is wired in.

This is inert until then.

https://issues.redhat.com/browse/CO-1254 subtask https://issues.redhat.com/browse/CO-1274