### PR TITLE
Bug 1923823: Improve TLS configuration for Kube RBAC Proxy

### DIFF
--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - "--tls-cert-file=/etc/tls/private/tls.crt"
         - "--tls-private-key-file=/etc/tls/private/tls.key"
         - "--config-file=/etc/kube-rbac-proxy/config-file.yaml"
+        - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305"
         - "--logtostderr=true"
         - "--v=3"
         ports:

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -642,6 +642,7 @@ func newKubeProxyContainer(image, portName, upstreamPort string, exposePort int3
 		fmt.Sprintf("--config-file=%s/config-file.yaml", configMountPath),
 		fmt.Sprintf("--tls-cert-file=%s/tls.crt", tlsCertMountPath),
 		fmt.Sprintf("--tls-private-key-file=%s/tls.key", tlsCertMountPath),
+		"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
 		"--logtostderr=true",
 		"--v=3",
 	}


### PR DESCRIPTION
The default ciphers are not secure and are susceptible to a number of different known vulnerabilities. This collection of ciphers should be more secure and have no known vulnerabilities present.

Suites inspired by the [cluster-monitoring-operator](https://github.com/openshift/cluster-monitoring-operator/blob/f98cd6d7d1dc50fe881c6aa29d772a581451afd1/manifests/0000_50_cluster-monitoring-operator_05-deployment.yaml#L54).