### PR TITLE
Bug 1975296: Respect MaxUnhealthy limit for external remediation

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -488,7 +488,7 @@ func (r *ReconcileMachineHealthCheck) healthCheckTargets(targets []target, timeo
 			continue
 		}
 
-		if t.Machine.DeletionTimestamp == nil && t.Node != nil {
+		if _, externalRemediation := t.Machine.Annotations[machineExternalAnnotationKey]; t.Machine.DeletionTimestamp == nil && t.Node != nil && !externalRemediation {
 			currentHealthy = append(currentHealthy, t)
 		}
 	}

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -245,6 +245,9 @@ func TestReconcile(t *testing.T) {
 	machineAlreadyDeleted := maotesting.NewMachine("machineAlreadyDeleted", nodeAlreadyDeleted.Name)
 	machineAlreadyDeleted.SetDeletionTimestamp(&metav1.Time{Time: time.Now()})
 
+	machineHealthyWithExtRemediationAnnotation := maotesting.NewMachine("machineHealthyWithExtRemAnn", nodeHealthy.Name)
+	machineHealthyWithExtRemediationAnnotation.Annotations[machineExternalAnnotationKey] = ""
+
 	testCases := []testCase{
 		{
 			name:    "machine unhealthy",
@@ -291,6 +294,25 @@ func TestReconcile(t *testing.T) {
 				ExpectedMachines:    IntPtr(1),
 				CurrentHealthy:      IntPtr(1),
 				RemediationsAllowed: 1,
+				Conditions: mapiv1beta1.Conditions{
+					remediationAllowedCondition,
+				},
+			},
+		},
+		{
+			name:    "machine with node healthy but external remediation annotation",
+			machine: machineHealthyWithExtRemediationAnnotation,
+			node:    nodeHealthy,
+			mhc:     machineHealthCheck,
+			expected: expectedReconcile{
+				result: reconcile.Result{Requeue: true},
+				error:  false,
+			},
+			expectedEvents: []string{},
+			expectedStatus: &mapiv1beta1.MachineHealthCheckStatus{
+				ExpectedMachines:    IntPtr(1),
+				CurrentHealthy:      IntPtr(0),
+				RemediationsAllowed: 0,
 				Conditions: mapiv1beta1.Conditions{
 					remediationAllowedCondition,
 				},


### PR DESCRIPTION
Replaces #898 because Zane is on PTO
Applied suggested refactoring, added unit test

From the original PR:
Conventional remediation consists of simply deleting the Machine object.
In consequence, it was safe to consider that any Machines that do not
need remediation, have a Node, and are not in the process of being
deleted, are 'healthy'.

However, external remediation takes place not by deleting a Machine but
by adding an annotation to it. While the Machine continues to exist (and
may be associated with a Node for part of the time), it will not be in a
working state throughout the remediation (generally because they are
being rebooted).

Because these Machines were considered 'healthy', additional Machines
could be remediated during this process in violation of the MaxUnhealthy
limit. If the process of acting on the external remediation annotation
was delayed, potentially the whole cluster could be remediated
simultaneously, thus taking it out of service.

To prevent this, treat Machines with the external remediation annotation
as unhealthy so that the MaxUnhealthy limit is respected.

Note that when a RemediationTemplate (as added in
338eab5) is provided, it will not be
taken into account in determining whether a Machine is healthy (unless
it also results in the external remediation annotation being applied to
the Machine), so the same issue still exists in that case.