### PR TITLE
Bug 1975296: Remove external remediation annotation for healthy machines

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -724,6 +724,9 @@ func (t *target) remediationStrategyExternal(r *ReconcileMachineHealthCheck) err
 
 func (t *target) removeRemediationStrategyExternal(r *ReconcileMachineHealthCheck) error {
 	// external annotation does not exist on the machine, nothing to do
+	if t.Machine.Annotations == nil {
+		return nil
+	}
 	if _, ok := t.Machine.Annotations[machineExternalAnnotationKey]; !ok {
 		return nil
 	}


### PR DESCRIPTION
There are cases when the machine is healthy again before external remediation happened, e.g. when remediation failed, but the machine rebooted for another reason. Prevent remediation of these now healthy machines by removing the external remediation annotation.

This is part of the fix for bz 1975296, the other one is in https://github.com/openshift/cluster-api-provider-baremetal/pull/157
