### PR TITLE
Bug 1977369: Prevent machine from stucking in Deleting phase on vSphere if related node object not found

### DIFF
--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -158,6 +158,10 @@ func (s *machineScope) getNode() (*apicorev1.Node, error) {
 func (s *machineScope) checkNodeReachable() (bool, error) {
 	node, err := s.getNode()
 	if err != nil {
+		// do not return error if node object not found, treat it as unreachable
+		if apimachineryerrors.IsNotFound(err) {
+			return false, nil
+		}
 		return false, err
 	}
 	for _, condition := range node.Status.Conditions {

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -784,6 +784,18 @@ func TestNodeGetter(t *testing.T) {
 				g.Expect(k8sClient.Status().Update(ctx, node)).To(Succeed())
 			},
 		},
+		{
+			name:     "checkNodeReachable: node not found",
+			err:      nil,
+			expected: false,
+			setStatuses: func(node *corev1.Node, machine *machinev1.Machine) {
+				machine.Status = machinev1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{
+						Name: "not-exists",
+					},
+				}
+			},
+		},
 	}
 	for _, tc := range checkNodeReachableTestCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1357,6 +1357,19 @@ func TestDelete(t *testing.T) {
 				})
 			},
 		},
+		{
+			testCase: "all good, node not found",
+			machine: func(t *testing.T) *machinev1.Machine {
+				return getMachineWithStatus(t, machinev1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{
+						Name: "not-exists",
+					},
+				})
+			},
+			node: func(t *testing.T) *corev1.Node {
+				return &corev1.Node{}
+			},
+		},
 	}
 
 	machinev1.AddToScheme(scheme.Scheme)


### PR DESCRIPTION
Treat node as unreachable and proceed with vm deletion in case on vSphere if node object referenced in machine not found.