### PR TITLE
Add webhook to ensure that only ID references AMI

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -604,13 +604,27 @@ func validateAWS(m *Machine, config *admissionConfig) (bool, []string, utilerror
 		return false, warnings, utilerrors.NewAggregate(errs)
 	}
 
-	if providerSpec.AMI.ARN == nil && providerSpec.AMI.Filters == nil && providerSpec.AMI.ID == nil {
+	if providerSpec.AMI.ID == nil {
 		errs = append(
 			errs,
 			field.Required(
 				field.NewPath("providerSpec", "ami"),
-				"expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+				"expected providerSpec.ami.id to be populated",
 			),
+		)
+	}
+
+	if providerSpec.AMI.ARN != nil {
+		warnings = append(
+			warnings,
+			"can't use providerSpec.ami.arn, only providerSpec.ami.id can be used to reference AMI",
+		)
+	}
+
+	if providerSpec.AMI.Filters != nil {
+		warnings = append(
+			warnings,
+			"can't use providerSpec.ami.filters, only providerSpec.ami.id can be used to reference AMI",
 		)
 	}
 

--- a/pkg/apis/machine/v1beta1/machine_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook_test.go
@@ -118,7 +118,7 @@ func TestMachineCreation(t *testing.T) {
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "providerSpec.ami: Required value: expected providerSpec.ami.id to be populated",
 		},
 		{
 			name:         "with AWS and an AMI ID set",
@@ -872,7 +872,7 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 				p.AMI = aws.AWSResourceReference{}
 			},
 			expectedOk:    false,
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "providerSpec.ami: Required value: expected providerSpec.ami.id to be populated",
 		},
 		{
 			testCase: "with no region values it fails",
@@ -1015,6 +1015,32 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk: true,
+		},
+		{
+			testCase: "with AMI ARN set",
+			modifySpec: func(p *aws.AWSMachineProviderConfig) {
+				p.AMI = aws.AWSResourceReference{
+					ID:  pointer.StringPtr("ami"),
+					ARN: pointer.StringPtr("arn"),
+				}
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"can't use providerSpec.ami.arn, only providerSpec.ami.id can be used to reference AMI"},
+		},
+		{
+			testCase: "with AMI filters set",
+			modifySpec: func(p *aws.AWSMachineProviderConfig) {
+				p.AMI = aws.AWSResourceReference{
+					ID: pointer.StringPtr("ami"),
+					Filters: []aws.Filter{
+						{
+							Name: "filter",
+						},
+					},
+				}
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"can't use providerSpec.ami.filters, only providerSpec.ami.id can be used to reference AMI"},
 		},
 	}
 

--- a/pkg/apis/machine/v1beta1/machineset_webhook_test.go
+++ b/pkg/apis/machine/v1beta1/machineset_webhook_test.go
@@ -101,7 +101,7 @@ func TestMachineSetCreation(t *testing.T) {
 			providerSpecValue: &runtime.RawExtension{
 				Object: &aws.AWSMachineProviderConfig{},
 			},
-			expectedError: "providerSpec.ami: Required value: expected either providerSpec.ami.arn or providerSpec.ami.filters or providerSpec.ami.id to be populated",
+			expectedError: "providerSpec.ami: Required value: expected providerSpec.ami.id to be populated",
 		},
 		{
 			name:         "with AWS and an AMI ID",


### PR DESCRIPTION
Currently, only ID is used to reference an AMI https://github.com/openshift/cluster-api-provider-aws/blob/master/pkg/actuators/machine/instances.go#L333 however we expose two other API fields - ARN and Filters. This PR adds a webhook to prevent users from using unsupported values.
