### PR TITLE
install/0000_90_machine-api-operator_04_alertrules: Drop MachineAPIOperatorDown

### DIFF
--- a/docs/user/Alerts.md
+++ b/docs/user/Alerts.md
@@ -49,19 +49,3 @@ due to either network issue or missing service definition.
 
 ### Resolution
 Investigate the logs of the machine-api-operator to determine why it is unable to gather machines and machinesets, or investigate the collection of metrics.
-
-## MachineAPIOperatorDown
-The machine-api-operator is not up.
-
-### Query
-```
-# for: 5m
-absent(up{job="machine-api-operator"} == 1)
-```
-
-### Possible Causes
-* The deployment has been scaled down
-* machine-api-operator is in a failed state
-
-### Resolution
-Investigate logs, deployment, and pod events for the machine-api-operator.

--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -42,13 +42,3 @@ spec:
             severity: critical
           annotations:
             message: "machine api operator metrics collection is failing. For more details:  oc logs <machine-api-operator-pod-name> -n openshift-machine-api"
-    - name: machine-api-operator-down
-      rules:
-        - alert: MachineAPIOperatorDown
-          expr: |
-             absent(up{job="machine-api-operator"} == 1)
-          for: 5m
-          labels:
-            severity: critical
-          annotations:
-            message: "machine api operator is down"


### PR DESCRIPTION
The cluster-version operator is responsible for complaining if the machine-API operator's deployment is sad, so no need for the operator to handle this directly (we end up doubling up if there's an issue).  This drops the alert which was added in 9b666d6f20 (#388).

See also openshift/cloud-credential-operator#308.  Also, I just saw MachineAPIOperatorDown in the wild during the recent build01 explosion.