### PR TITLE
Bug 1939054: Disable startup timeout for Spot MHC

### DIFF
--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -71,11 +71,13 @@ spec:
               nodeStartupTimeout:
                 default: 10m
                 description: Machines older than this duration without a node will
-                  be considered to have failed and will be remediated. Expects an
-                  unsigned duration string of decimal numbers each with optional fraction
-                  and a unit suffix, eg "300ms", "1.5h" or "2h45m". Valid time units
-                  are "ns", "us" (or "µs"), "ms", "s", "m", "h".
-                pattern: ^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
+                  be considered to have failed and will be remediated. To prevent
+                  Machines without Nodes from being removed, disable startup checks
+                  by setting this value explicitly to "0". Expects an unsigned duration
+                  string of decimal numbers each with optional fraction and a unit
+                  suffix, eg "300ms", "1.5h" or "2h45m". Valid time units are "ns",
+                  "us" (or "µs"), "ms", "s", "m", "h".
+                pattern: ^0|([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$
                 type: string
               remediationTemplate:
                 description: "RemediationTemplate is a reference to a remediation

--- a/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
+++ b/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
@@ -15,6 +15,9 @@ spec:
     matchLabels:
       machine.openshift.io/interruptible-instance: ""
   maxUnhealthy: 100%
+  # This MHC should only ever remove nodes that have the terminating condition.
+  # Disable node startup timeout check.
+  nodeStartupTimeout: "0"
   unhealthyConditions:
   - type: Terminating
     status: "True"

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -72,14 +72,16 @@ type MachineHealthCheckSpec struct {
 
 	// Machines older than this duration without a node will be considered to have
 	// failed and will be remediated.
+	// To prevent Machines without Nodes from being removed, disable startup checks
+	// by setting this value explicitly to "0".
 	// Expects an unsigned duration string of decimal numbers each with optional
 	// fraction and a unit suffix, eg "300ms", "1.5h" or "2h45m".
 	// Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
 	// +optional
 	// +kubebuilder:default:="10m"
-	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
+	// +kubebuilder:validation:Pattern="^0|([0-9]+(\\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$"
 	// +kubebuilder:validation:Type:=string
-	NodeStartupTimeout metav1.Duration `json:"nodeStartupTimeout,omitempty"`
+	NodeStartupTimeout *metav1.Duration `json:"nodeStartupTimeout,omitempty"`
 
 	// RemediationTemplate is a reference to a remediation template
 	// provided by an infrastructure provider.

--- a/pkg/apis/machine/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/machine/v1beta1/zz_generated.deepcopy.go
@@ -199,7 +199,11 @@ func (in *MachineHealthCheckSpec) DeepCopyInto(out *MachineHealthCheckSpec) {
 		*out = new(intstr.IntOrString)
 		**out = **in
 	}
-	out.NodeStartupTimeout = in.NodeStartupTimeout
+	if in.NodeStartupTimeout != nil {
+		in, out := &in.NodeStartupTimeout, &out.NodeStartupTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.RemediationTemplate != nil {
 		in, out := &in.RemediationTemplate, &out.RemediationTemplate
 		*out = new(corev1.ObjectReference)


### PR DESCRIPTION
The spot termination handler MHC should only ever remove Machines that meet the spot termination condition. We do not want it to remove machines because they took too long to start up. That should be a user decision.

This PR adds the ability to disable the node startup timeout completely, and uses that for the spot termination MHC.