### PR TITLE
Bug 1918307: backported vmsizes and closing response body to 4.6 in cluster-api-provider-azure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,4 +38,4 @@ require (
 
 replace sigs.k8s.io/cluster-api-provider-aws => github.com/openshift/cluster-api-provider-aws v0.2.1-0.20200929152424-eab2e087f366
 
-replace sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20201119004617-db9109863f2f
+replace sigs.k8s.io/cluster-api-provider-azure => github.com/openshift/cluster-api-provider-azure v0.1.0-alpha.3.0.20210324211250-7a14c7f1a41a


### PR DESCRIPTION
Updating to newest commit in release-4.6 branch of cluster-api-provider-azure.