### PR TITLE
remove kubevirt credentials request

### DIFF
--- a/hack/push-updates.sh
+++ b/hack/push-updates.sh
@@ -48,7 +48,6 @@ cluster-api-provider-azure
 cluster-api-provider-baremetal
 cluster-api-provider-gcp
 cluster-api-provider-openstack
-cluster-api-provider-kubevirt
 "
 TITLE=""
 SHA=""

--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -163,23 +163,6 @@ kind: CredentialsRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: openshift-machine-api-kubevirt
-  namespace: openshift-cloud-credential-operator
-  annotations:
-    include.release.openshift.io/self-managed-high-availability: "true"
-spec:
-  secretRef:
-    namespace: openshift-machine-api
-    name: kubevirt-credentials
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: KubevirtProviderSpec
----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-ibmcloud
   namespace: openshift-cloud-credential-operator
   annotations:


### PR DESCRIPTION
as the kubevirt images have been removed, this change completes the
operation by removing the credentials request and cleaning up one of the
updater functions.