### PR TITLE
Fetch credentials  with server name in lowercase

### DIFF
--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	apivsphere "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
@@ -230,8 +231,8 @@ func getCredentialsSecret(client runtimeclient.Client, namespace string, spec ap
 		return "", "", errors.New("no workspace")
 	}
 
-	credentialsSecretUser := fmt.Sprintf("%s.username", spec.Workspace.Server)
-	credentialsSecretPassword := fmt.Sprintf("%s.password", spec.Workspace.Server)
+	credentialsSecretUser := fmt.Sprintf("%s.username", strings.ToLower(spec.Workspace.Server))
+	credentialsSecretPassword := fmt.Sprintf("%s.password", strings.ToLower(spec.Workspace.Server))
 
 	user, exists := credentialsSecret.Data[credentialsSecretUser]
 	if !exists {

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -146,6 +146,7 @@ func TestGetCredentialsSecret(t *testing.T) {
 	expectedUser := "user"
 	expectedPassword := "password"
 	expectedServer := "test-server"
+	expectedCaseInsensitiveServer := "TEST-server"
 	expectedCredentialsSecretUsername := fmt.Sprintf("%s.username", expectedServer)
 	expectedCredentialsSecretPassword := fmt.Sprintf("%s.password", expectedServer)
 	testCases := []struct {
@@ -173,6 +174,28 @@ func TestGetCredentialsSecret(t *testing.T) {
 				},
 				Workspace: &vspherev1.Workspace{
 					Server: expectedServer,
+				},
+			},
+			expectCredentials: true,
+		},
+		{
+		    testCase: "all good when server name is case insensitive",
+		    secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: TestNamespace,
+				},
+				Data: map[string][]byte{
+					expectedCredentialsSecretUsername: []byte(expectedUser),
+					expectedCredentialsSecretPassword: []byte(expectedPassword),
+				},
+			},
+		    providerSpec: &vspherev1.VSphereMachineProviderSpec{
+				CredentialsSecret: &corev1.LocalObjectReference{
+					Name: "test",
+				},
+				Workspace: &vspherev1.Workspace{
+					Server: expectedCaseInsensitiveServer,
 				},
 			},
 			expectCredentials: true,


### PR DESCRIPTION
Searches for the credentialsSecretUser and credentialsSecretPassword with server name in lower case.
As per the secret's format, parameters in `data` section are expected to be in lower case, so a Workspace.server  set in another format leads to errors while scaling up the node.

Reference: [bz-1945823](https://bugzilla.redhat.com/show_bug.cgi?id=1945823)