### PR TITLE
Bug 1954610: Update GCP default image to match 4.7 release

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -93,10 +93,9 @@ const (
 	defaultGCPCredentialsSecret = "gcp-cloud-credentials"
 	defaultGCPDiskSizeGb        = 128
 	defaultGCPDiskType          = "pd-standard"
-	// https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.6/46.82.202007212240-0/x86_64/meta.json
-	// https://github.com/openshift/installer/pull/3808
-	// https://github.com/openshift/installer/blob/d75bf7ad98124b901ae7e22b5595e0392ed6ea3c/data/data/rhcos.json
-	defaultGCPDiskImage = "projects/rhcos-cloud/global/images/rhcos-46-82-202007212240-0-gcp-x86-64"
+	// https://releases-art-rhcos.svc.ci.openshift.org/art/storage/releases/rhcos-4.7/47.83.202103251640-0/x86_64/meta.json
+	// https://github.com/openshift/installer/blob/fae650e24e7036b333b2b2d9dfb5a08a29cd07b1/data/data/rhcos.json#L93-L97
+	defaultGCPDiskImage = "projects/rhcos-cloud/global/images/rhcos-47-83-202103251640-0-gcp-x86-64"
 
 	// vSphere Defaults
 	defaultVSphereCredentialsSecret = "vsphere-cloud-credentials"


### PR DESCRIPTION
4.7 clusters set up an ignition v3 stub, which doesn't work with the default 4.6 image as it supports v2.2 as a maximum version.

This should fix the defaulting and in turn, the broken GCP operator suite.