### PR TITLE
Bug 1986237: add avg_over_time to the MachineNotYetDeleted alert

### DIFF
--- a/docs/user/Alerts.md
+++ b/docs/user/Alerts.md
@@ -39,7 +39,7 @@ Machine has been in the "Deleting" phase for a long time. Deleting phase is adde
 ### Query
 ```
 # for: 360m
-sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
+sum by (name, namespace) (avg_over_time(mapi_machine_created_timestamp_seconds{phase="Deleting"}[15m])) > 0
 ```
 
 ### Possible Causes

--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -43,7 +43,7 @@ spec:
       rules:
         - alert: MachineNotYetDeleted
           expr: |
-            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase="Deleting"}) > 0
+            sum by (name, namespace) (avg_over_time(mapi_machine_created_timestamp_seconds{phase="Deleting"}[15m])) > 0
           for: 360m
           labels:
             severity: warning


### PR DESCRIPTION
This change is adding the averaging function to help smooth out drops
that can occur when the MAO is redeployed or moved within a cluster. It
is possible for the deletion phase timestamp metric to occassionaly drop
out, when this happens it can upset the entire 6 hour window for the
metric. With this change we introduce a 15 min sliding average for the
metric, which should alleviate issues where the MAO is gone for up to <
15 minutes.