### PR TITLE
Bug 1986237: modify MachineNotYetDeleted alert to ignore pod

### DIFF
--- a/docs/user/Alerts.md
+++ b/docs/user/Alerts.md
@@ -39,7 +39,7 @@ Machine has been in the "Deleting" phase for a long time. Deleting phase is adde
 ### Query
 ```
 # for: 360m
-(mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
+sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
 ```
 
 ### Possible Causes

--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -36,7 +36,7 @@ spec:
       rules:
         - alert: MachineNotYetDeleted
           expr: |
-            (mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
+            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
           for: 360m
           labels:
             severity: warning


### PR DESCRIPTION
This change makes it so that the alert will ignore changes in the `pod`
label during the duration of the alert. It is being added to account for
cases where the machine-api-operator pod might be rescheduled and thus
its pod name will change. This should allow the alert to persist.