### PR TITLE
[release-4.6] Bug 1896705: Inject cluster-wide proxy configuration in to machine-api-controller deployment 

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -125,6 +125,7 @@ func startControllers(ctx *ControllerContext) {
 		ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 		ctx.KubeNamespacedInformerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations(),
 		ctx.KubeNamespacedInformerFactory.Admissionregistration().V1().MutatingWebhookConfigurations(),
+		ctx.ConfigInformerFactory.Config().V1().Proxies(),
 		ctx.ClientBuilder.KubeClientOrDie(componentName),
 		ctx.ClientBuilder.OpenshiftClientOrDie(componentName),
 		ctx.ClientBuilder.DynamicClientOrDie(componentName),

--- a/docs/user/cluster-wide-proxy.md
+++ b/docs/user/cluster-wide-proxy.md
@@ -1,0 +1,10 @@
+# Overview
+
+The [cluster-wide proxy](https://docs.openshift.com/container-platform/4.6/networking/enable-cluster-wide-proxy.html) is a configuration applied which communicates the need to perform outbound communication via an HTTP proxy.  Components are responsible for watching for changes to a `Proxy` resource named `cluster` and configuring applicable deployments to consume and honor the HTTP proxy configuration.  In some environments, such as installations in to some private networks, direct connections to external servers are not allowed and must flow through an HTTP proxy.
+
+Typically, the following environment variables are defined to communicate proxy configuration to processes:
+
+- HTTP_PROXY - The URL of the proxy server which handles HTTP requests
+- HTTPS_PROXY - The URL of the proxy server which handles HTTPS requests
+- NO_PROXY - comma-separated list of strings representing IP addresses and host names which should bypass the proxy and connect directly to the target server.  If the host name matches one of these strings, or the host is within the domain of one of these strings, transactions with that node will not be proxied. When a domain is used, it needs to start with a period. A user can specify that both www.example.com and foo.example.com should not use a proxy by setting NO_PROXY to .example.com. By including the full name you can exclude specific host names, so to make www.example.com not use a proxy but still have foo.example.com do it, set NO_PROXY to www.example.com.
+

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -308,6 +308,7 @@ rules:
     resources:
       - featuregates
       - featuregates/status
+      - proxies
     verbs:
       - get
       - list

--- a/pkg/operator/baremetal_test.go
+++ b/pkg/operator/baremetal_test.go
@@ -118,6 +118,7 @@ func newOperatorWithBaremetalConfig() *OperatorConfig {
 			"quay.io/openshift/origin-ironic-machine-os-downloader:v4.2.0",
 			"quay.io/openshift/origin-ironic-static-ip-manager:v4.2.0",
 		},
+		&osconfigv1.Proxy{},
 	}
 }
 

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -23,6 +23,7 @@ type OperatorConfig struct {
 	TargetNamespace      string `json:"targetNamespace"`
 	Controllers          Controllers
 	BaremetalControllers BaremetalControllers
+	Proxy                *configv1.Proxy
 }
 
 type Controllers struct {


### PR DESCRIPTION
This is a cherry-pick of #725 

This updates MAO to honour cluster wide proxy settings and inject the required environment variables into containers within the machine-api-controllers deployment