### PR TITLE
Bug 1902157: Fix spelling of automountServiceAccountToken

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -23,7 +23,7 @@ metadata:
   namespace: openshift-machine-api
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
-autoMountServiceAccountToken: false
+automountServiceAccountToken: false
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
This doesn't work if you spell it wrong. This is needed to ensure the security policy matches (ie no secret mounting).

Pods currently can't schedule as the pod is trying to mount a secret which we haven't allowed.