### PR TITLE
Bug 1869320: [release-4.5] [vSphere] Reduce sync period to 10 minutes

### DIFF
--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -63,6 +63,7 @@ func main() {
 	}
 
 	cfg := config.GetConfigOrDie()
+	syncPeriod := 10 * time.Minute
 
 	opts := manager.Options{
 		// Disable metrics serving
@@ -74,6 +75,7 @@ func main() {
 		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
 		RetryPeriod:   &retryPeriod,
 		RenewDeadline: &renewDealine,
+		SyncPeriod:    &syncPeriod,
 	}
 
 	if *watchNamespace != "" {


### PR DESCRIPTION
That is a manual cherry-pick. Its purpose is to reduce the sync period to 10 minutes in order to better reflect the real state of vSphere VMs.