### PR TITLE
Replace broken image references

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -10,18 +10,18 @@ metadata:
 data:
   images.json: >
     {
-      "machineAPIOperator": "registry.svc.ci.openshift.org/openshift:machine-api-operator",
-      "kubeRBACProxy": "registry.svc.ci.openshift.org/openshift:kube-rbac-proxy",
-      "clusterAPIControllerAWS": "registry.svc.ci.openshift.org/openshift:aws-machine-controllers",
-      "clusterAPIControllerAlibaba": "registry.svc.ci.openshift.org/openshift:alibaba-machine-controllers",
-      "clusterAPIControllerOpenStack": "registry.svc.ci.openshift.org/openshift:openstack-machine-controllers",
-      "clusterAPIControllerMAPO": "quay.io/openshift/origin-openstack-machine-api-provider",
-      "clusterAPIControllerLibvirt": "registry.svc.ci.openshift.org/openshift:libvirt-machine-controllers",
-      "clusterAPIControllerBareMetal": "registry.svc.ci.openshift.org/openshift:baremetal-machine-controllers",
-      "clusterAPIControllerAzure": "registry.svc.ci.openshift.org/openshift:azure-machine-controllers",
-      "clusterAPIControllerGCP": "registry.svc.ci.openshift.org/openshift:gcp-machine-controllers",
-      "clusterAPIControllerIBMCloud": "registry.svc.ci.openshift.org/openshift:ibmcloud-machine-controllers",
-      "clusterAPIControllerOvirt": "registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers",
-      "clusterAPIControllerPowerVS": "registry.svc.ci.openshift.org/openshift:powervs-machine-controllers",
-      "clusterAPIControllerVSphere": "registry.svc.ci.openshift.org/openshift:machine-api-operator"
+      "machineAPIOperator": "quay.io/openshift/origin-machine-api-operator",
+      "kubeRBACProxy": "quay.io/openshift/origin-kube-rbac-proxy",
+      "clusterAPIControllerAWS": "quay.io/openshift/origin-aws-machine-controllers",
+      "clusterAPIControllerAlibaba": "quay.io/openshift/origin-alibaba-machine-controllers",
+      "clusterAPIControllerOpenStack": "quay.io/openshift/origin-openstack-machine-controllers",
+      "clusterAPIControllerMAPO": "quay.io/shiftstack/machine-api-provider-openstack:latest",
+      "clusterAPIControllerLibvirt": "quay.io/openshift/origin-libvirt-machine-controllers",
+      "clusterAPIControllerBareMetal": "quay.io/openshift/origin-baremetal-machine-controllers",
+      "clusterAPIControllerAzure": "quay.io/openshift/origin-azure-machine-controllers",
+      "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers",
+      "clusterAPIControllerIBMCloud": "quay.io/openshift/origin-ibmcloud-machine-controllers",
+      "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
+      "clusterAPIControllerPowerVS": "quay.io/openshift/origin-powervs-machine-controllers",
+      "clusterAPIControllerVSphere": "quay.io/openshift/origin-machine-api-operator"
     }

--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: machine-api-operator
       containers:
       - name: kube-rbac-proxy
-        image: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
+        image: quay.io/openshift/origin-kube-rbac-proxy
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://localhost:8080/"
@@ -49,7 +49,7 @@ spec:
         - mountPath: /etc/tls/private
           name: machine-api-operator-tls
       - name: machine-api-operator
-        image: registry.svc.ci.openshift.org/openshift:machine-api-operator
+        image: quay.io/openshift/origin-machine-api-operator
         command:
         - "/machine-api-operator"
         args:

--- a/install/image-references
+++ b/install/image-references
@@ -5,15 +5,15 @@ spec:
   - name: machine-api-operator
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:machine-api-operator
+      name: quay.io/openshift/origin-machine-api-operator
   - name: aws-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:aws-machine-controllers
+      name: quay.io/openshift/origin-aws-machine-controllers
   - name: openstack-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:openstack-machine-controllers
+      name: quay.io/openshift/origin-openstack-machine-controllers
   - name: openstack-machine-api-provider
     from:
       kind: DockerImage
@@ -21,40 +21,40 @@ spec:
   - name: libvirt-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:libvirt-machine-controllers
+      name: quay.io/openshift/origin-libvirt-machine-controllers
   - name: baremetal-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:baremetal-machine-controllers
+      name: quay.io/openshift/origin-baremetal-machine-controllers
   - name: azure-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:azure-machine-controllers
+      name: quay.io/openshift/origin-azure-machine-controllers
   - name: gcp-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:gcp-machine-controllers
+      name: quay.io/openshift/origin-gcp-machine-controllers
   - name: ibmcloud-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ibmcloud-machine-controllers
+      name: quay.io/openshift/origin-ibmcloud-machine-controllers
   - name: powervs-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:powervs-machine-controllers
+      name: quay.io/openshift/origin-powervs-machine-controllers
   - name: baremetal-operator
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:baremetal-operator
+      name: quay.io/openshift/origin-baremetal-operator
   - name: kube-rbac-proxy
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:kube-rbac-proxy
+      name: quay.io/openshift/origin-kube-rbac-proxy
   - name: ovirt-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers
+      name: quay.io/openshift/origin-ovirt-machine-controllers
   - name: alibaba-machine-controllers
     from:
       kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:alibaba-machine-controllers
+      name: quay.io/openshift/origin-alibaba-machine-controllers


### PR DESCRIPTION
Now all image references in the operator use "registry.svc.ci.openshift.org", which has been disabled.

This commit replaces broken image references with working ones from quay.io