### PR TITLE
install/0000_90_machine-api-operator_04_alertrules: Use '!~' for MachineWithNoRunningPhase

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -26,7 +26,7 @@ spec:
       rules:
         - alert: MachineWithNoRunningPhase
           expr: |
-            (mapi_machine_created_timestamp_seconds{phase!="Running|Deleting"}) > 0
+            (mapi_machine_created_timestamp_seconds{phase!~"Running|Deleting"}) > 0
           for: 60m
           labels:
             severity: warning


### PR DESCRIPTION
b13dbe9949 (#807) added `|Deleting`.  But to move from "not equal" to "regexp does not match" we need to match that with `!~`.

/assign @elmiko