### PR TITLE
machine-api-operator: release leader lock when context is cancelled

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -73,10 +73,11 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	stopCh := make(chan struct{})
 
 	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
-		Lock:          CreateResourceLock(cb, componentNamespace, componentName),
-		LeaseDuration: util.LeaseDuration,
-		RenewDeadline: util.RenewDeadline,
-		RetryPeriod:   util.RetryPeriod,
+		Lock:            CreateResourceLock(cb, componentNamespace, componentName),
+		ReleaseOnCancel: true,
+		LeaseDuration:   util.LeaseDuration,
+		RenewDeadline:   util.RenewDeadline,
+		RetryPeriod:     util.RetryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				ctrlCtx := CreateControllerContext(cb, stopCh, componentNamespace)


### PR DESCRIPTION
This should speed up machine-api operator updates.


Testing 4.9 upgrades:
* [test upgrade 4.9 openshift/machine-api-operator#933 aws](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1447830580975636480)
* [test upgrade 4.9 openshift/machine-api-operator#933 gcp](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-gcp/1447830601599029248)
* [test upgrade 4.9 openshift/machine-api-operator#933 azure](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-azure/1447830619546456064)