### PR TITLE
Add service account names to credentials request manifest

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -9,6 +9,8 @@ metadata:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
+  serviceAccountNames:
+  - machine-api-controllers
   secretRef:
     name: aws-cloud-credentials
     namespace: openshift-machine-api


### PR DESCRIPTION
For a new way of managing OpenShift credentials on AWS to work, using Security
Token Service, we need external tooling to know the service account names from
the Credentials Request manifest so that it can create IAM Roles that can be
assumed only by those specific service accounts.

Managing credentials using STS ref: https://github.com/openshift/cloud-credential-operator/blob/master/docs/sts.md
Tooling design ref: https://issues.redhat.com/browse/CCO-60

/cc @joelddiaz 