### PR TITLE
Bug 1880161: Set retry timeout for actuator.Update() failures

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -284,8 +284,8 @@ func (r *ReconcileMachine) Reconcile(request reconcile.Request) (reconcile.Resul
 	if instanceExists {
 		klog.Infof("%v: reconciling machine triggers idempotent update", machineName)
 		if err := r.actuator.Update(ctx, m); err != nil {
-			klog.Errorf("%v: error updating machine: %v", machineName, err)
-			return delayIfRequeueAfterError(err)
+			klog.Errorf("%v: error updating machine: %v, retrying in %v seconds", machineName, err, requeueAfter)
+			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 
 		if !machineIsProvisioned(m) {


### PR DESCRIPTION
Set retry timeout for actuator.Update() failures in order to avoid exponential backoff for slow providers.