### PR TITLE
docs/user/nodelink-controller: Fix name/namespace order for machine.openshift.io/machine

### DIFF
--- a/docs/user/nodelink-controller.md
+++ b/docs/user/nodelink-controller.md
@@ -38,7 +38,7 @@ In short the nodelink controller does the following:
 3. If the machine is found, update its node reference (`.status.nodeRef`)
    with the name and UID of the associated node.
 4. Add the `machine.openshift.io/machine` annotation to the node, with
-   the value of `{machine name}/{machine namespace}`.
+   the value of `{machine namespace}/{machine name}`.
 5. Copy the labels from the machine spec (`.spec.labels`) to the node.
 6. Copy the taints from the machine spec (`.spec.taints`) to the node.
 


### PR DESCRIPTION
A bit further up in the file we have:

    machine.openshift.io/machine: openshift-machine-api/alpha-b6dhr-worker-us-east-2a-jxqng

which is namespace first.  Confirming in [4.8.2->4.8.3 CI][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1420413555873681408/artifacts/launch/nodes.json | jq -r '.items[].metadata.annotations["machine.openshift.io/machine"]' | sort
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-master-0
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-master-1
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-master-2
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-worker-us-east-2a-454fw
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-worker-us-east-2a-b95ng
openshift-machine-api/ci-ln-zzbp4lb-d5d6b-zjbh9-worker-us-east-2b-bjntz
```

Typo is as old as the file, 02a70fb842 (#880).

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1420413555873681408