### PR TITLE
Fix user-agent in vCenter sessions list

### DIFF
--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -67,6 +67,7 @@ func GetOrCreate(
 			return &session, nil
 		}
 	}
+	klog.Infof("No existing vCenter session found, creating new session")
 
 	soapURL, err := soap.ParseURL(server)
 	if err != nil {
@@ -76,11 +77,18 @@ func GetOrCreate(
 		return nil, fmt.Errorf("error parsing vSphere URL %q", server)
 	}
 
-	soapURL.User = url.UserPassword(username, password)
-
+	// Set user to nil there for prevent login during client creation.
+	// See https://github.com/vmware/govmomi/blob/master/client.go#L91
+	soapURL.User = nil
 	client, err := govmomi.NewClient(ctx, soapURL, insecure)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up new vSphere SOAP client: %w", err)
+	}
+
+	// Set up user agent before login for being able to track mapi component in vcenter sessions list
+	client.UserAgent = "machineAPIvSphereProvider"
+	if err := client.Login(ctx, url.UserPassword(username, password)); err != nil {
+		return nil, fmt.Errorf("unable to login to vCenter: %w", err)
 	}
 
 	session := Session{
@@ -89,7 +97,6 @@ func GetOrCreate(
 		password: password,
 	}
 
-	session.UserAgent = "machineAPIvSphereProvider"
 	session.Finder = find.NewFinder(session.Client.Client, false)
 
 	dc, err := session.Finder.DatacenterOrDefault(ctx, datacenter)


### PR DESCRIPTION
For some reason vCenter using user-agent from first
login request and does not respect it's change after.
Moved login step into our code with setting user-agent
for soap client beforehand.
Info log message for new vCenter session creation added
by the way.

tested on vCenter 7.0.1.00200