### PR TITLE
add mapi_machinehealthcheck_nodes_covered metric

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -124,6 +124,9 @@ func main() {
 		klog.Fatal(err)
 	}
 
+	// Register the MHC specific metrics
+	metrics.InitializeMachineHealthCheckMetrics()
+
 	klog.Info("Starting the Cmd.")
 
 	// Start the Cmd

--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -111,3 +111,21 @@ mapi_instance_delete_failed{name=machine-3,namespace=openshift-machine-api,reaso
 ```
 
 [Demo](https://user-images.githubusercontent.com/32226600/87791648-e72b6900-c842-11ea-90b7-4967b0d06fb5.gif)
+
+## Metrics about MachineHealthCheck resources
+
+When using MachineHealthChecks, metrics are available from the `machine-api-controllers` Pod on the
+default metrics port(`8083`) for the `machine-healthcheck-controller` container.
+
+The `mapi_machinehealthcheck_nodes_covered` metric describes the number of Nodes that are currently
+being monitored by `machine-healthcheck-controller`. The `name` label in this metric refers to the
+name of the MachineHealthCheck that is being reported. The `namespace` label refers to the owning
+namespace of the MachineHealthCheck.
+
+**Sample metrics**
+```
+# HELP mapi_machinehealthcheck_nodes_covered Number of nodes covered by MachineHealthChecks
+# TYPE mapi_machinehealthcheck_nodes_covered gauge
+mapi_machinehealthcheck_nodes_covered{name="machine-api-termination-handler",namespace="openshift-machine-api"} 0
+mapi_machinehealthcheck_nodes_covered{name="mhc-1",namespace="openshift-machine-api"} 1
+```

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/klog/v2"
 
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"github.com/openshift/machine-api-operator/pkg/metrics"
 	"github.com/openshift/machine-api-operator/pkg/util/conditions"
 	corev1 "k8s.io/api/core/v1"
 	apimachineryerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -155,6 +156,8 @@ func (r *ReconcileMachineHealthCheck) Reconcile(request reconcile.Request) (reco
 	if err := r.client.Get(context.TODO(), request.NamespacedName, mhc); err != nil {
 		if apimachineryerrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
+			// In the event that this was a deletion, we need to remove the associated metric label
+			metrics.DeleteMachineHealthCheckNodesCovered(request.NamespacedName.Name, request.NamespacedName.Namespace)
 			return reconcile.Result{}, nil
 		}
 		klog.Errorf("Reconciling %s: failed to get MHC: %v", request.String(), err)
@@ -168,6 +171,8 @@ func (r *ReconcileMachineHealthCheck) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 	totalTargets := len(targets)
+
+	metrics.ObserveMachineHealthCheckNodesCovered(mhc.Name, mhc.Namespace, totalTargets)
 
 	// health check all targets and reconcile mhc status
 	currentHealthy, needRemediationTargets, nextCheckTimes, errList := r.healthCheckTargets(targets, mhc.Spec.NodeStartupTimeout.Duration)

--- a/pkg/metrics/machinehealthcheck.go
+++ b/pkg/metrics/machinehealthcheck.go
@@ -1,0 +1,53 @@
+/*
+   Copyright 2020 The Machine API Operator authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+const (
+	DefaultHealthCheckMetricsAddress = ":8083"
+)
+
+var (
+	// MachineHealthCheckNodesCovered is a Prometheus metric, which reports the number of nodes covered by MachineHealthChecks
+	MachineHealthCheckNodesCovered = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mapi_machinehealthcheck_nodes_covered",
+			Help: "Number of nodes covered by MachineHealthChecks",
+		}, []string{"name", "namespace"},
+	)
+)
+
+func InitializeMachineHealthCheckMetrics() {
+	metrics.Registry.MustRegister(MachineHealthCheckNodesCovered)
+}
+
+func DeleteMachineHealthCheckNodesCovered(name string, namespace string) {
+	MachineHealthCheckNodesCovered.Delete(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+	})
+}
+
+func ObserveMachineHealthCheckNodesCovered(name string, namespace string, count int) {
+	MachineHealthCheckNodesCovered.With(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+	}).Set(float64(count))
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,10 +11,9 @@ import (
 )
 
 const (
-	DefaultHealthCheckMetricsAddress = ":8083"
-	DefaultMachineSetMetricsAddress  = ":8082"
-	DefaultMachineMetricsAddress     = ":8081"
-	DefaultMetal3MetricsAddress      = ":60000"
+	DefaultMachineSetMetricsAddress = ":8082"
+	DefaultMachineMetricsAddress    = ":8081"
+	DefaultMetal3MetricsAddress     = ":60000"
 )
 
 var (


### PR DESCRIPTION
This change adds a gauge metric to record the nodes covered by MHCs, it
also adds a helper function to make setting this value more convenient.