### PR TITLE
Bug 1988032: add cvo ha annotations to tombstones

### DIFF
--- a/install/0000_99_machine-api-operator_00_tombstones.yaml
+++ b/install/0000_99_machine-api-operator_00_tombstones.yaml
@@ -1,67 +1,76 @@
-apiVersion: cloudcredentials.openshift.io/v1
+apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
   name: openshift-machine-api
   namespace: openshift-cloud-credential-operator
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: apiextensions.k8s.io
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: machinehealthchecks.healthchecking.openshift.io
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: apiextensions.k8s.io
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: machinedisruptionbudgets.healthchecking.openshift.io
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: machine-api-manager
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: machine-api-manager-rolebinding
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: machine-api-termination-handler
   namespace: openshift-machine-api
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: machine-api-termination-handler
   namespace: openshift-machine-api
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: cloud-provider-config-reader
   namespace: openshift-config
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"
 ---
-apiVersion: rbac.authorization.k8s.io
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: machine-api-cloud-provider-config-reader
   namespace: openshift-config
   annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/delete: "true"


### PR DESCRIPTION
This change adds the annotation
`include.release.openshift.io/self-managed-high-availability: "true"`
to the tombstones. This is needed to ensure that the CVO will process
them.