### PR TITLE
Bug 1951029: Drainer panics on missing context for node patch

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -205,7 +205,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 	}
 
 	if !m.ObjectMeta.DeletionTimestamp.IsZero() {
-		if err := r.updateStatus(m, phaseDeleting, nil, originalConditions); err != nil {
+		if err := r.updateStatus(ctx, m, phaseDeleting, nil, originalConditions); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -222,7 +222,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		// by cloud controller manager. In that case some machines would never get
 		// deleted without a manual intervention.
 		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {
-			if err := r.drainNode(m); err != nil {
+			if err := r.drainNode(ctx, m); err != nil {
 				klog.Errorf("%v: failed to drain node for machine: %v", machineName, err)
 				return delayIfRequeueAfterError(err)
 			}
@@ -262,7 +262,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 		// Remove finalizer on successful deletion.
 		m.ObjectMeta.Finalizers = util.Filter(m.ObjectMeta.Finalizers, machinev1.MachineFinalizer)
-		if err := r.Client.Update(context.Background(), m); err != nil {
+		if err := r.Client.Update(ctx, m); err != nil {
 			klog.Errorf("%v: failed to remove finalizer from machine: %v", machineName, err)
 			return reconcile.Result{}, err
 		}
@@ -286,7 +286,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 			"Failed to check if machine exists: %v", err,
 		))
 
-		if patchErr := r.updateStatus(m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+		if patchErr := r.updateStatus(ctx, m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 			klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 		}
 
@@ -298,7 +298,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		if err := r.actuator.Update(ctx, m); err != nil {
 			klog.Errorf("%v: error updating machine: %v, retrying in %v seconds", machineName, err, requeueAfter)
 
-			if patchErr := r.updateStatus(m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+			if patchErr := r.updateStatus(ctx, m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 				klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 			}
 
@@ -310,7 +310,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 		if !machineIsProvisioned(m) {
 			klog.Errorf("%v: instance exists but providerID or addresses has not been given to the machine yet, requeuing", machineName)
-			if patchErr := r.updateStatus(m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
+			if patchErr := r.updateStatus(ctx, m, pointer.StringPtrDerefOr(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 				klog.Errorf("%v: error patching status: %v", machineName, patchErr)
 			}
 
@@ -319,14 +319,14 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 		if !machineHasNode(m) {
 			// Requeue until we reach running phase
-			if err := r.updateStatus(m, phaseProvisioned, nil, originalConditions); err != nil {
+			if err := r.updateStatus(ctx, m, phaseProvisioned, nil, originalConditions); err != nil {
 				return reconcile.Result{}, err
 			}
 			klog.Infof("%v: has no node yet, requeuing", machineName)
 			return reconcile.Result{RequeueAfter: requeueAfter}, nil
 		}
 
-		return reconcile.Result{}, r.updateStatus(m, phaseRunning, nil, originalConditions)
+		return reconcile.Result{}, r.updateStatus(ctx, m, phaseRunning, nil, originalConditions)
 	}
 
 	// Instance does not exist but the machine has been given a providerID/address.
@@ -339,7 +339,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 			"Instance not found on provider",
 		))
 
-		if err := r.updateStatus(m, phaseFailed, errors.New("Can't find created instance."), originalConditions); err != nil {
+		if err := r.updateStatus(ctx, m, phaseFailed, errors.New("Can't find created instance."), originalConditions); err != nil {
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{}, nil
@@ -353,14 +353,14 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 	))
 
 	// Machine resource created and instance does not exist yet.
-	if err := r.updateStatus(m, phaseProvisioning, nil, originalConditions); err != nil {
+	if err := r.updateStatus(ctx, m, phaseProvisioning, nil, originalConditions); err != nil {
 		return reconcile.Result{}, err
 	}
 	klog.Infof("%v: reconciling machine triggers idempotent create", machineName)
 	if err := r.actuator.Create(ctx, m); err != nil {
 		klog.Warningf("%v: failed to create machine: %v", machineName, err)
 		if isInvalidMachineConfigurationError(err) {
-			if err := r.updateStatus(m, phaseFailed, err, originalConditions); err != nil {
+			if err := r.updateStatus(ctx, m, phaseFailed, err, originalConditions); err != nil {
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
@@ -372,12 +372,12 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
 }
 
-func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
+func (r *ReconcileMachine) drainNode(ctx context.Context, machine *machinev1.Machine) error {
 	kubeClient, err := kubernetes.NewForConfig(r.config)
 	if err != nil {
 		return fmt.Errorf("unable to build kube client: %v", err)
 	}
-	node, err := kubeClient.CoreV1().Nodes().Get(context.Background(), machine.Status.NodeRef.Name, metav1.GetOptions{})
+	node, err := kubeClient.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// If an admin deletes the node directly, we'll end up here.
@@ -388,6 +388,7 @@ func (r *ReconcileMachine) drainNode(machine *machinev1.Machine) error {
 	}
 
 	drainer := &drain.Helper{
+		Ctx:                 ctx,
 		Client:              kubeClient,
 		Force:               true,
 		IgnoreAllDaemonSets: true,
@@ -471,7 +472,7 @@ func isInvalidMachineConfigurationError(err error) bool {
 // updateStatus is intended to ensure that the status of the Machine reflects the input to this function.
 // Because the conditions are set on the machine outside of this function, we must pass the original state of the
 // machine conditions so that the diff can be calculated properly within this function.
-func (r *ReconcileMachine) updateStatus(machine *machinev1.Machine, phase string, failureCause error, originalConditions []machinev1.Condition) error {
+func (r *ReconcileMachine) updateStatus(ctx context.Context, machine *machinev1.Machine, phase string, failureCause error, originalConditions []machinev1.Condition) error {
 	if stringPointerDeref(machine.Status.Phase) != phase {
 		klog.V(3).Infof("%v: going into phase %q", machine.GetName(), phase)
 	}
@@ -484,7 +485,7 @@ func (r *ReconcileMachine) updateStatus(machine *machinev1.Machine, phase string
 	// Before we make any changes to the status subresource on our local copy, we need to patch the object first,
 	// otherwise our local changes to the status subresource will be lost.
 	if phase == phaseFailed {
-		err := r.patchFailedMachineInstanceAnnotation(machine)
+		err := r.patchFailedMachineInstanceAnnotation(ctx, machine)
 		if err != nil {
 			klog.Errorf("Failed to update machine %q: %v", machine.GetName(), err)
 			return err
@@ -528,7 +529,7 @@ func (r *ReconcileMachine) updateStatus(machine *machinev1.Machine, phase string
 		machine.Status.LastUpdated = &now
 	}
 
-	if err := r.Client.Status().Patch(context.Background(), machine, baseToPatch); err != nil {
+	if err := r.Client.Status().Patch(ctx, machine, baseToPatch); err != nil {
 		klog.Errorf("Failed to update machine status %q: %v", machine.GetName(), err)
 		return err
 	}
@@ -545,13 +546,13 @@ func (r *ReconcileMachine) updateStatus(machine *machinev1.Machine, phase string
 	return nil
 }
 
-func (r *ReconcileMachine) patchFailedMachineInstanceAnnotation(machine *machinev1.Machine) error {
+func (r *ReconcileMachine) patchFailedMachineInstanceAnnotation(ctx context.Context, machine *machinev1.Machine) error {
 	baseToPatch := client.MergeFrom(machine.DeepCopy())
 	if machine.Annotations == nil {
 		machine.Annotations = map[string]string{}
 	}
 	machine.Annotations[MachineInstanceStateAnnotationName] = unknownInstanceState
-	if err := r.Client.Patch(context.Background(), machine, baseToPatch); err != nil {
+	if err := r.Client.Patch(ctx, machine, baseToPatch); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -475,7 +475,7 @@ func TestUpdateStatus(t *testing.T) {
 			}
 
 			// Set the phase to Running initially
-			g.Expect(reconciler.updateStatus(machine, phaseRunning, nil, machinev1.Conditions{})).To(Succeed())
+			g.Expect(reconciler.updateStatus(context.TODO(), machine, phaseRunning, nil, machinev1.Conditions{})).To(Succeed())
 			// validate persisted object
 			got := machinev1.Machine{}
 			g.Expect(reconciler.Client.Get(context.TODO(), namespacedName, &got)).To(Succeed())
@@ -500,7 +500,7 @@ func TestUpdateStatus(t *testing.T) {
 				c := cond
 				conditions.Set(machine, &c)
 			}
-			g.Expect(reconciler.updateStatus(machine, tc.phase, tc.err, gotConditions)).To(Succeed())
+			g.Expect(reconciler.updateStatus(context.TODO(), machine, tc.phase, tc.err, gotConditions)).To(Succeed())
 			// validate the persisted object
 			got = machinev1.Machine{}
 			g.Expect(reconciler.Client.Get(context.TODO(), namespacedName, &got)).To(Succeed())


### PR DESCRIPTION
Fixed all missing places where context was not passed to client call or draining call.

Fixes this panic in draining as node update requires context to be passed:
```
I0416 15:31:44.531825       1 machine_scope.go:102] ci-op-06xhm87t-34603-vts6z-worker-hpnrd: patching machine
I0416 15:31:44.531960       1 recorder.go:104] controller-runtime/manager/events "msg"="Normal"  "message"="Updated Machine ci-op-06xhm87t-34603-vts6z-worker-hpnrd" "object"={"kind":"Machine","namespace":"openshift-machine-api","name":"ci-op-06xhm87t-34603-vts6z-worker-hpnrd","uid":"19099d27-ae2b-42f4-a5e0-7b567ba03f27","apiVersion":"machine.openshift.io/v1beta1","resourceVersion":"40829"} "reason"="Update"
I0416 15:31:44.566238       1 controller.go:174] ci-op-06xhm87t-34603-vts6zvcp6t-sjxkf: reconciling Machine
I0416 15:31:44.576283       1 controller.go:218] ci-op-06xhm87t-34603-vts6zvcp6t-sjxkf: reconciling machine triggers delete
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0xc204fa]
goroutine 507 [running]:
golang.org/x/time/rate.(*Limiter).WaitN(0xc0007d74f0, 0x0, 0x0, 0x1, 0x0, 0x0)
        /go/src/github.com/openshift/machine-api-operator/vendor/golang.org/x/time/rate/rate.go:237 +0xba
golang.org/x/time/rate.(*Limiter).Wait(...)
        /go/src/github.com/openshift/machine-api-operator/vendor/golang.org/x/time/rate/rate.go:219
k8s.io/client-go/util/flowcontrol.(*tokenBucketRateLimiter).Wait(0xc000c0cca0, 0x0, 0x0, 0xc000eca300, 0x98)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/util/flowcontrol/throttle.go:106 +0x4b
k8s.io/client-go/rest.(*Request).tryThrottleWithInfo(0xc0009f6780, 0x0, 0x0, 0x0, 0x0, 0x0, 0xc000231340)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/rest/request.go:587 +0xa5
k8s.io/client-go/rest.(*Request).tryThrottle(...)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/rest/request.go:613
k8s.io/client-go/rest.(*Request).request(0xc0009f6780, 0x0, 0x0, 0xc0002314b8, 0x0, 0x0)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/rest/request.go:873 +0x2bc
k8s.io/client-go/rest.(*Request).Do(0xc0009f6780, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/rest/request.go:980 +0xf1
k8s.io/client-go/kubernetes/typed/core/v1.(*nodes).Patch(0xc000c27840, 0x0, 0x0, 0xc000b8c2a0, 0x25, 0x2283879, 0x26, 0xc000e9e440, 0x1f, 0x20, ...)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/client-go/kubernetes/typed/core/v1/node.go:186 +0x237
k8s.io/kubectl/pkg/drain.(*CordonHelper).PatchOrReplaceWithContext(0xc0002318a8, 0x0, 0x0, 0x25763c0, 0xc0007c66e0, 0x3589100, 0xc000addbf0, 0xc, 0xc000e38be0, 0x1f)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/kubectl/pkg/drain/cordon.go:102 +0x416
k8s.io/kubectl/pkg/drain.RunCordonOrUncordon(0xc000e345b0, 0xc000dea000, 0xc000126301, 0xc000643200, 0x25)
        /go/src/github.com/openshift/machine-api-operator/vendor/k8s.io/kubectl/pkg/drain/default.go:60 +0xbf
github.com/openshift/machine-api-operator/pkg/controller/machine.(*ReconcileMachine).drainNode(0xc000386370, 0xc00076e400, 0x228d9c8, 0x2a)
        /go/src/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go:420 +0x49a
github.com/openshift/machine-api-operator/pkg/controller/machine.(*ReconcileMachine).Reconcile(0xc000386370, 0x254b420, 0xc000fae180, 0xc00023e7e0, 0x15, 0xc0003ef560, 0x25, 0xc000fae180, 0x40a1bf, 0xc0004c4000, ...)
        /go/src/github.com/openshift/machine-api-operator/pkg/controller/machine/controller.go:225 +0x2db1
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004ebae0, 0x254b360, 0xc0006f3180, 0x1f8ed20, 0xc0004530e0)
        /go/src/github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:298 +0x317
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004ebae0, 0x254b360, 0xc0006f3180, 0x0)
        /go/src/github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:253 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc000ba9260, 0xc0004ebae0, 0x254b360, 0xc0006f3180)
        /go/src/github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:214 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        /go/src/github.com/openshift/machine-api-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:210 +0x46b
```