### PR TITLE
Update GCP default disk image to include ignition v3

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -93,10 +93,9 @@ const (
 	defaultGCPCredentialsSecret = "gcp-cloud-credentials"
 	defaultGCPDiskSizeGb        = 128
 	defaultGCPDiskType          = "pd-standard"
-	// https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202007212240-0/x86_64/meta.json
-	// https://github.com/openshift/installer/pull/3808
-	// https://github.com/openshift/installer/blob/d75bf7ad98124b901ae7e22b5595e0392ed6ea3c/data/data/rhcos.json
-	defaultGCPDiskImage = "projects/rhcos-cloud/global/images/rhcos-46-82-202007212240-0-gcp-x86-64"
+	// https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.8/48.83.202103122318-0/x86_64/meta.json
+	// https://github.com/openshift/installer/blob/796a99049d3b7489b6c08ec5bd7c7983731afbcf/data/data/rhcos.json#L90-L94
+	defaultGCPDiskImage = "projects/rhcos-cloud/global/images/rhcos-48.83.202103122318-0-gcp.x86_64"
 
 	// vSphere Defaults
 	defaultVSphereCredentialsSecret = "vsphere-cloud-credentials"


### PR DESCRIPTION
The webhook test started failing consistently for GCP because the default image that was being used does not support ignition v3. Update to a newer image (as used in the installer) so that the tests pass again