### PR TITLE
Fixing label from clutserapi to clusterapi

### DIFF
--- a/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
+++ b/install/0000_30_machine-api-operator_13_machinehealthcheck.yaml
@@ -5,7 +5,7 @@ metadata:
   name: machine-api-termination-handler
   namespace: openshift-machine-api
   labels:
-    api: clsuterapi
+    api: clusterapi
     k8s-app: termination-handler
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"


### PR DESCRIPTION
Since the MachineHealthCheck object does not allow modifying default labels manually, hence I would like to fix this in it's resource yaml itself.