### PR TITLE
Remove ironic-inspector reference in MAO

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -34,26 +34,6 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:baremetal-operator
-  - name: ironic
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ironic
-  - name: ironic-inspector
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ironic-inspector
-  - name: ironic-ipa-downloader
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ironic-ipa-downloader
-  - name: ironic-machine-os-downloader
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ironic-machine-os-downloader
-  - name: ironic-static-ip-manager
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:ironic-static-ip-manager
   - name: kube-rbac-proxy
     from:
       kind: DockerImage


### PR DESCRIPTION
The ironic-inspector image was deprecated in 4.9 and removed in 4.10

We need this to fix the builds for 4.10 see [1]
We already removed from CBO in  openshift/cluster-baremetal-operator#196

[1] https://amd64.ocp.releases.ci.openshift.org/releasestream/4.10.0-0.nightly/release/4.10.0-0.nightly-2021-09-08-172131