### PR TITLE
Bug 1975296: Respect MaxUnhealthy limit for external remediation

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -488,7 +488,7 @@ func (r *ReconcileMachineHealthCheck) healthCheckTargets(targets []target, timeo
 			continue
 		}
 
-		if t.Machine.DeletionTimestamp == nil && t.Node != nil {
+		if _, externalRemediation := t.Machine.Annotations[machineExternalAnnotationKey]; t.Machine.DeletionTimestamp == nil && t.Node != nil && !externalRemediation {
 			currentHealthy = append(currentHealthy, t)
 		}
 	}


### PR DESCRIPTION
Conventional remediation consists of simply deleting the Machine object.
In consequence, it was safe to consider that any Machines that do not
need remediation, have a Node, and are not in the process of being
deleted, are 'healthy'.

However, external remediation takes place not by deleting a Machine but
by adding an annotation to it. While the Machine continues to exist (and
may be associated with a Node for part of the time), it will not be in a
working state throughout the remediation (generally because they are
being rebooted).

Because these Machines were considered 'healthy', additional Machines
could be remediated during this process in violation of the MaxUnhealthy
limit. If the process of acting on the external remediation annotation
was delayed, potentially the whole cluster could be remediated
simultaneously, thus taking it out of service.

To prevent this, treat Machines with the external remediation annotation
as unhealthy so that the MaxUnhealthy limit is respected.

Note that when a RemediationTemplate (as added in
338eab54e7ecae11b1c4dcede91266c28b58e300) is provided, it will *not* be
taken into account in determining whether a Machine is healthy (unless
it also results in the external remediation annotation being applied to
the Machine), so the same issue still exists in that case.