### PR TITLE
Bug 1999425: MaxUnhealthy should not be a string type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	sigs.k8s.io/cluster-api-provider-aws v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/cluster-api-provider-azure v0.0.0-00010101000000-000000000000
 	sigs.k8s.io/controller-runtime v0.9.6
-	sigs.k8s.io/controller-tools v0.6.2
+	sigs.k8s.io/controller-tools v0.6.3-0.20210916130746-94401651a6c3
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1574,8 +1574,9 @@ sigs.k8s.io/controller-runtime v0.9.6 h1:EevVMlgUj4fC1NVM4+DB3iPkWkmGRNarA66neqv
 sigs.k8s.io/controller-runtime v0.9.6/go.mod h1:q6PpkM5vqQubEKUKOM6qr06oXGzOBcCby1DA9FbyZeA=
 sigs.k8s.io/controller-tools v0.2.8/go.mod h1:9VKHPszmf2DHz/QmHkcfZoewO6BL7pPs9uAiBVsaJSE=
 sigs.k8s.io/controller-tools v0.3.0/go.mod h1:enhtKGfxZD1GFEoMgP8Fdbu+uKQ/cq1/WGJhdVChfvI=
-sigs.k8s.io/controller-tools v0.6.2 h1:+Y8L0UsAugDipGRw8lrkPoAi6XqlQVZuf1DQHME3PgU=
 sigs.k8s.io/controller-tools v0.6.2/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
+sigs.k8s.io/controller-tools v0.6.3-0.20210916130746-94401651a6c3 h1:qtPiACAG0oAtZrjSXNg7HSCKFKUfaecpUKLGyzIk4pU=
+sigs.k8s.io/controller-tools v0.6.3-0.20210916130746-94401651a6c3/go.mod h1:oaeGpjXn6+ZSEIQkUe/+3I40PNiDYp9aeawbt3xTgJ8=
 sigs.k8s.io/kube-storage-version-migrator v0.0.3/go.mod h1:mXfSLkx9xbJHQsgNDDUZK/iQTs2tMbx/hsJlWe6Fthw=
 sigs.k8s.io/kube-storage-version-migrator v0.0.4 h1:qsCecgZHgdismlTt8xCmS/3numvpxrj58RWJeIg76wc=
 sigs.k8s.io/kube-storage-version-migrator v0.0.4/go.mod h1:mXfSLkx9xbJHQsgNDDUZK/iQTs2tMbx/hsJlWe6Fthw=

--- a/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
+++ b/install/0000_30_machine-api-operator_07_machinehealthcheck.crd.yaml
@@ -66,7 +66,6 @@ spec:
                   must be positive whole numbers and are capped at 100%. Both 0 and
                   0% are valid and will block all remediation.
                 pattern: ^((100|[0-9]{1,2})%|[0-9]+)$
-                type: string
                 x-kubernetes-int-or-string: true
               nodeStartupTimeout:
                 default: 10m

--- a/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
+++ b/pkg/apis/machine/v1beta1/machinehealthcheck_types.go
@@ -66,8 +66,8 @@ type MachineHealthCheckSpec struct {
 	// Percentage values must be positive whole numbers and are capped at 100%.
 	// Both 0 and 0% are valid and will block all remediation.
 	// +kubebuilder:default:="100%"
+	// +kubebuilder:validation:XIntOrString
 	// +kubebuilder:validation:Pattern="^((100|[0-9]{1,2})%|[0-9]+)$"
-	// +kubebuilder:validation:Type:=string
 	MaxUnhealthy *intstr.IntOrString `json:"maxUnhealthy,omitempty"`
 
 	// Machines older than this duration without a node will be considered to have

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -988,7 +988,7 @@ sigs.k8s.io/controller-runtime/pkg/webhook
 sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/conversion
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
-# sigs.k8s.io/controller-tools v0.6.2
+# sigs.k8s.io/controller-tools v0.6.3-0.20210916130746-94401651a6c3
 ## explicit
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/validation.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/validation.go
@@ -66,6 +66,7 @@ var ValidationMarkers = mustMakeAllWithPrefix("kubebuilder:validation", markers.
 	Type(""),
 	XPreserveUnknownFields{},
 	XEmbeddedResource{},
+	XIntOrString{},
 )
 
 // FieldOnlyMarkers list field-specific validation markers (i.e. those markers that don't make
@@ -233,6 +234,14 @@ type XPreserveUnknownFields struct{}
 type XEmbeddedResource struct{}
 
 // +controllertools:marker:generateHelp:category="CRD validation"
+// IntOrString marks a fields as an IntOrString.
+//
+// This is required when applying patterns or other validations to an IntOrString
+// field. Knwon information about the type is applied during the collapse phase
+// and as such is not normally available during marker application.
+type XIntOrString struct{}
+
+// +controllertools:marker:generateHelp:category="CRD validation"
 // Schemaless marks a field as being a schemaless object.
 //
 // Schemaless objects are not introspected, so you must provide
@@ -298,8 +307,11 @@ func (m MinLength) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	return nil
 }
 func (m Pattern) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
-	if schema.Type != "string" {
-		return fmt.Errorf("must apply pattern to a string")
+	// Allow string types or IntOrStrings. An IntOrString will still
+	// apply the pattern validation when a string is detected, the pattern
+	// will not apply to ints though.
+	if schema.Type != "string" && !schema.XIntOrString {
+		return fmt.Errorf("must apply pattern to a `string` or `IntOrString`")
 	}
 	schema.Pattern = string(m)
 	return nil
@@ -406,3 +418,13 @@ func (m XEmbeddedResource) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
 	schema.XEmbeddedResource = true
 	return nil
 }
+
+// NB(JoelSpeed): we use this property in other markers here,
+// which means the "XIntOrString" marker *must* be applied first.
+
+func (m XIntOrString) ApplyToSchema(schema *apiext.JSONSchemaProps) error {
+	schema.XIntOrString = true
+	return nil
+}
+
+func (m XIntOrString) ApplyFirst() {}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/zz_generated.markerhelp.go
@@ -48,7 +48,7 @@ func (DeprecatedVersion) Help() *markers.DefinitionHelp {
 			Details: "",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{
-			"Warning": markers.DetailedHelp{
+			"Warning": {
 				Summary: "message to be shown on the deprecated version",
 				Details: "",
 			},
@@ -440,6 +440,17 @@ func (XEmbeddedResource) Help() *markers.DefinitionHelp {
 		DetailedHelp: markers.DetailedHelp{
 			Summary: "EmbeddedResource marks a fields as an embedded resource with apiVersion, kind and metadata fields. ",
 			Details: "An embedded resource is a value that has apiVersion, kind and metadata fields. They are validated implicitly according to the semantics of the currently running apiserver. It is not necessary to add any additional schema for these field, yet it is possible. This can be combined with PreserveUnknownFields.",
+		},
+		FieldHelp: map[string]markers.DetailedHelp{},
+	}
+}
+
+func (XIntOrString) Help() *markers.DefinitionHelp {
+	return &markers.DefinitionHelp{
+		Category: "CRD validation",
+		DetailedHelp: markers.DetailedHelp{
+			Summary: "IntOrString marks a fields as an IntOrString. ",
+			Details: "This is required when applying patterns or other validations to an IntOrString field. Knwon information about the type is applied during the collapse phase and as such is not normally available during marker application.",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}


### PR DESCRIPTION
This field is an int or string and as such should not specify the type to be a string, this can cause errors in the CRD conversion when upgrading as we have changed the underlying type. Removing `type: string` should resolve these upgrade errors.