### PR TITLE
add mapi_machinehealthcheck_short_circuit metric

### DIFF
--- a/docs/dev/metrics.md
+++ b/docs/dev/metrics.md
@@ -123,8 +123,12 @@ being monitored by `machine-healthcheck-controller`.
 The `mapi_machinehealthcheck_remediation_success_total` metric gives a total count of the successful
 remediation performed by a MachineHealthCheck.
 
+The `mapi_machinehealthcheck_short_circuit` metric indicates when a MachineHealthCheck has been
+short-circuited, a `0` value indicates normal operation, a `1` value indicates a short-circuit.
+
 The `name` label in these metric refers to the name of the MachineHealthCheck that is being reported.
 The `namespace` label refers to the owning namespace of the MachineHealthCheck.
+
 
 **Sample metrics**
 ```
@@ -135,4 +139,8 @@ mapi_machinehealthcheck_nodes_covered{name="mhc-1",namespace="openshift-machine-
 # HELP mapi_machinehealthcheck_remediation_success_total Number of successful remediations performed by MachineHealthChecks
 # TYPE mapi_machinehealthcheck_remediation_success_total counter
 mapi_machinehealthcheck_remediation_success_total{name="mhc-1",namespace="openshift-machine-api"} 1
+# HELP mapi_machinehealthcheck_short_circuit Short circuit status for MachineHealthCheck (0=no, 1=yes)
+# TYPE mapi_machinehealthcheck_short_circuit gauge
+mapi_machinehealthcheck_short_circuit{name="machine-api-termination-handler",namespace="openshift-machine-api"} 0
+mapi_machinehealthcheck_short_circuit{name="mhc-1",namespace="openshift-machine-api"} 0
 ```

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -222,6 +222,7 @@ func (r *ReconcileMachineHealthCheck) Reconcile(request reconcile.Request) (reco
 			unhealthyCount,
 			mhc.Spec.MaxUnhealthy,
 		)
+		metrics.ObserveMachineHealthCheckShortCircuitEnabled(mhc.Name, mhc.Namespace)
 		return reconcile.Result{Requeue: true}, nil
 	}
 	klog.V(3).Infof("Remediations are allowed for %s: total targets: %v,  max unhealthy: %v, unhealthy targets: %v",
@@ -230,6 +231,8 @@ func (r *ReconcileMachineHealthCheck) Reconcile(request reconcile.Request) (reco
 		mhc.Spec.MaxUnhealthy,
 		unhealthyCount,
 	)
+	metrics.ObserveMachineHealthCheckShortCircuitDisabled(mhc.Name, mhc.Namespace)
+
 	conditions.MarkTrue(mhc, mapiv1.RemediationAllowedCondition)
 	if err := r.reconcileStatus(mergeBase, mhc); err != nil {
 		klog.Errorf("Reconciling %s: error patching status: %v", request.String(), err)

--- a/pkg/metrics/machinehealthcheck.go
+++ b/pkg/metrics/machinehealthcheck.go
@@ -40,12 +40,21 @@ var (
 			Help: "Number of successful remediations performed by MachineHealthChecks",
 		}, []string{"name", "namespace"},
 	)
+
+	// MachineHealthCheckShortCircuit is a Prometheus metric, which reports when the named MachineHealthCheck is currently short-circuited (0=no, 1=yes)
+	MachineHealthCheckShortCircuit = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "mapi_machinehealthcheck_short_circuit",
+			Help: "Short circuit status for MachineHealthCheck (0=no, 1=yes)",
+		}, []string{"name", "namespace"},
+	)
 )
 
 func InitializeMachineHealthCheckMetrics() {
 	metrics.Registry.MustRegister(
 		MachineHealthCheckNodesCovered,
 		MachineHealthCheckRemediationSuccessTotal,
+		MachineHealthCheckShortCircuit,
 	)
 }
 
@@ -68,4 +77,18 @@ func ObserveMachineHealthCheckRemediationSuccess(name string, namespace string) 
 		"name":      name,
 		"namespace": namespace,
 	}).Inc()
+}
+
+func ObserveMachineHealthCheckShortCircuitDisabled(name string, namespace string) {
+	MachineHealthCheckShortCircuit.With(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+	}).Set(0)
+}
+
+func ObserveMachineHealthCheckShortCircuitEnabled(name string, namespace string) {
+	MachineHealthCheckShortCircuit.With(prometheus.Labels{
+		"name":      name,
+		"namespace": namespace,
+	}).Set(1)
 }


### PR DESCRIPTION
This change adds the counter metric to track when a MachineHealthCheck
has been short-circuited. It adds helper functions for enabling and
disabling the metric, and an update to the metrics doc showing the new
metric.
