### PR TITLE
Bug 1907380: Reduce verbosity of kube-rbac-proxy logging for operator

### DIFF
--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - "--tls-private-key-file=/etc/tls/private/tls.key"
         - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
         - "--logtostderr=true"
-        - "--v=10"
+        - "--v=3"
         ports:
         - containerPort: 8443
           name: https


### PR DESCRIPTION
The Kube RBAC Proxy containers are logging excessively. Having log level 10 includes logging bearer tokens and full http request/responses. This is insecure, more logging than we need, and has an impact on aggregated logging. Reduce to 3 to be inline with other components.