### PR TITLE
Vsphere sessions check: fix log string formatting

### DIFF
--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -65,7 +65,7 @@ func GetOrCreate(
 	if session, ok := sessionCache[sessionKey]; ok {
 		sessionActive, err := session.SessionManager.SessionIsActive(ctx)
 		if err != nil {
-			klog.Errorf("Error performing session check request to vSphere: %w", err)
+			klog.Errorf("Error performing session check request to vSphere: %v", err)
 		}
 		if sessionActive {
 			return &session, nil


### PR DESCRIPTION
Improve log message:
before:
- E0923 17:00:20.257037   14509 session.go:68] Error performing session check request to vSphere: %!w(soap.soapFaultError={0xc0016a7270})

after:
- E0923 17:01:58.988560   14813 session.go:68] Error performing session check request to vSphere: ServerFaultCode: Permission to perform this operation was denied.