### PR TITLE
Bug 1989980: Create event only if the machine was modified

### DIFF
--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -313,6 +313,10 @@ func TestMachineEvents(t *testing.T) {
 				if len(eventList.Items) != 1 {
 					return fmt.Errorf("expected len 1, got %d", len(eventList.Items))
 				}
+
+				if eventList.Items[0].Count != 1 {
+					return fmt.Errorf("expected event %v to happen only once", eventList.Items[0].Name)
+				}
 				return nil
 			}
 


### PR DESCRIPTION
Now vsphere actuator always creates an event after Update, even though the change might not have happened.

To prevent creating fake events we compare machine resource version before and after update, and create an event only if they are different.