### PR TITLE
Bug 1889620: Azure disconnected reject publicIP setting

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -194,6 +194,7 @@ rules:
     - config.openshift.io
     resources:
     - infrastructures
+    - dnses
     verbs:
     - get
     - list

--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -128,10 +128,32 @@ func getInfra() (*osconfigv1.Infrastructure, error) {
 	return infra, nil
 }
 
-type machineAdmissionFn func(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate)
+func getDNS() (*osconfigv1.DNS, error) {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := osclientset.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	dns, err := client.ConfigV1().DNSes().Get(context.Background(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return dns, nil
+}
+
+type machineAdmissionFn func(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate)
+
+type admissionConfig struct {
+	clusterID       string
+	dnsDisconnected bool
+}
 
 type admissionHandler struct {
-	clusterID         string
+	*admissionConfig
 	webhookOperations machineAdmissionFn
 	decoder           *admission.Decoder
 }
@@ -163,14 +185,23 @@ func NewMachineValidator() (*machineValidatorHandler, error) {
 		return nil, err
 	}
 
-	return createMachineValidator(infra.Status.PlatformStatus.Type, infra.Status.InfrastructureName), nil
+	dns, err := getDNS()
+	if err != nil {
+		return nil, err
+	}
+
+	return createMachineValidator(infra, dns), nil
 }
 
-func createMachineValidator(platform osconfigv1.PlatformType, clusterID string) *machineValidatorHandler {
+func createMachineValidator(infra *osconfigv1.Infrastructure, dns *osconfigv1.DNS) *machineValidatorHandler {
+	admissionConfig := &admissionConfig{
+		dnsDisconnected: dns.Spec.PublicZone == nil,
+		clusterID:       infra.Status.InfrastructureName,
+	}
 	return &machineValidatorHandler{
 		admissionHandler: &admissionHandler{
-			clusterID:         clusterID,
-			webhookOperations: getMachineValidatorOperation(platform),
+			admissionConfig:   admissionConfig,
+			webhookOperations: getMachineValidatorOperation(infra.Status.PlatformStatus.Type),
 		},
 	}
 }
@@ -187,7 +218,7 @@ func getMachineValidatorOperation(platform osconfigv1.PlatformType) machineAdmis
 		return validateVSphere
 	default:
 		// just no-op
-		return func(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+		return func(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 			return true, []string{}, nil
 		}
 	}
@@ -206,7 +237,7 @@ func NewMachineDefaulter() (*machineDefaulterHandler, error) {
 func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *machineDefaulterHandler {
 	return &machineDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			clusterID:         clusterID,
+			admissionConfig:   &admissionConfig{clusterID: clusterID},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -228,7 +259,7 @@ func getMachineDefaulterOperation(platformStatus *osconfigv1.PlatformStatus) mac
 		return defaultVSphere
 	default:
 		// just no-op
-		return func(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+		return func(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 			return true, []string{}, nil
 		}
 	}
@@ -417,7 +448,7 @@ func (h *machineValidatorHandler) Handle(ctx context.Context, req admission.Requ
 
 	klog.V(3).Infof("Validate webhook called for Machine: %s", m.GetName())
 
-	ok, warnings, errs := h.webhookOperations(m, h.clusterID)
+	ok, warnings, errs := h.webhookOperations(m, h.admissionConfig)
 	if !ok {
 		return responseWithWarnings(admission.Denied(errs.Error()), warnings)
 	}
@@ -446,7 +477,7 @@ func (h *machineDefaulterHandler) Handle(ctx context.Context, req admission.Requ
 		m.Labels[MachineClusterIDLabel] = h.clusterID
 	}
 
-	ok, warnings, errs := h.webhookOperations(m, h.clusterID)
+	ok, warnings, errs := h.webhookOperations(m, h.admissionConfig)
 	if !ok {
 		return responseWithWarnings(admission.Denied(errs.Error()), warnings)
 	}
@@ -462,7 +493,7 @@ type awsDefaulter struct {
 	region string
 }
 
-func (a awsDefaulter) defaultAWS(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func (a awsDefaulter) defaultAWS(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Defaulting AWS providerSpec")
 
 	var errs []error
@@ -513,7 +544,7 @@ func unmarshalInto(m *Machine, providerSpec interface{}) error {
 	return nil
 }
 
-func validateAWS(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func validateAWS(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Validating AWS providerSpec")
 
 	var errs []error
@@ -604,7 +635,7 @@ func validateAWS(m *Machine, clusterID string) (bool, []string, utilerrors.Aggre
 	return true, warnings, nil
 }
 
-func defaultAzure(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func defaultAzure(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Defaulting Azure providerSpec")
 
 	var errs []error
@@ -621,12 +652,12 @@ func defaultAzure(m *Machine, clusterID string) (bool, []string, utilerrors.Aggr
 
 	// Vnet and Subnet need to be provided together by the user
 	if providerSpec.Vnet == "" && providerSpec.Subnet == "" {
-		providerSpec.Vnet = defaultAzureVnet(clusterID)
-		providerSpec.Subnet = defaultAzureSubnet(clusterID)
+		providerSpec.Vnet = defaultAzureVnet(config.clusterID)
+		providerSpec.Subnet = defaultAzureSubnet(config.clusterID)
 	}
 
 	if providerSpec.Image == (azure.Image{}) {
-		providerSpec.Image.ResourceID = defaultAzureImageResourceID(clusterID)
+		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID)
 	}
 
 	if providerSpec.UserDataSecret == nil {
@@ -659,7 +690,7 @@ func defaultAzure(m *Machine, clusterID string) (bool, []string, utilerrors.Aggr
 	return true, warnings, nil
 }
 
-func validateAzure(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func validateAzure(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Validating Azure providerSpec")
 
 	var errs []error
@@ -674,6 +705,9 @@ func validateAzure(m *Machine, clusterID string) (bool, []string, utilerrors.Agg
 		errs = append(errs, field.Required(field.NewPath("providerSpec", "vmSize"), "vmSize should be set to one of the supported Azure VM sizes"))
 	}
 
+	if providerSpec.PublicIP && config.dnsDisconnected {
+		errs = append(errs, field.Forbidden(field.NewPath("providerSpec", "publicIP"), "publicIP is not allowed in Azure disconnected installation"))
+	}
 	// Vnet requires Subnet
 	if providerSpec.Vnet != "" && providerSpec.Subnet == "" {
 		errs = append(errs, field.Required(field.NewPath("providerSpec", "subnet"), "must provide a subnet when a virtual network is specified"))
@@ -743,7 +777,7 @@ func validateAzureImage(image azure.Image) []error {
 	return errors
 }
 
-func defaultGCP(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func defaultGCP(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Defaulting GCP providerSpec")
 
 	var errs []error
@@ -760,15 +794,15 @@ func defaultGCP(m *Machine, clusterID string) (bool, []string, utilerrors.Aggreg
 
 	if len(providerSpec.NetworkInterfaces) == 0 {
 		providerSpec.NetworkInterfaces = append(providerSpec.NetworkInterfaces, &gcp.GCPNetworkInterface{
-			Network:    defaultGCPNetwork(clusterID),
-			Subnetwork: defaultGCPSubnetwork(clusterID),
+			Network:    defaultGCPNetwork(config.clusterID),
+			Subnetwork: defaultGCPSubnetwork(config.clusterID),
 		})
 	}
 
-	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, clusterID)
+	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, config.clusterID)
 
 	if len(providerSpec.Tags) == 0 {
-		providerSpec.Tags = defaultGCPTags(clusterID)
+		providerSpec.Tags = defaultGCPTags(config.clusterID)
 	}
 
 	if providerSpec.UserDataSecret == nil {
@@ -818,7 +852,7 @@ func defaultGCPDisks(disks []*gcp.GCPDisk, clusterID string) []*gcp.GCPDisk {
 	return disks
 }
 
-func validateGCP(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func validateGCP(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Validating GCP providerSpec")
 
 	var errs []error
@@ -941,7 +975,7 @@ func validateGCPServiceAccounts(serviceAccounts []gcp.GCPServiceAccount, parentP
 	return errs
 }
 
-func defaultVSphere(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func defaultVSphere(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Defaulting vSphere providerSpec")
 
 	var errs []error
@@ -973,7 +1007,7 @@ func defaultVSphere(m *Machine, clusterID string) (bool, []string, utilerrors.Ag
 	return true, warnings, nil
 }
 
-func validateVSphere(m *Machine, clusterID string) (bool, []string, utilerrors.Aggregate) {
+func validateVSphere(m *Machine, config *admissionConfig) (bool, []string, utilerrors.Aggregate) {
 	klog.V(3).Infof("Validating vSphere providerSpec")
 
 	var errs []error

--- a/pkg/apis/machine/v1beta1/machineset_webhook.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook.go
@@ -38,7 +38,7 @@ func NewMachineSetValidator() (*machineSetValidatorHandler, error) {
 func createMachineSetValidator(platform osconfigv1.PlatformType, clusterID string) *machineSetValidatorHandler {
 	return &machineSetValidatorHandler{
 		admissionHandler: &admissionHandler{
-			clusterID:         clusterID,
+			admissionConfig:   &admissionConfig{clusterID: clusterID},
 			webhookOperations: getMachineValidatorOperation(platform),
 		},
 	}
@@ -57,7 +57,7 @@ func NewMachineSetDefaulter() (*machineSetDefaulterHandler, error) {
 func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *machineSetDefaulterHandler {
 	return &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			clusterID:         clusterID,
+			admissionConfig:   &admissionConfig{clusterID: clusterID},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -108,7 +108,7 @@ func (h *machineSetValidatorHandler) validateMachineSet(ms *MachineSet) (bool, [
 
 	// Create a Machine from the MachineSet and validate the Machine template
 	m := &Machine{Spec: ms.Spec.Template.Spec}
-	ok, warnings, err := h.webhookOperations(m, h.clusterID)
+	ok, warnings, err := h.webhookOperations(m, h.admissionConfig)
 	if !ok {
 		errs = append(errs, err.Errors()...)
 	}
@@ -122,7 +122,7 @@ func (h *machineSetValidatorHandler) validateMachineSet(ms *MachineSet) (bool, [
 func (h *machineSetDefaulterHandler) defaultMachineSet(ms *MachineSet) (bool, []string, utilerrors.Aggregate) {
 	// Create a Machine from the MachineSet and default the Machine template
 	m := &Machine{Spec: ms.Spec.Template.Spec}
-	ok, warnings, err := h.webhookOperations(m, h.clusterID)
+	ok, warnings, err := h.webhookOperations(m, h.admissionConfig)
 	if !ok {
 		return false, warnings, utilerrors.NewAggregate(err.Errors())
 	}


### PR DESCRIPTION
Disconnected installations are using different DNS settings, and this is displayed in the resource
```yaml
apiVersion: config.openshift.io/v1
kind: DNS
metadata:
  name: cluster
spec:
  baseDomain: ***
  privateZone:
    id: <id>
  publicZone: <- this field is absent in disconnected install
    id: <id>
```

The PR goal is to reject an invalid MachineSet configuration when a `publicIP: true`, to prevent Machine from failing.