### PR TITLE
Add missing ErrorCount field to BareMetalHost CRD

### DIFF
--- a/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
+++ b/install/0000_30_machine-api-operator_08_baremetalhost.crd.yaml
@@ -306,6 +306,11 @@ spec:
           status:
             description: BareMetalHostStatus defines the observed state of BareMetalHost
             properties:
+              errorCount:
+                description: ErrorCount records how many times the host has encoutered
+                  an error since the last successful operation
+                type: integer
+                default: 0
               errorMessage:
                 description: the last error message reported by the provisioning subsystem
                 type: string
@@ -705,6 +710,7 @@ spec:
                     type: string
                 type: object
             required:
+            - errorCount
             - errorMessage
             - hardwareProfile
             - operationHistory


### PR DESCRIPTION
Updating MAO BMH crd while CBO migration is still in progress. Related to https://github.com/openshift/cluster-baremetal-operator/pull/64.