### PR TITLE
Bug 1967662: change provider config to look at PlatformStatus.Type

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -50,10 +50,12 @@ type Images struct {
 }
 
 func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.PlatformType, error) {
-	if infra.Status.Platform == "" {
-		return "", fmt.Errorf("no platform provider found on install config")
+	if infra.Status.PlatformStatus != nil {
+		if infra.Status.PlatformStatus.Type != "" {
+			return infra.Status.PlatformStatus.Type, nil
+		}
 	}
-	return infra.Status.Platform, nil
+	return "", fmt.Errorf("no platform provider found on install config")
 }
 
 func getImagesFromJSONFile(filePath string) (*Images, error) {

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -28,78 +28,106 @@ func TestGetProviderFromInfrastructure(t *testing.T) {
 	}{{
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.AWSPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AWSPlatformType,
+				},
 			},
 		},
 		expected: configv1.AWSPlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.LibvirtPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.LibvirtPlatformType,
+				},
 			},
 		},
 		expected: configv1.LibvirtPlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.OpenStackPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.OpenStackPlatformType,
+				},
 			},
 		},
 		expected: configv1.OpenStackPlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.AzurePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.AzurePlatformType,
+				},
 			},
 		},
 		expected: configv1.AzurePlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.GCPPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.GCPPlatformType,
+				},
 			},
 		},
 		expected: configv1.GCPPlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.BareMetalPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.BareMetalPlatformType,
+				},
 			},
 		},
 		expected: configv1.BareMetalPlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: kubemarkPlatform,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: kubemarkPlatform,
+				},
 			},
 		},
 		expected: kubemarkPlatform,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.VSpherePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.VSpherePlatformType,
+				},
 			},
 		},
 		expected: configv1.VSpherePlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.NonePlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.NonePlatformType,
+				},
 			},
 		},
 		expected: configv1.NonePlatformType,
 	}, {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
-				Platform: configv1.OvirtPlatformType,
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: configv1.OvirtPlatformType,
+				},
 			},
 		},
 		expected: configv1.OvirtPlatformType,
+	}, {
+		infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				Platform: configv1.OvirtPlatformType,
+			},
+		},
+		expected: "",
 	}}
 
 	for _, test := range tests {
 		res, err := getProviderFromInfrastructure(test.infra)
-		if err != nil {
+		// empty expected string means we were expecting it to error
+		if err != nil && test.expected != "" {
 			t.Errorf("failed getProviderFromInfrastructure: %v", err)
 		}
 		if test.expected != res {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -146,7 +146,9 @@ func TestOperatorSync_NoOp(t *testing.T) {
 					Name: "cluster",
 				},
 				Status: openshiftv1.InfrastructureStatus{
-					Platform: tc.platform,
+					PlatformStatus: &openshiftv1.PlatformStatus{
+						Type: tc.platform,
+					},
 				},
 			}
 
@@ -533,7 +535,7 @@ func TestMAOConfigFromInfrastructure(t *testing.T) {
 			if tc.infra != nil {
 				inf := tc.infra.DeepCopy()
 				// Ensure platform is correct on infrastructure
-				inf.Status.Platform = tc.platform
+				inf.Status.PlatformStatus = &openshiftv1.PlatformStatus{Type: tc.platform}
 				objects = append(objects, inf)
 			}
 			if tc.proxy != nil {


### PR DESCRIPTION
As Infrastructure.Status.Platform is being deprecated, this change
switches the internal logic to look at
Infrastructure.Status.PlatformStatus.Type instead. Unit tests have been
adjusted, and an extra test for the deprecated value has been added.