### PR TITLE
Add missing default cluster profile annotation

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -167,4 +167,3 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: KubevirtProviderSpec
----

--- a/install/0000_30_machine-api-operator_09_security_context_constraint.yaml
+++ b/install/0000_30_machine-api-operator_09_security_context_constraint.yaml
@@ -3,6 +3,7 @@ apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     kubernetes.io/description: 'machine-api-termination-handler allows the
       machine-api-termination-handler service account to run as root, access host
       paths and access the host network. This SCC is limited and should not be used


### PR DESCRIPTION
I thought last PR was the last one. Sorry for the noise.

A check in the CI will be soon available.