### PR TITLE
Bug 1954177: add constant variables back into machine v1beta1

### DIFF
--- a/pkg/apis/machine/v1beta1/consts.go
+++ b/pkg/apis/machine/v1beta1/consts.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package v1beta1
 
+// Constants aren't automatically generated for unversioned packages.
+// Instead share the same constant for all versioned packages
+type MachineStatusError string
+
 const (
 	// Represents that the combination of configuration in the MachineSpec
 	// is not supported by this cluster. This is not a transient error, but
@@ -23,6 +27,20 @@ const (
 	//
 	// Example: the ProviderSpec specifies an instance type that doesn't exist,
 	InvalidConfigurationMachineError MachineStatusError = "InvalidConfiguration"
+
+	// This indicates that the MachineSpec has been updated in a way that
+	// is not supported for reconciliation on this cluster. The spec may be
+	// completely valid from a configuration standpoint, but the controller
+	// does not support changing the real world state to match the new
+	// spec.
+	//
+	// Example: the responsible controller is not capable of changing the
+	// container runtime from docker to rkt.
+	UnsupportedChangeMachineError MachineStatusError = "UnsupportedChange"
+
+	// This generally refers to exceeding one's quota in a cloud provider,
+	// or running out of physical machines in an on-premise environment.
+	InsufficientResourcesMachineError MachineStatusError = "InsufficientResources"
 
 	// There was an error while trying to create a Node to match this
 	// Machine. This may indicate a transient problem that will be fixed
@@ -48,17 +66,68 @@ const (
 	// Example: cannot resolve EC2 IP address.
 	DeleteMachineError MachineStatusError = "DeleteError"
 
-	// TemplateClonedFromGroupKindAnnotation is the infrastructure machine annotation that stores the group-kind of the infrastructure template resource
-	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
+	// TemplateClonedFromGroupKindAnnotation is the infrastructure machine
+	// annotation that stores the group-kind of the infrastructure template resource
+	// that was cloned for the machine. This annotation is set only during cloning a
+	// template. Older/adopted machines will not have this annotation.
 	TemplateClonedFromGroupKindAnnotation = "machine.openshift.io/cloned-from-groupkind"
 
-	// TemplateClonedFromNameAnnotation is the infrastructure machine annotation that stores the name of the infrastructure template resource
-	// that was cloned for the machine. This annotation is set only during cloning a template. Older/adopted machines will not have this annotation.
+	// TemplateClonedFromNameAnnotation is the infrastructure machine annotation that
+	// stores the name of the infrastructure template resource
+	// that was cloned for the machine. This annotation is set only during cloning a
+	//  template. Older/adopted machines will not have this annotation.
 	TemplateClonedFromNameAnnotation = "machine.openshift.io/cloned-from-name"
+
+	// This error indicates that the machine did not join the cluster
+	// as a new node within the expected timeframe after instance
+	// creation at the provider succeeded
+	//
+	// Example use case: A controller that deletes Machines which do
+	// not result in a Node joining the cluster within a given timeout
+	// and that are managed by a MachineSet
+	JoinClusterTimeoutMachineError = "JoinClusterTimeoutError"
 )
 
-// Constants aren't automatically generated for unversioned packages.
-// Instead share the same constant for all versioned packages
-type MachineStatusError string
+type ClusterStatusError string
+
+const (
+	// InvalidConfigurationClusterError indicates that the cluster
+	// configuration is invalid.
+	InvalidConfigurationClusterError ClusterStatusError = "InvalidConfiguration"
+
+	// UnsupportedChangeClusterError indicates that the cluster
+	// spec has been updated in an unsupported way. That cannot be
+	// reconciled.
+	UnsupportedChangeClusterError ClusterStatusError = "UnsupportedChange"
+
+	// CreateClusterError indicates that an error was encountered
+	// when trying to create the cluster.
+	CreateClusterError ClusterStatusError = "CreateError"
+
+	// UpdateClusterError indicates that an error was encountered
+	// when trying to update the cluster.
+	UpdateClusterError ClusterStatusError = "UpdateError"
+
+	// DeleteClusterError indicates that an error was encountered
+	// when trying to delete the cluster.
+	DeleteClusterError ClusterStatusError = "DeleteError"
+)
 
 type MachineSetStatusError string
+
+const (
+	// Represents that the combination of configuration in the MachineTemplateSpec
+	// is not supported by this cluster. This is not a transient error, but
+	// indicates a state that must be fixed before progress can be made.
+	//
+	// Example: the ProviderSpec specifies an instance type that doesn't exist.
+	InvalidConfigurationMachineSetError MachineSetStatusError = "InvalidConfiguration"
+)
+
+type MachineDeploymentStrategyType string
+
+const (
+	// Replace the old MachineSet by new one using rolling update
+	// i.e. gradually scale down the old MachineSet and scale up the new one.
+	RollingUpdateMachineDeploymentStrategyType MachineDeploymentStrategyType = "RollingUpdate"
+)


### PR DESCRIPTION
These constants were removed during a cleanup, but some of them are
being used by external dependencies. This change adds them back in
with the newer changes.