### PR TITLE
Bug 1895838: Remove extraneous code comments

### DIFF
--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -56,7 +56,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: / [Machine] Machine is the Schema for the machines API
+        description: Machine is the Schema for the machines API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -67,7 +67,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: / [MachineSpec] MachineSpec defines the desired state of Machine
+            description: MachineSpec defines the desired state of Machine
             properties:
               metadata:
                 description: ObjectMeta will autopopulate the Node created. Use this to indicate what labels, annotations, name prefix, etc., should be used when creating the Node.
@@ -158,7 +158,7 @@ spec:
                 type: array
             type: object
           status:
-            description: / [MachineStatus] MachineStatus defines the observed state of Machine
+            description: MachineStatus defines the observed state of Machine
             properties:
               addresses:
                 description: Addresses is a list of addresses assigned to the machine. Queried from cloud provider, if available.

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -41,7 +41,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: / [MachineSet] MachineSet ensures that a specified number of machines replicas are running at any given time.
+        description: MachineSet ensures that a specified number of machines replicas are running at any given time.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -52,7 +52,7 @@ spec:
           metadata:
             type: object
           spec:
-            description: / [MachineSetSpec] MachineSetSpec defines the desired state of MachineSet
+            description: MachineSetSpec defines the desired state of MachineSet
             properties:
               deletePolicy:
                 description: DeletePolicy defines the policy used to identify nodes to delete when downscaling. Defaults to "Random".  Valid values are "Random, "Newest", "Oldest"
@@ -252,7 +252,7 @@ spec:
             - selector
             type: object
           status:
-            description: / [MachineSetStatus] MachineSetStatus defines the observed state of MachineSet
+            description: MachineSetStatus defines the observed state of MachineSet
             properties:
               availableReplicas:
                 description: The number of available replicas (ready for at least minReadySeconds) for this MachineSet.

--- a/pkg/apis/machine/v1beta1/machine_types.go
+++ b/pkg/apis/machine/v1beta1/machine_types.go
@@ -40,7 +40,6 @@ const (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-/// [Machine]
 // Machine is the Schema for the machines API
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
@@ -60,9 +59,6 @@ type Machine struct {
 	Status MachineStatus `json:"status,omitempty"`
 }
 
-/// [Machine]
-
-/// [MachineSpec]
 // MachineSpec defines the desired state of Machine
 type MachineSpec struct {
 	// ObjectMeta will autopopulate the Node created. Use this to
@@ -98,9 +94,6 @@ type MachineSpec struct {
 	ProviderID *string `json:"providerID,omitempty"`
 }
 
-/// [MachineSpec]
-
-/// [MachineStatus]
 // MachineStatus defines the observed state of Machine
 type MachineStatus struct {
 	// NodeRef will point to the corresponding Node if it exists.
@@ -190,8 +183,6 @@ type LastOperation struct {
 	// E.g. Create, Delete, Update etc
 	Type *string `json:"type,omitempty"`
 }
-
-/// [MachineVersionInfo]
 
 func (m *Machine) Validate() field.ErrorList {
 	errors := field.ErrorList{}

--- a/pkg/apis/machine/v1beta1/machineset_types.go
+++ b/pkg/apis/machine/v1beta1/machineset_types.go
@@ -29,7 +29,6 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-/// [MachineSet]
 // MachineSet ensures that a specified number of machines replicas are running at any given time.
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
@@ -47,9 +46,6 @@ type MachineSet struct {
 	Status MachineSetStatus `json:"status,omitempty"`
 }
 
-/// [MachineSet]
-
-/// [MachineSetSpec]
 // MachineSetSpec defines the desired state of MachineSet
 type MachineSetSpec struct {
 	// Replicas is the number of desired replicas.
@@ -104,9 +100,6 @@ const (
 	OldestMachineSetDeletePolicy MachineSetDeletePolicy = "Oldest"
 )
 
-/// [MachineSetSpec] // doxygen marker
-
-/// [MachineTemplateSpec] // doxygen marker
 // MachineTemplateSpec describes the data needed to create a Machine from a template
 type MachineTemplateSpec struct {
 	// Standard object's metadata.
@@ -120,9 +113,6 @@ type MachineTemplateSpec struct {
 	Spec MachineSpec `json:"spec,omitempty"`
 }
 
-/// [MachineTemplateSpec]
-
-/// [MachineSetStatus]
 // MachineSetStatus defines the observed state of MachineSet
 type MachineSetStatus struct {
 	// Replicas is the most recently observed number of replicas.
@@ -167,8 +157,6 @@ type MachineSetStatus struct {
 	// +optional
 	ErrorMessage *string `json:"errorMessage,omitempty"`
 }
-
-/// [MachineSetStatus]
 
 func (m *MachineSet) Validate() field.ErrorList {
 	errors := field.ErrorList{}


### PR DESCRIPTION
This change removes some comments that are creating extra information in the generated descriptions for some of the CRDs. It also regenerates the all the necessary files.