### PR TITLE
Update repo url for https://github.com/metal3-io/cluster-api-provider-metal3 as metal3-io/cluster-api-provider-baremetal is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Ensure presence of expected number of replicas and a given provider config for a
 
   - [cluster-api-provider-openstack](https://github.com/openshift/cluster-api-provider-openstack)
 
-  - [cluster-api-provider-baremetal](https://github.com/metal3-io/cluster-api-provider-baremetal)
+  - [cluster-api-provider-metal3](https://github.com/metal3-io/cluster-api-provider-metal3)
 
   - [cluster-api-provider-ovirt](https://github.com/openshift/cluster-api-provider-ovirt)
 


### PR DESCRIPTION
Update repo url for https://github.com/metal3-io/cluster-api-provider-metal3 as metal3-io/cluster-api-provider-baremetal is deprecated