### PR TITLE
Bug 1915962: Add exclusion annotation for machine health check on ROKS

### DIFF
--- a/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
+++ b/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
@@ -9,6 +9,7 @@ metadata:
     k8s-app: termination-handler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
Until we switch to cluster profiles for ROKS, we still need to exclude manifests that do not apply. The MachineHealthCheck CRD is not defined in a ROKS cluster.