### PR TITLE
Bug 2010368: fix mispelled field in alert rules

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -72,7 +72,7 @@ spec:
           for: 30m
           labels:
             severity: warning
-          annotation:
+          annotations:
             summary: "machine health check {{ $labels.name }} has been disabled by short circuit for more than 30 minutes"
             description: |
               The number of unhealthy machines has exceeded the `maxUnhealthy` limit for the check, you should check


### PR DESCRIPTION
changes `annotation` to `annotations`