### PR TITLE
Vsphere enable autoscaling from/to zero

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/go-logr/logr v0.3.0
 	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.2
 	github.com/onsi/ginkgo v1.14.1

--- a/pkg/controller/vsphere/machineset/controller.go
+++ b/pkg/controller/vsphere/machineset/controller.go
@@ -1,0 +1,122 @@
+package machineset
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	providerconfigv1 "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
+	mapierrors "github.com/openshift/machine-api-operator/pkg/controller/machine"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+)
+
+const (
+	// This exposes compute information based on the providerSpec input.
+	// This is needed by the autoscaler to foresee upcoming capacity when scaling from zero.
+	// https://github.com/openshift/enhancements/pull/186
+	cpuKey    = "machine.openshift.io/vCPU"
+	memoryKey = "machine.openshift.io/memoryMb"
+)
+
+// Reconciler reconciles machineSets.
+type Reconciler struct {
+	Client client.Client
+	Log    logr.Logger
+
+	recorder record.EventRecorder
+	scheme   *runtime.Scheme
+}
+
+// SetupWithManager creates a new controller for a manager.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	_, err := ctrl.NewControllerManagedBy(mgr).
+		For(&machinev1.MachineSet{}).
+		WithOptions(options).
+		Build(r)
+
+	if err != nil {
+		return fmt.Errorf("failed setting up with a controller manager: %w", err)
+	}
+
+	r.recorder = mgr.GetEventRecorderFor("machineset-controller")
+	r.scheme = mgr.GetScheme()
+	return nil
+}
+
+// Reconcile implements controller runtime Reconciler interface.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := r.Log.WithValues("machineset", req.Name, "namespace", req.Namespace)
+	logger.V(3).Info("Reconciling")
+
+	machineSet := &machinev1.MachineSet{}
+	if err := r.Client.Get(ctx, req.NamespacedName, machineSet); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return. Created objects are automatically garbage collected.
+			// For additional cleanup logic use finalizers.
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
+	}
+
+	// Ignore deleted MachineSets, this can happen when foregroundDeletion
+	// is enabled
+	if !machineSet.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+	originalMachineSetToPatch := client.MergeFrom(machineSet.DeepCopy())
+
+	result, err := reconcile(machineSet)
+	if err != nil {
+		logger.Error(err, "Failed to reconcile MachineSet")
+		r.recorder.Eventf(machineSet, corev1.EventTypeWarning, "ReconcileError", "%v", err)
+		// we don't return here so we want to attempt to patch the machine regardless of an error.
+	}
+
+	if err := r.Client.Patch(ctx, machineSet, originalMachineSetToPatch); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to patch machineSet: %v", err)
+	}
+
+	if isInvalidConfigurationError(err) {
+		// For situations where requeuing won't help we don't return error.
+		// https://github.com/kubernetes-sigs/controller-runtime/issues/617
+		return result, nil
+	}
+
+	return result, err
+}
+
+func isInvalidConfigurationError(err error) bool {
+	switch t := err.(type) {
+	case *mapierrors.MachineError:
+		if t.Reason == machinev1.InvalidConfigurationMachineError {
+			return true
+		}
+	}
+	return false
+}
+
+func reconcile(machineSet *machinev1.MachineSet) (ctrl.Result, error) {
+	providerConfig, err := providerconfigv1.ProviderSpecFromRawExtension(machineSet.Spec.Template.Spec.ProviderSpec.Value)
+	if err != nil {
+		return ctrl.Result{}, mapierrors.InvalidMachineConfiguration("failed to get providerConfig: %v", err)
+	}
+
+	if machineSet.Annotations == nil {
+		machineSet.Annotations = make(map[string]string)
+	}
+
+	// TODO: get annotations keys from machine API
+	machineSet.Annotations[cpuKey] = strconv.FormatInt(int64(providerConfig.NumCPUs), 10)
+	machineSet.Annotations[memoryKey] = strconv.FormatInt(providerConfig.MemoryMiB, 10)
+
+	return ctrl.Result{}, nil
+}

--- a/pkg/controller/vsphere/machineset/controller_suite_test.go
+++ b/pkg/controller/vsphere/machineset/controller_suite_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	timeout = 10 * time.Second
+)
+
+var (
+	cfg     *rest.Config
+	testEnv *envtest.Environment
+
+	ctx = context.Background()
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "install")},
+	}
+	machinev1.AddToScheme(scheme.Scheme)
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	Expect(testEnv.Stop()).To(Succeed())
+})
+
+// StartTestManager adds recFn
+func StartTestManager(mgr manager.Manager) context.CancelFunc {
+	mgrCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		defer GinkgoRecover()
+
+		Expect(mgr.Start(mgrCtx)).To(Succeed())
+	}()
+	return cancel
+}

--- a/pkg/controller/vsphere/machineset/controller_test.go
+++ b/pkg/controller/vsphere/machineset/controller_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	gtypes "github.com/onsi/gomega/types"
+	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+	providerconfigv1 "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("Reconciler", func() {
+	var c client.Client
+	var stopMgr context.CancelFunc
+	var fakeRecorder *record.FakeRecorder
+	var namespace *corev1.Namespace
+
+	BeforeEach(func() {
+		mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
+		Expect(err).ToNot(HaveOccurred())
+
+		r := Reconciler{
+			Client: mgr.GetClient(),
+			Log:    log.Log,
+		}
+		Expect(r.SetupWithManager(mgr, controller.Options{})).To(Succeed())
+
+		fakeRecorder = record.NewFakeRecorder(1)
+		r.recorder = fakeRecorder
+
+		c = mgr.GetClient()
+		stopMgr = StartTestManager(mgr)
+
+		namespace = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "mhc-test-"}}
+		Expect(c.Create(ctx, namespace)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(deleteMachineSets(c, namespace.Name)).To(Succeed())
+		stopMgr()
+	})
+
+	type reconcileTestCase = struct {
+		vmNumCPUs           int32
+		vmMemoryMiB         int64
+		existingAnnotations map[string]string
+		expectedAnnotations map[string]string
+		expectedEvents      []string
+	}
+
+	DescribeTable("when reconciling MachineSets", func(rtc reconcileTestCase) {
+		machineSet, err := newTestMachineSet(namespace.Name, rtc.vmNumCPUs, rtc.vmMemoryMiB, rtc.existingAnnotations)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(c.Create(ctx, machineSet)).To(Succeed())
+
+		Eventually(func() map[string]string {
+			m := &machinev1.MachineSet{}
+			key := client.ObjectKey{Namespace: machineSet.Namespace, Name: machineSet.Name}
+			err := c.Get(ctx, key, m)
+			if err != nil {
+				return nil
+			}
+			annotations := m.GetAnnotations()
+			if annotations != nil {
+				return annotations
+			}
+			// Return an empty map to distinguish between empty annotations and errors
+			return make(map[string]string)
+		}, timeout).Should(Equal(rtc.expectedAnnotations))
+
+		// Check which event types were sent
+		Eventually(fakeRecorder.Events, timeout).Should(HaveLen(len(rtc.expectedEvents)))
+		receivedEvents := []string{}
+		eventMatchers := []gtypes.GomegaMatcher{}
+		for _, ev := range rtc.expectedEvents {
+			receivedEvents = append(receivedEvents, <-fakeRecorder.Events)
+			eventMatchers = append(eventMatchers, ContainSubstring(fmt.Sprintf(" %s ", ev)))
+		}
+		Expect(receivedEvents).To(ConsistOf(eventMatchers))
+	},
+		Entry("with 2cpu 8memory", reconcileTestCase{
+			vmNumCPUs:           2,
+			vmMemoryMiB:         8192,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "2",
+				memoryKey: "8192",
+			},
+			expectedEvents: []string{},
+		}),
+		Entry("with 4cpu 16memory", reconcileTestCase{
+			vmNumCPUs:           4,
+			vmMemoryMiB:         16384,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "4",
+				memoryKey: "16384",
+			},
+			expectedEvents: []string{},
+		}),
+	)
+})
+
+func deleteMachineSets(c client.Client, namespaceName string) error {
+	machineSets := &machinev1.MachineSetList{}
+	err := c.List(ctx, machineSets, client.InNamespace(namespaceName))
+	if err != nil {
+		return err
+	}
+
+	for _, ms := range machineSets.Items {
+		err := c.Delete(ctx, &ms)
+		if err != nil {
+			return err
+		}
+	}
+
+	Eventually(func() error {
+		machineSets := &machinev1.MachineSetList{}
+		err := c.List(ctx, machineSets)
+		if err != nil {
+			return err
+		}
+		if len(machineSets.Items) > 0 {
+			return errors.New("MachineSets not deleted")
+		}
+		return nil
+	}, timeout).Should(Succeed())
+
+	return nil
+}
+
+func TestReconcile(t *testing.T) {
+	testCases := []struct {
+		name                string
+		vmNumCPUs           int32
+		vmMemoryMiB         int64
+		existingAnnotations map[string]string
+		expectedAnnotations map[string]string
+		expectErr           bool
+	}{
+		{
+			name:                "with 2cpu 8memory",
+			vmNumCPUs:           2,
+			vmMemoryMiB:         8192,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "2",
+				memoryKey: "8192",
+			},
+			expectErr: false,
+		},
+		{
+			name:                "with 4cpu 16memory",
+			vmNumCPUs:           4,
+			vmMemoryMiB:         16384,
+			existingAnnotations: make(map[string]string),
+			expectedAnnotations: map[string]string{
+				cpuKey:    "4",
+				memoryKey: "16384",
+			},
+			expectErr: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(tt)
+
+			machineSet, err := newTestMachineSet("default", tc.vmNumCPUs, tc.vmMemoryMiB, tc.existingAnnotations)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			_, err = reconcile(machineSet)
+			g.Expect(err != nil).To(Equal(tc.expectErr))
+			g.Expect(machineSet.Annotations).To(Equal(tc.expectedAnnotations))
+		})
+	}
+}
+
+func newTestMachineSet(namespace string, vmNumCPUs int32, vmMemoryMiB int64, existingAnnotations map[string]string) (*machinev1.MachineSet, error) {
+	// Copy anntotations map so we don't modify the input
+	annotations := make(map[string]string)
+	for k, v := range existingAnnotations {
+		annotations[k] = v
+	}
+
+	machineProviderSpec := &providerconfigv1.VSphereMachineProviderSpec{
+		NumCPUs:   vmNumCPUs,
+		MemoryMiB: vmMemoryMiB,
+	}
+	providerSpec, err := providerSpecFromMachine(machineProviderSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	return &machinev1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:  annotations,
+			GenerateName: "test-machineset-",
+			Namespace:    namespace,
+		},
+		Spec: machinev1.MachineSetSpec{
+			Template: machinev1.MachineTemplateSpec{
+				Spec: machinev1.MachineSpec{
+					ProviderSpec: providerSpec,
+				},
+			},
+		},
+	}, nil
+}
+
+func providerSpecFromMachine(in *providerconfigv1.VSphereMachineProviderSpec) (machinev1.ProviderSpec, error) {
+	bytes, err := json.Marshal(in)
+	if err != nil {
+		return machinev1.ProviderSpec{}, err
+	}
+	return machinev1.ProviderSpec{
+		Value: &runtime.RawExtension{Raw: bytes},
+	}, nil
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table.go
@@ -1,0 +1,110 @@
+/*
+
+Table provides a simple DSL for Ginkgo-native Table-Driven Tests
+
+The godoc documentation describes Table's API.  More comprehensive documentation (with examples!) is available at http://onsi.github.io/ginkgo#table-driven-tests
+
+*/
+
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+DescribeTable describes a table-driven test.
+
+For example:
+
+    DescribeTable("a simple table",
+        func(x int, y int, expected bool) {
+            Ω(x > y).Should(Equal(expected))
+        },
+        Entry("x > y", 1, 0, true),
+        Entry("x == y", 0, 0, false),
+        Entry("x < y", 0, 1, false),
+    )
+
+The first argument to `DescribeTable` is a string description.
+The second argument is a function that will be run for each table entry.  Your assertions go here - the function is equivalent to a Ginkgo It.
+The subsequent arguments must be of type `TableEntry`.  We recommend using the `Entry` convenience constructors.
+
+The `Entry` constructor takes a string description followed by an arbitrary set of parameters.  These parameters are passed into your function.
+
+Under the hood, `DescribeTable` simply generates a new Ginkgo `Describe`.  Each `Entry` is turned into an `It` within the `Describe`.
+
+It's important to understand that the `Describe`s and `It`s are generated at evaluation time (i.e. when Ginkgo constructs the tree of tests and before the tests run).
+
+Individual Entries can be focused (with FEntry) or marked pending (with PEntry or XEntry).  In addition, the entire table can be focused or marked pending with FDescribeTable and PDescribeTable/XDescribeTable.
+
+A description function can be passed to Entry in place of the description. The function is then fed with the entry parameters to generate the description of the It corresponding to that particular Entry.
+
+For example:
+
+	describe := func(desc string) func(int, int, bool) string {
+		return func(x, y int, expected bool) string {
+			return fmt.Sprintf("%s x=%d y=%d expected:%t", desc, x, y, expected)
+		}
+	}
+
+	DescribeTable("a simple table",
+		func(x int, y int, expected bool) {
+			Ω(x > y).Should(Equal(expected))
+		},
+		Entry(describe("x > y"), 1, 0, true),
+		Entry(describe("x == y"), 0, 0, false),
+		Entry(describe("x < y"), 0, 1, false),
+	)
+*/
+func DescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeNone)
+	return true
+}
+
+/*
+You can focus a table with `FDescribeTable`.  This is equivalent to `FDescribe`.
+*/
+func FDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypeFocused)
+	return true
+}
+
+/*
+You can mark a table as pending with `PDescribeTable`.  This is equivalent to `PDescribe`.
+*/
+func PDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+/*
+You can mark a table as pending with `XDescribeTable`.  This is equivalent to `XDescribe`.
+*/
+func XDescribeTable(description string, itBody interface{}, entries ...TableEntry) bool {
+	describeTable(description, itBody, entries, types.FlagTypePending)
+	return true
+}
+
+func describeTable(description string, itBody interface{}, entries []TableEntry, flag types.FlagType) {
+	itBodyValue := reflect.ValueOf(itBody)
+	if itBodyValue.Kind() != reflect.Func {
+		panic(fmt.Sprintf("DescribeTable expects a function, got %#v", itBody))
+	}
+
+	global.Suite.PushContainerNode(
+		description,
+		func() {
+			for _, entry := range entries {
+				entry.generateIt(itBodyValue)
+			}
+		},
+		flag,
+		codelocation.New(2),
+	)
+}

--- a/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
+++ b/vendor/github.com/onsi/ginkgo/extensions/table/table_entry.go
@@ -1,0 +1,129 @@
+package table
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/ginkgo/internal/codelocation"
+	"github.com/onsi/ginkgo/internal/global"
+	"github.com/onsi/ginkgo/types"
+)
+
+/*
+TableEntry represents an entry in a table test.  You generally use the `Entry` constructor.
+*/
+type TableEntry struct {
+	Description  interface{}
+	Parameters   []interface{}
+	Pending      bool
+	Focused      bool
+	codeLocation types.CodeLocation
+}
+
+func (t TableEntry) generateIt(itBody reflect.Value) {
+	var description string
+	descriptionValue := reflect.ValueOf(t.Description)
+	switch descriptionValue.Kind() {
+	case reflect.String:
+		description = descriptionValue.String()
+	case reflect.Func:
+		values := castParameters(descriptionValue, t.Parameters)
+		res := descriptionValue.Call(values)
+		if len(res) != 1 {
+			panic(fmt.Sprintf("The describe function should return only a value, returned %d", len(res)))
+		}
+		if res[0].Kind() != reflect.String {
+			panic(fmt.Sprintf("The describe function should return a string, returned %#v", res[0]))
+		}
+		description = res[0].String()
+	default:
+		panic(fmt.Sprintf("Description can either be a string or a function, got %#v", descriptionValue))
+	}
+
+	if t.Pending {
+		global.Suite.PushItNode(description, func() {}, types.FlagTypePending, t.codeLocation, 0)
+		return
+	}
+
+	values := castParameters(itBody, t.Parameters)
+	body := func() {
+		itBody.Call(values)
+	}
+
+	if t.Focused {
+		global.Suite.PushItNode(description, body, types.FlagTypeFocused, t.codeLocation, global.DefaultTimeout)
+	} else {
+		global.Suite.PushItNode(description, body, types.FlagTypeNone, t.codeLocation, global.DefaultTimeout)
+	}
+}
+
+func castParameters(function reflect.Value, parameters []interface{}) []reflect.Value {
+	res := make([]reflect.Value, len(parameters))
+	funcType := function.Type()
+	for i, param := range parameters {
+		if param == nil {
+			inType := funcType.In(i)
+			res[i] = reflect.Zero(inType)
+		} else {
+			res[i] = reflect.ValueOf(param)
+		}
+	}
+	return res
+}
+
+/*
+Entry constructs a TableEntry.
+
+The first argument is a required description (this becomes the content of the generated Ginkgo `It`).
+Subsequent parameters are saved off and sent to the callback passed in to `DescribeTable`.
+
+Each Entry ends up generating an individual Ginkgo It.
+*/
+func Entry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can focus a particular entry with FEntry.  This is equivalent to FIt.
+*/
+func FEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      false,
+		Focused:      true,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with PEntry.  This is equivalent to PIt.
+*/
+func PEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}
+
+/*
+You can mark a particular entry as pending with XEntry.  This is equivalent to XIt.
+*/
+func XEntry(description interface{}, parameters ...interface{}) TableEntry {
+	return TableEntry{
+		Description:  description,
+		Parameters:   parameters,
+		Pending:      true,
+		Focused:      false,
+		codeLocation: codelocation.New(1),
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,6 +115,7 @@ github.com/nxadm/tail/winfile
 # github.com/onsi/ginkgo v1.14.1
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
+github.com/onsi/ginkgo/extensions/table
 github.com/onsi/ginkgo/internal/codelocation
 github.com/onsi/ginkgo/internal/containernode
 github.com/onsi/ginkgo/internal/failer


### PR DESCRIPTION
This PR adds a new controller to annotate machinesets with information required to enable autoscaling to/from zero based on providerSpec input based on openshift/enhancements#186.

Analogous to openshift/cluster-api-provider-aws#301, openshift/cluster-api-provider-azure#112 and openshift/cluster-api-provider-gcp#77.