### PR TITLE
Bug 1910318: Ensure conditions are correctly copied before annotations are patched

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -476,9 +476,9 @@ func (r *ReconcileMachine) updateStatus(machine *machinev1.Machine, phase string
 		klog.V(3).Infof("%v: going into phase %q", machine.GetName(), phase)
 	}
 
-	// Conditions need to be copied as they are set outside of this function.
-	// They will be restored after any updates to the base.
-	conditions := machine.GetConditions()
+	// Conditions need to be deep copied as they are set outside of this function.
+	// They will be restored after any updates to the base (done by patching annotations).
+	conditions := machine.GetConditions().DeepCopy()
 
 	// A call to Patch will mutate our local copy of the machine to match what is stored in the API.
 	// Before we make any changes to the status subresource on our local copy, we need to patch the object first,


### PR DESCRIPTION
If we don't do a deepcopy, because the conditions list is a reference type, our new variable will be overwritten by the below update to annotations when the Machine is entering a Failed state. This results in weird mixed conditions.

I've manually tested this change on AWS and it now works as expected.