### PR TITLE
Correct doc namespace err and misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can see it in action by running an [OpenShift Cluster deployed by the Instal
 
 However you can run it in a vanilla Kubernetes cluster by precreating some assets:
 
-- Create a `openshift-machine-api-operator` namespace
+- Create a `openshift-machine-api` namespace
 - Create a [CRD Status definition](config/0000_00_cluster-version-operator_01_clusteroperator.crd.yaml)
 - Create a [CRD Machine definition](install/0000_30_machine-api-operator_02_machine.crd.yaml)
 - Create a [CRD MachineSet definition](install/0000_30_machine-api-operator_03_machineset.crd.yaml)

--- a/docs/dev/hacking-guide.md
+++ b/docs/dev/hacking-guide.md
@@ -63,7 +63,7 @@ You may want to run unit tests before pushing changes. It can be done in a simil
 
 Prerequisite:
 ```
-git checkout github.com/openshit/$repository_name
+git checkout github.com/openshift/$repository_name
 cd $repository_name
 ```
 In order to run the unit tests locally on your machine run the following command:
@@ -78,7 +78,7 @@ If this command is run inside a cloud provider repository you will run only clou
 ### Running machine controller
 Prerequisites:
 ```
-git checkout github.com/openshit/$repository_name
+git checkout github.com/openshift/$repository_name
 cd $repository_name
 ```
 Make sure your $KUBECONFIG is set properly, because it will be used to interact with your cluster.
@@ -120,7 +120,7 @@ The section is inspired by [this](https://notes.elmiko.dev/2020/08/18/tips-exper
 
 Prerequisites:
 ```
-git checkout github.com/openshit/$repository_name
+git checkout github.com/openshift/$repository_name
 cd $repository_name
 ```
 
@@ -207,7 +207,7 @@ machine-api-operator is vendored in every provider repository.
 ```
 git checkout github.com/openshfit/$provider_repository_name
 cd $provider_repository_name
-go get github.com/openshit/machine-api-operator@master
+go get github.com/openshift/machine-api-operator@master
 make vendor
 ```
 


### PR DESCRIPTION
I believe this Dev instruction in the readme : 

- Create a `openshift-machine-api-operator` namespace

aught to be this namespace instead:

- Create a `openshift-machine-api` namespace

small update