### PR TITLE
Bug 1915114: allow machine-api-controllers to access configmaps in openshift-config-managed

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -24,6 +24,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
 automountServiceAccountToken: false
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -41,6 +42,24 @@ rules:
       - get
       - list
       - watch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: machine-api-controllers
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -416,6 +435,23 @@ subjects:
   - kind: ServiceAccount
     name: machine-api-controllers
     namespace: openshift-machine-api
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: machine-api-controllers
+  namespace: openshift-config-managed
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: machine-api-controllers
+subjects:
+- kind: ServiceAccount
+  name: machine-api-controllers
+  namespace: openshift-machine-api
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
To support custom CA bundles for AWS, the machine-api-controllers need access to the kube-cloud-config ConfigMap in the openshift-config-managed namespace.