### PR TITLE
Bug 1907380: Reduce verbosity of kube-rbac-proxy logging

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -615,7 +615,7 @@ func newKubeProxyContainer(image, portName, upstreamPort string, exposePort int3
 		fmt.Sprintf("--tls-cert-file=%s/tls.crt", tlsCertMountPath),
 		fmt.Sprintf("--tls-private-key-file=%s/tls.key", tlsCertMountPath),
 		"--logtostderr=true",
-		"--v=10",
+		"--v=3",
 	}
 	ports := []corev1.ContainerPort{{
 		Name:          portName,


### PR DESCRIPTION
The Kube RBAC Proxy containers are logging excessively. Having log level 10 includes logging bearer tokens and full http request/responses. This is insecure, more logging than we need, and has an impact on aggregated logging. Reduce to 3 to be inline with other components.