### PR TITLE
[OCPCLOUD-809] Add verify-diff check in generate task and enable in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,12 @@ machineset:
 	$(DOCKER_CMD) ./hack/go-build.sh machineset
 
 .PHONY: generate
-generate: gen-crd update-codegen
+generate: gen-crd gogen update-codegen goimports
+	./hack/verify-diff.sh
+
+.PHONY: gogen
+gogen:
+	./hack/go-gen.sh
 
 .PHONY: gen-crd
 gen-crd:

--- a/hack/go-gen.sh
+++ b/hack/go-gen.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+REPO_NAME=$(basename "${PWD}")
+if [ "$IS_CONTAINER" != "" ]; then
+  go generate ./pkg/apis/...
+else
+  docker run -it --rm \
+    --env IS_CONTAINER=TRUE \
+    --volume "${PWD}:/go/src/sigs.k8s.io/${REPO_NAME}:z" \
+    --workdir "/go/src/sigs.k8s.io/${REPO_NAME}" \
+    openshift/origin-release:golang-1.13 \
+    ./hack/go-gen.sh
+fi

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,12 +21,6 @@ set -o pipefail
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd "${SCRIPT_ROOT}"; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
-# The provider types don't need all the extra bits that generate-groups.sh
-# creates.  A simple `go generate` is enough for these.
-# Also use this for generating deepcopy for all types (so that we use the same generator).
-echo "Generating deepcopy funcs"
-go generate ./pkg/apis/...
-
 # generate the code with:
 # --output-base    because this script should also be able to run inside the vendor dir of
 #                  k8s.io/kubernetes. The output-base is needed for the generators to output into the vendor dir

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,0 +1,9 @@
+FILE_DIFF=$(git ls-files -o --exclude-standard)
+
+if [ "$FILE_DIFF" != "" ]; then
+  echo "Found untracked files:"
+  echo $FILE_DIFF
+  exit 1
+fi
+
+git diff --exit-code


### PR DESCRIPTION
This PR is dependent on openshift/release#13400 to enable the functionality in CI. Should go prior to the PR, allowing CI to get green.

Changes:

- Check file diff between committed code and generated bits with hack/verify-diff.sh
- go generate is moved into it's own script, which uses docker image with goimports tool in it - hack/go-gen.sh