### PR TITLE
Add management workload annotations

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   name: openshift-machine-api
   labels:
     name: openshift-machine-api

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -16,6 +16,8 @@ spec:
       k8s-app: machine-api-operator
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: machine-api-operator
     spec:

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -48,6 +48,10 @@ var (
 	// daemonsetMaxUnavailable must be set to "10%" to conform with other
 	// daemonsets.
 	daemonsetMaxUnavailable = intstr.FromString("10%")
+
+	commonPodTemplateAnnotations = map[string]string{
+		"target.workload.openshift.io/management": `{"effect": "PreferredDuringScheduling"}`,
+	}
 )
 
 func (optr *Operator) syncAll(config *OperatorConfig) error {
@@ -428,6 +432,7 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: commonPodTemplateAnnotations,
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "controller",
@@ -706,6 +711,7 @@ func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSp
 
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
+			Annotations: commonPodTemplateAnnotations,
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "termination-handler",


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.