### PR TITLE
Remove "kubevirt-machine-controllers" image from permanently

### DIFF
--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -20,6 +20,5 @@ data:
       "clusterAPIControllerGCP": "registry.svc.ci.openshift.org/openshift:gcp-machine-controllers",
       "clusterAPIControllerIBMCloud": "registry.svc.ci.openshift.org/openshift:ibmcloud-machine-controllers",
       "clusterAPIControllerOvirt": "registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers",
-      "clusterAPIControllerKubevirt": "registry.svc.ci.openshift.org/openshift:kubevirt-machine-controllers",
       "clusterAPIControllerVSphere": "registry.svc.ci.openshift.org/openshift:machine-api-operator"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -46,7 +46,3 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:ovirt-machine-controllers
-  - name: kubevirt-machine-controllers
-    from:
-      kind: DockerImage
-      name: registry.svc.ci.openshift.org/openshift:kubevirt-machine-controllers

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -45,7 +45,6 @@ type Images struct {
 	ClusterAPIControllerGCP       string `json:"clusterAPIControllerGCP"`
 	ClusterAPIControllerOvirt     string `json:"clusterAPIControllerOvirt"`
 	ClusterAPIControllerVSphere   string `json:"clusterAPIControllerVSphere"`
-	ClusterAPIControllerKubevirt  string `json:"clusterAPIControllerKubevirt"`
 	ClusterAPIControllerIBMCloud  string `json:"clusterAPIControllerIBMCloud"`
 	KubeRBACProxy                 string `json:"kubeRBACProxy"`
 }
@@ -90,8 +89,6 @@ func getProviderControllerFromImages(platform configv1.PlatformType, images Imag
 		return images.ClusterAPIControllerOvirt, nil
 	case configv1.VSpherePlatformType:
 		return images.ClusterAPIControllerVSphere, nil
-	case configv1.KubevirtPlatformType:
-		return images.ClusterAPIControllerKubevirt, nil
 	case configv1.IBMCloudPlatformType:
 		return images.ClusterAPIControllerIBMCloud, nil
 	case kubemarkPlatform:

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -18,7 +18,6 @@ var (
 	expectedGCPImage                = "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0"
 	expectedOvirtImage              = "quay.io/openshift/origin-ovirt-machine-controllers"
 	expectedVSphereImage            = "docker.io/openshift/origin-machine-api-operator:v4.0.0"
-	expectedKubevirtImage           = "quay.io/openshift/origin-kubevirt-machine-controllers"
 )
 
 func TestGetProviderFromInfrastructure(t *testing.T) {
@@ -165,9 +164,6 @@ func TestGetImagesFromJSONFile(t *testing.T) {
 	if img.ClusterAPIControllerVSphere != expectedVSphereImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedVSphereImage, img.ClusterAPIControllerVSphere)
 	}
-	if img.ClusterAPIControllerKubevirt != expectedKubevirtImage {
-		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedKubevirtImage, img.ClusterAPIControllerKubevirt)
-	}
 }
 
 func TestGetProviderControllerFromImages(t *testing.T) {
@@ -213,10 +209,6 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 		{
 			provider:      configv1.OvirtPlatformType,
 			expectedImage: expectedOvirtImage,
-		},
-		{
-			provider:      configv1.KubevirtPlatformType,
-			expectedImage: expectedKubevirtImage,
 		},
 	}
 

--- a/pkg/operator/fixtures/images.json
+++ b/pkg/operator/fixtures/images.json
@@ -8,7 +8,6 @@
   "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers:v4.0.0",
   "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
   "clusterAPIControllerVSphere": "docker.io/openshift/origin-machine-api-operator:v4.0.0",
-  "clusterAPIControllerKubevirt": "quay.io/openshift/origin-kubevirt-machine-controllers",
   "clusterAPIControllerIBMCloud": "quay.io/openshift/origin-ibmcloud-machine-controllers:v4.0.0",
   "kubeRBACProxy": "docker.io/openshift/origin-kube-rbac-proxy:v4.0.0"
 }


### PR DESCRIPTION
It is done as part of the decision to stop support kubevirt platform in Openshift Installer