### PR TITLE
Adds ibmcloud mapi controller to image ref

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -30,6 +30,10 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:gcp-machine-controllers
+  - name: ibmcloud-machine-controllers
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:ibmcloud-machine-controllers
   - name: baremetal-operator
     from:
       kind: DockerImage


### PR DESCRIPTION
Cannot be merged until the ibmcloud mapi controller image is available in the release payload.