### PR TITLE
Bug 1948471: Add release inclusion annotations to external remediation cluster role

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -399,6 +399,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-api-operator-ext-remediation
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 aggregationRule:
   clusterRoleSelectors:
     - matchLabels: # Allowing external remediations to add their permissions


### PR DESCRIPTION
Without annotations, it appears CVO ignores the ClusterRole. Need to add these annotations and verify that CVO is in fact creating the ClusterRole