### PR TITLE
Bug 1934555: Use static restmapper (with dynamic fallback) with manager clients

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -10,7 +10,9 @@ import (
 
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -79,7 +81,12 @@ func main() {
 		klog.Fatal(err)
 	}
 
+	sch := scheme.Scheme
+	mapperProvider := util.NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(sch)
+
 	opts := manager.Options{
+		Scheme:                  sch,
+		MapperProvider:          mapperProvider,
 		MetricsBindAddress:      *metricsAddress,
 		HealthProbeBindAddress:  *healthAddr,
 		LeaderElection:          *leaderElect,

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/openshift/machine-api-operator/pkg/controller"
 	"github.com/openshift/machine-api-operator/pkg/controller/machineset"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
+	"github.com/openshift/machine-api-operator/pkg/util"
+	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -100,7 +102,12 @@ func main() {
 
 	// Create a new Cmd to provide shared dependencies and start components
 	syncPeriod := 10 * time.Minute
+	sch := scheme.Scheme
+	mapperProvider := util.NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(sch)
+
 	opts := manager.Options{
+		Scheme:                  sch,
+		MapperProvider:          mapperProvider,
 		MetricsBindAddress:      *metricsAddress,
 		SyncPeriod:              &syncPeriod,
 		Namespace:               *watchNamespace,

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -8,7 +8,9 @@ import (
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
 	"github.com/openshift/machine-api-operator/pkg/controller/nodelink"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -65,7 +67,12 @@ func main() {
 		klog.Fatal(err)
 	}
 
+	sch := scheme.Scheme
+	mapperProvider := util.NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(sch)
+
 	opts := manager.Options{
+		Scheme:         sch,
+		MapperProvider: mapperProvider,
 		// Disable metrics serving
 		MetricsBindAddress:      "0",
 		LeaderElection:          *leaderElect,

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -13,7 +13,9 @@ import (
 	machine "github.com/openshift/machine-api-operator/pkg/controller/vsphere"
 	machinesetcontroller "github.com/openshift/machine-api-operator/pkg/controller/vsphere/machineset"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	"github.com/openshift/machine-api-operator/pkg/version"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -80,8 +82,12 @@ func main() {
 
 	cfg := config.GetConfigOrDie()
 	syncPeriod := 10 * time.Minute
+	sch := scheme.Scheme
+	mapperProvider := util.NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(sch)
 
 	opts := manager.Options{
+		Scheme:                  sch,
+		MapperProvider:          mapperProvider,
 		MetricsBindAddress:      *metricsAddress,
 		HealthProbeBindAddress:  *healthAddr,
 		SyncPeriod:              &syncPeriod,

--- a/pkg/util/rest_mapper.go
+++ b/pkg/util/rest_mapper.go
@@ -1,0 +1,51 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewDefaultWithLazyFallbackRESTMapper creates a rest mapper from the scheme.Scheme which will
+// fall back to a lazy dynamic rest mapper if an object is not registered in the scheme.
+func NewDefaultWithLazyFallbackRESTMapper(cfg *rest.Config) (meta.RESTMapper, error) {
+	return NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(scheme.Scheme)(cfg)
+}
+
+// NewDefaultWithLazyFallbackRESTMapperProviderFromScheme creates a rest mapper provider from the scheme which will
+// fall back to a lazy dynamic rest mapper if an object is not registered in the scheme.
+func NewDefaultWithLazyFallbackRESTMapperProviderFromScheme(sch *runtime.Scheme) func(*rest.Config) (meta.RESTMapper, error) {
+	return func(cfg *rest.Config) (meta.RESTMapper, error) {
+		lazyDynamicRestMapper, err := apiutil.NewDynamicRESTMapper(cfg, apiutil.WithLazyDiscovery)
+		if err != nil {
+			return nil, fmt.Errorf("could not initialise dynamic rest mapper: %v", err)
+		}
+
+		mapper := meta.NewDefaultRESTMapper(sch.PreferredVersionAllGroups())
+		return meta.FirstHitRESTMapper{
+			MultiRESTMapper: meta.MultiRESTMapper{
+				mapper,
+				lazyDynamicRestMapper,
+			},
+		}, nil
+	}
+}


### PR DESCRIPTION
This replaces the dynamic restmapper that is used in controller runtime with a static restmapper, based on the runtime.Scheme, which then falls back to a dynamic (lazy) rest mapper in case we missed anything in the mapper provider (ie if we forgot to add anything to the scheme).

This should reduce the surge of API requests our controllers make on startup.