### PR TITLE
Bug 1980930: Update the default durations for MAO leader election operations

### DIFF
--- a/cmd/machine-api-operator/helpers.go
+++ b/cmd/machine-api-operator/helpers.go
@@ -15,13 +15,6 @@ import (
 )
 
 const (
-	// LeaseDuration is the default duration for the leader election lease.
-	LeaseDuration = 90 * time.Second
-	// RenewDeadline is the default duration for the leader renewal.
-	RenewDeadline = 60 * time.Second
-	// RetryPeriod is the default duration for the leader electrion retrial.
-	RetryPeriod = 30 * time.Second
-
 	minResyncPeriod = 10 * time.Minute
 )
 

--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -11,6 +11,7 @@ import (
 	osconfigv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
 	"github.com/openshift/machine-api-operator/pkg/operator"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	"github.com/openshift/machine-api-operator/pkg/version"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -73,9 +74,9 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 
 	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
 		Lock:          CreateResourceLock(cb, componentNamespace, componentName),
-		LeaseDuration: LeaseDuration,
-		RenewDeadline: RenewDeadline,
-		RetryPeriod:   RetryPeriod,
+		LeaseDuration: util.LeaseDuration,
+		RenewDeadline: util.RenewDeadline,
+		RetryPeriod:   util.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				ctrlCtx := CreateControllerContext(cb, stopCh, componentNamespace)

--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -3,10 +3,10 @@ package main
 import (
 	"flag"
 	"runtime"
-	"time"
 
 	"github.com/openshift/machine-api-operator/pkg/controller/machinehealthcheck"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
+	"github.com/openshift/machine-api-operator/pkg/util"
 
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
@@ -17,13 +17,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-)
-
-// The default durations for the leader electrion operations.
-var (
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -65,7 +58,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		leaseDuration,
+		util.LeaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -86,9 +79,8 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-healthcheck-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
-		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
-		RetryPeriod:   &retryPeriod,
-		RenewDeadline: &renewDealine,
+		RetryPeriod:             util.TimeDuration(util.RetryPeriod),
+		RenewDeadline:           util.TimeDuration(util.RenewDeadline),
 	}
 
 	if *watchNamespace != "" {

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -3,23 +3,16 @@ package main
 import (
 	"flag"
 	"runtime"
-	"time"
 
 	mapiv1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/controller"
 	"github.com/openshift/machine-api-operator/pkg/controller/nodelink"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-)
-
-// The default durations for the leader electrion operations.
-var (
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
 )
 
 func printVersion() {
@@ -51,7 +44,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		leaseDuration,
+		util.LeaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -72,9 +65,8 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-nodelink-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
-		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
-		RetryPeriod:   &retryPeriod,
-		RenewDeadline: &renewDealine,
+		RetryPeriod:             util.TimeDuration(util.RetryPeriod),
+		RenewDeadline:           util.TimeDuration(util.RenewDeadline),
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -13,6 +13,7 @@ import (
 	machine "github.com/openshift/machine-api-operator/pkg/controller/vsphere"
 	machinesetcontroller "github.com/openshift/machine-api-operator/pkg/controller/vsphere/machineset"
 	"github.com/openshift/machine-api-operator/pkg/metrics"
+	"github.com/openshift/machine-api-operator/pkg/util"
 	"github.com/openshift/machine-api-operator/pkg/version"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
@@ -21,13 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-)
-
-// The default durations for the leader electrion operations.
-var (
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
 )
 
 func main() {
@@ -55,7 +49,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		leaseDuration,
+		util.LeaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -89,9 +83,8 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-vsphere-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
-		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
-		RetryPeriod:   &retryPeriod,
-		RenewDeadline: &renewDealine,
+		RetryPeriod:             util.TimeDuration(util.RetryPeriod),
+		RenewDeadline:           util.TimeDuration(util.RenewDeadline),
 	}
 
 	if *watchNamespace != "" {

--- a/pkg/util/durations.go
+++ b/pkg/util/durations.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 Red Hat.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+)
+
+// The default durations for the leader election operations.
+const (
+	// LeaseDuration is the default duration for the leader election lease.
+	LeaseDuration = 137 * time.Second
+	// RenewDeadline is the default duration for the leader renewal.
+	RenewDeadline = 107 * time.Second
+	// RetryPeriod is the default duration for the leader election retrial.
+	RetryPeriod = 26 * time.Second
+)
+
+// TimeDuration returns a pointer to the time.Duration.
+func TimeDuration(i time.Duration) *time.Duration {
+	return &i
+}


### PR DESCRIPTION
According to [1] to successfully handle kube-apiserver disruption  we need to updated default durations for MAO leader election operations.
    
New values are LeaseDuration=137s, RenewDealine=107s, RetryPeriod=26s.
    
[1] https://github.com/openshift/enhancements/pull/832