### PR TITLE
Bug 1902253: Ensure zero value of remediationsAllowed is printed

### DIFF
--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -115,7 +115,8 @@ type MachineHealthCheckStatus struct {
 	// RemediationsAllowed is the number of further remediations allowed by this machine health check before
 	// maxUnhealthy short circuiting will be applied
 	// +kubebuilder:validation:Minimum=0
-	RemediationsAllowed int32 `json:"remediationsAllowed,omitempty"`
+	// +optional
+	RemediationsAllowed int32 `json:"remediationsAllowed"`
 
 	// Conditions defines the current state of the MachineHealthCheck
 	Conditions Conditions `json:"conditions,omitempty"`


### PR DESCRIPTION
So long as the value has been non-zero before, this will ensure that the value is printed. If it has never been non-zero, it's very difficult for us to set the field without making it a pointer, which we would preferably not do as it complicates a lot of logic throughout the codebase.