### PR TITLE
Backport MHC pause feature from cluster API

### DIFF
--- a/pkg/apis/machine/v1beta1/consts.go
+++ b/pkg/apis/machine/v1beta1/consts.go
@@ -16,6 +16,12 @@ limitations under the License.
 
 package v1beta1
 
+const (
+	// PausedAnnotation is an annotation that can be applied to MachineHealthCheck objects to prevent the MHC controller
+	// from processing it.
+	PausedAnnotation = "cluster.x-k8s.io/paused"
+)
+
 // Constants aren't automatically generated for unversioned packages.
 // Instead share the same constant for all versioned packages
 type MachineStatusError string

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -227,6 +227,10 @@ func TestReconcile(t *testing.T) {
 	machineHealthCheckNegativeMaxUnhealthy.Spec.MaxUnhealthy = &negativeOne
 	machineHealthCheckNegativeMaxUnhealthy.Spec.NodeStartupTimeout = &metav1.Duration{Duration: nodeStartupTimeout}
 
+	machineHealthCheckPaused := maotesting.NewMachineHealthCheck("machineHealthCheck")
+	machineHealthCheckPaused.Annotations = make(map[string]string)
+	machineHealthCheckPaused.Annotations[mapiv1beta1.PausedAnnotation] = "test"
+
 	// remediationExternal
 	nodeUnhealthyForTooLong := maotesting.NewNode("nodeUnhealthyForTooLong", false)
 	nodeUnhealthyForTooLong.Annotations = map[string]string{
@@ -260,6 +264,18 @@ func TestReconcile(t *testing.T) {
 					remediationAllowedCondition,
 				},
 			},
+		},
+		{
+			name:    "machine unhealthy, MHC paused",
+			machine: machineUnhealthyForTooLong,
+			node:    nodeUnhealthyForTooLong,
+			mhc:     machineHealthCheckPaused,
+			expected: expectedReconcile{
+				result: reconcile.Result{},
+				error:  false,
+			},
+			expectedEvents: []string{},
+			expectedStatus: &mapiv1beta1.MachineHealthCheckStatus{},
 		},
 		{
 			name:    "machine with node healthy",

--- a/pkg/util/annotations/helpers.go
+++ b/pkg/util/annotations/helpers.go
@@ -1,0 +1,28 @@
+// Package annotations implements annotation helper functions.
+package annotations
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
+)
+
+// IsPaused returns true if the Cluster is paused or the object has the `paused` annotation.
+func IsPaused(o metav1.Object) bool {
+	return HasPausedAnnotation(o)
+}
+
+// HasPausedAnnotation returns true if the object has the `paused` annotation.
+func HasPausedAnnotation(o metav1.Object) bool {
+	return hasAnnotation(o, v1beta1.PausedAnnotation)
+}
+
+// hasAnnotation returns true if the object has the specified annotation.
+func hasAnnotation(o metav1.Object, annotation string) bool {
+	annotations := o.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	_, ok := annotations[annotation]
+	return ok
+}


### PR DESCRIPTION
With this PR we backport the pause annotation for MachineHealthCheck resources from upstream SIG Cluster API. It can be used for e.g. pausing remediation during cluster upgrades. See https://github.com/openshift/enhancements/pull/827

Upstream code:
https://github.com/kubernetes-sigs/cluster-api/blob/87270011c60fdd336949ad22dd1b3c59498b8480/controllers/machinehealthcheck_controller.go#L134
https://github.com/kubernetes-sigs/cluster-api/blob/a5e1b5fe003a29ec09a433cc5f6118e76993caa2/api/v1alpha4/common_types.go#L54