### PR TITLE
Update README to point cluster-api-provider-baremetal to the correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ensure presence of expected number of replicas and a given provider config for a
 
   - [cluster-api-provider-openstack](https://github.com/openshift/cluster-api-provider-openstack)
 
-  - [cluster-api-provider-baremetal](https://github.com/metal3-io/cluster-api-provider-baremetal)
+  - [cluster-api-provider-baremetal](https://github.com/openshift/cluster-api-provider-baremetal)
 
   - [cluster-api-provider-ovirt](https://github.com/openshift/cluster-api-provider-ovirt)
 


### PR DESCRIPTION
This is a minor update to the README to fix the link to cluster-api-provider-baremetal, which currently points to an archived repo. The correct repo is in openshift/cluster-api-provider-baremetal.