### PR TITLE
add in-container vendoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,7 @@ endif
 
 .PHONY: vendor
 vendor:
-	go mod tidy
-	go mod vendor
-	go mod verify
+	$(DOCKER_CMD) ./hack/go-mod.sh
 
 .PHONY: check
 check: lint fmt vet verify-codegen test ## Run code validations

--- a/hack/go-mod.sh
+++ b/hack/go-mod.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+go mod tidy
+go mod vendor
+go mod verify


### PR DESCRIPTION
Add option to run make vendor in container like other targets, to avoid issues with go module caching depending on what you already have on your machine.