### PR TITLE
Return a valid error message when multiple templates are found

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -475,9 +475,10 @@ func clone(s *machineScope) (string, error) {
 
 	vmTemplate, err := s.GetSession().FindVM(*s, "", s.providerSpec.Template)
 	if err != nil {
+		const multipleFoundMsg = "multiple templates found, specify one in config"
 		const notFoundMsg = "template not found, specify valid value"
 		defaultError := fmt.Errorf("unable to get template %q: %w", s.providerSpec.Template, err)
-		return "", handleVSphereError("", notFoundMsg, defaultError, err)
+		return "", handleVSphereError(multipleFoundMsg, notFoundMsg, defaultError, err)
 	}
 
 	var snapshotRef *types.ManagedObjectReference


### PR DESCRIPTION
We should never pass an empty string into `handleVSphereError` as it may result in error messages being returned such as `ocp4-llplx-windows-qs6cx error: ocp4-llplx-windows-qs6cx: reconciler failed to Create machine: ` which isn't helpful for debugging.

There has been some conversation and debugging around a potential bug that seems to be coming from this piece of the code, so we should make sure that we are returning useful errors, even in cases that seem unlikely.