### PR TITLE
[OCPCLOUD-1153] add a tombstones manifest to the install directory

### DIFF
--- a/install/0000_99_machine-api-operator_00_tombstones.yaml
+++ b/install/0000_99_machine-api-operator_00_tombstones.yaml
@@ -1,0 +1,67 @@
+apiVersion: cloudcredentials.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: openshift-machine-api
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: apiextensions.k8s.io
+kind: CustomResourceDefinition
+metadata:
+  name: machinehealthchecks.healthchecking.openshift.io
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: apiextensions.k8s.io
+kind: CustomResourceDefinition
+metadata:
+  name: machinedisruptionbudgets.healthchecking.openshift.io
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: ClusterRole
+metadata:
+  name: machine-api-manager
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: ClusterRoleBinding
+metadata:
+  name: machine-api-manager-rolebinding
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: RoleBinding
+metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: Role
+metadata:
+  name: machine-api-termination-handler
+  namespace: openshift-machine-api
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: Role
+metadata:
+  name: cloud-provider-config-reader
+  namespace: openshift-config
+  annotations:
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io
+kind: RoleBinding
+metadata:
+  name: machine-api-cloud-provider-config-reader
+  namespace: openshift-config
+  annotations:
+    release.openshift.io/delete: "true"


### PR DESCRIPTION
CVO has added the ability to remove objects created in previous releases
of OpenShift. This change adds a manifest to remove old objects which
are no longer used by the machine-api.

ref: https://issues.redhat.com/browse/OTA-395