### PR TITLE
[OCPCLOUD-855] add a distinct status message for NoOp mode

### DIFF
--- a/docs/user/machine-api-operator-overview.md
+++ b/docs/user/machine-api-operator-overview.md
@@ -68,9 +68,14 @@ Providers which currently works with MAO, are:
 
 ### Status management
 
-MAO is responsible for status reporting on the `machine-api` ClusterOperator. Our status reporting  is following the [best practices](https://github.com/openshift/cluster-version-operator/blob/master/docs/dev/clusteroperator.md#conditions).
+MAO is responsible for status reporting on the `machine-api` ClusterOperator. Our status reporting  is following the [best practices](https://github.com/openshift/enhancements/blob/master/dev-guide/cluster-version-operator/dev/clusteroperator.md#conditions).
 
 The status condition will turn `Degraded` if any of the managed resources fail to rollout, or are unavailable for longer [periods](https://github.com/openshift/machine-api-operator/blob/master/pkg/operator/sync.go#L31-L34) of time.
+
+When the MAO is running on an unrecognized infrastructure platform it is
+considered to be running in "NoOp" (no operation) mode. Its operator status
+will be `Available`, but you will see a status message indicating that it is
+running in "NoOp" mode.
 
 In addition to the cluster-operator status reporting, it is recommended to know relevant alerts described in the alerting [document](https://github.com/openshift/machine-api-operator/blob/master/docs/user/Alerts.md)
 

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -90,8 +90,9 @@ func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, s
 // for platforms that are no-ops.
 func TestOperatorSync_NoOp(t *testing.T) {
 	cases := []struct {
-		platform     openshiftv1.PlatformType
-		expectedNoop bool
+		platform        openshiftv1.PlatformType
+		expectedNoop    bool
+		expectedMessage string
 	}{
 		{
 			platform:     openshiftv1.AWSPlatformType,
@@ -130,12 +131,14 @@ func TestOperatorSync_NoOp(t *testing.T) {
 			expectedNoop: false,
 		},
 		{
-			platform:     openshiftv1.NonePlatformType,
-			expectedNoop: true,
+			platform:        openshiftv1.NonePlatformType,
+			expectedNoop:    true,
+			expectedMessage: operatorStatusNoOpMessage,
 		},
 		{
-			platform:     "bad-platform",
-			expectedNoop: true,
+			platform:        "bad-platform",
+			expectedNoop:    true,
+			expectedMessage: operatorStatusNoOpMessage,
 		},
 	}
 
@@ -207,6 +210,10 @@ func TestOperatorSync_NoOp(t *testing.T) {
 			}
 
 			for _, c := range o.Status.Conditions {
+				// if expecting a Noop and the operator is available, then check to ensure that the proper message is displayed
+				if tc.expectedNoop && c.Type == openshiftv1.OperatorAvailable && c.Status == openshiftv1.ConditionTrue {
+					assert.Equal(t, tc.expectedMessage, c.Message)
+				}
 				assert.Equal(t, expectedConditions[c.Type], c.Status, fmt.Sprintf("unexpected clusteroperator condition %s status", c.Type))
 			}
 		})

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -81,10 +81,9 @@ func (optr *Operator) statusProgressing() error {
 
 // statusAvailable sets the Available condition to True, with the given reason
 // and message, and sets both the Progressing and Degraded conditions to False.
-func (optr *Operator) statusAvailable() error {
+func (optr *Operator) statusAvailable(message string) error {
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonAsExpected),
-			fmt.Sprintf("Cluster Machine API Operator is available at %s", optr.printOperandVersions())),
+		newClusterOperatorStatusCondition(osconfigv1.OperatorAvailable, osconfigv1.ConditionTrue, string(ReasonAsExpected), message),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, osconfigv1.ConditionFalse, string(ReasonAsExpected), ""),
 		newClusterOperatorStatusCondition(osconfigv1.OperatorDegraded, osconfigv1.ConditionFalse, string(ReasonAsExpected), ""),
 		operatorUpgradeable,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -43,6 +43,7 @@ const (
 	externalTrustBundleConfigMapName    = "mao-trusted-ca"
 	hostKubeConfigPath                  = "/var/lib/kubelet/kubeconfig"
 	hostKubePKIPath                     = "/var/lib/kubelet/pki"
+	operatorStatusNoOpMessage           = "Cluster Machine API Operator is in NoOp mode"
 )
 
 var (
@@ -63,7 +64,7 @@ func (optr *Operator) syncAll(config *OperatorConfig) error {
 
 	if config.Controllers.Provider == clusterAPIControllerNoOp {
 		klog.V(3).Info("Provider is NoOp, skipping synchronisation")
-		if err := optr.statusAvailable(); err != nil {
+		if err := optr.statusAvailable(operatorStatusNoOpMessage); err != nil {
 			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
 			return fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
 		}
@@ -110,7 +111,8 @@ func (optr *Operator) syncAll(config *OperatorConfig) error {
 
 	klog.V(3).Info("Synced up all machine API webhook configurations")
 
-	if err := optr.statusAvailable(); err != nil {
+	message := fmt.Sprintf("Cluster Machine API Operator is available at %s", optr.printOperandVersions())
+	if err := optr.statusAvailable(message); err != nil {
 		klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
 		return fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
 	}


### PR DESCRIPTION
When the MAO is running on platforms it does not recognize it will be in
NoOp mode. This change adds a message to the operator status that
indicates this mode of operation, it also adds tests and documentation.