### PR TITLE
Bug 1905709: Drain: ignore gracePeriod on unreachable kublets

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -92,7 +92,7 @@ const (
 	// Hardcoded instance state set on machine failure
 	unknownInstanceState = "Unknown"
 
-	skipWaitForDeleteTimeoutSeconds = 60 * 5
+	skipWaitForDeleteTimeoutSeconds = 1
 )
 
 var DefaultActuator Actuator
@@ -365,9 +365,12 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	if nodeIsUnreachable(node) {
-		klog.Infof("%q: Node %q is unreachable, draining will wait %d seconds after pod is signalled for deletion and skip after it",
-			machine.Name, node.Name, skipWaitForDeleteTimeoutSeconds)
+		klog.Infof("%q: Node %q is unreachable, draining will wait ignore gracePeriod. PDBs are still honored.",
+			machine.Name, node.Name)
+		// Since kubelet is unreachable, pods will never disappear and we still
+		// need SkipWaitForDeleteTimeoutSeconds so we don't wait for them.
 		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
+		drainer.GracePeriodSeconds = 1
 	}
 
 	if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -365,7 +365,7 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	if nodeIsUnreachable(node) {
-		klog.Infof("%q: Node %q is unreachable, draining will wait ignore gracePeriod. PDBs are still honored.",
+		klog.Infof("%q: Node %q is unreachable, draining will ignore gracePeriod. PDBs are still honored.",
 			machine.Name, node.Name)
 		// Since kubelet is unreachable, pods will never disappear and we still
 		// need SkipWaitForDeleteTimeoutSeconds so we don't wait for them.


### PR DESCRIPTION
Any pod having a long gracePeriod will block drain for that length of time on unreachable kubelets, and this is undesirable.  This is because a pod's deletionTimestamp is not a timestamp which indicates when it was marked deleted (as assumed), rather it's the deadline of some future time (if utilizing a gracePeriod) for the kubelet to send SIGKILL.

We want pods to be drained quickly on unreachable kubelets are we're intended to remove the machine in our case, we don't need to wait for them to come back.  PDBs are still honored and any pod covered by a PDB is not affected by this change.  Kubelets that are not unreachable are not impacted by this change.

More discussion here: https://bugzilla.redhat.com/show_bug.cgi?id=1905709#c13