### PR TITLE
Don't mount service account token in termination daemonset

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -712,11 +712,12 @@ func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSp
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers:         containers,
-			PriorityClassName:  "system-node-critical",
-			NodeSelector:       map[string]string{machinecontroller.MachineInterruptibleInstanceLabelName: ""},
-			ServiceAccountName: machineAPITerminationHandler,
-			HostNetwork:        true,
+			Containers:                   containers,
+			PriorityClassName:            "system-node-critical",
+			NodeSelector:                 map[string]string{machinecontroller.MachineInterruptibleInstanceLabelName: ""},
+			ServiceAccountName:           machineAPITerminationHandler,
+			AutomountServiceAccountToken: pointer.BoolPtr(false),
+			HostNetwork:                  true,
 			Volumes: []corev1.Volume{
 				{
 					Name: "kubeconfig",


### PR DESCRIPTION
We were relying on the service account to be updated before the daemonset was rolling out. But CVO does not guarantee the ordering of objects being rolled out when they are at the same runlevel. 

To avoid having to create ordering dependencies by using multiple run levels, we can instead specify not to mount the service account token directly on the pod spec

I've manually tested this on AWS and the deployment can roll out even when the service account hasn't been updated with this patch in plcase