### PR TITLE
Bug 1955554: Webhook filter should check for both mutating and validating webhooks

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -263,7 +263,7 @@ func isMachineWebhook(obj interface{}) bool {
 		return mutatingWebhook.Name == "machine-api"
 	}
 
-	validatingWebhook, ok := obj.(*admissionregistrationv1.MutatingWebhookConfiguration)
+	validatingWebhook, ok := obj.(*admissionregistrationv1.ValidatingWebhookConfiguration)
 	if ok {
 		return validatingWebhook.Name == "machine-api"
 	}


### PR DESCRIPTION
This filter is meant to check if either mutating or validating webhooks are modified, except it was checking for mutating webhooks twice. This meant that our operator wasn't actually reacting to events triggered by validating webhooks.

This explains why the validating webhook tests are so flaky and take a long period to complete even when they do pass.