### PR TITLE
Fix flaky AWS provider unit test

### DIFF
--- a/pkg/apis/machine/v1beta1/machine_webhook.go
+++ b/pkg/apis/machine/v1beta1/machine_webhook.go
@@ -718,6 +718,8 @@ func getDuplicatedTags(tagSpecs []aws.TagSpecification) []string {
 	duplicatedTags := []string{}
 	for _, spec := range tagSpecs {
 		tagNames[spec.Name] += 1
+		// Only append the duplicated tag on the second occurrence to prevent it
+		// being listed multiple times when there are more than 2 occurrences.
 		if tagNames[spec.Name] == 2 {
 			duplicatedTags = append(duplicatedTags, spec.Name)
 		}


### PR DESCRIPTION
The map used in `getDuplicatedTags` does not guarantee any order when items are read,
so create the `duplicatedTags` slice on the fly in the first loop.

Fixes flakiness of the `TestValidateAWSProviderSpec/with_double_tag_names,_lists_duplicated_tags` test.