### PR TITLE
Bug 2005052: Deny selector updates via webhook to prevent leaked machines

### DIFF
--- a/pkg/webhooks/machineset_webhook.go
+++ b/pkg/webhooks/machineset_webhook.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -85,9 +87,20 @@ func (h *machineSetValidatorHandler) Handle(ctx context.Context, req admission.R
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
+	var oldMS *machinev1.MachineSet
+	if len(req.OldObject.Raw) > 0 {
+		// oldMS must only be initialised if there is an old object (ie on UPDATE or DELETE).
+		// It should be nil otherwise to allow skipping certain validations that rely on
+		// the presence of the old object.
+		oldMS = &machinev1.MachineSet{}
+		if err := h.decoder.DecodeRaw(req.OldObject, oldMS); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+	}
+
 	klog.V(3).Infof("Validate webhook called for MachineSet: %s", ms.GetName())
 
-	ok, warnings, errs := h.validateMachineSet(ms)
+	ok, warnings, errs := h.validateMachineSet(ms, oldMS)
 	if !ok {
 		return admission.Denied(errs.Error()).WithWarnings(warnings...)
 	}
@@ -117,8 +130,8 @@ func (h *machineSetDefaulterHandler) Handle(ctx context.Context, req admission.R
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledMachineSet).WithWarnings(warnings...)
 }
 
-func (h *machineSetValidatorHandler) validateMachineSet(ms *machinev1.MachineSet) (bool, []string, utilerrors.Aggregate) {
-	var errs []error
+func (h *machineSetValidatorHandler) validateMachineSet(ms, oldMS *machinev1.MachineSet) (bool, []string, utilerrors.Aggregate) {
+	errs := validateMachineSetSpec(ms, oldMS)
 
 	// Create a Machine from the MachineSet and validate the Machine template
 	m := &machinev1.Machine{
@@ -149,4 +162,14 @@ func (h *machineSetDefaulterHandler) defaultMachineSet(ms *machinev1.MachineSet)
 	// Restore the defaulted template
 	ms.Spec.Template.Spec = m.Spec
 	return true, warnings, nil
+}
+
+// validateMachineSetSpec is used to validate any changes to the MachineSet spec outside of
+// the providerSpec. Eg it can be used to verify changes to the selector.
+func validateMachineSetSpec(ms, oldMS *machinev1.MachineSet) []error {
+	var errs []error
+	if oldMS != nil && !reflect.DeepEqual(ms.Spec.Selector, oldMS.Spec.Selector) {
+		errs = append(errs, field.Forbidden(field.NewPath("spec", "selector"), "selector is immutable"))
+	}
+	return errs
 }


### PR DESCRIPTION
If a user were to modify the selector on a MachineSet, then it would no longer pick up the Machines originally selected by it (unless the Machines had already been updated). In this case, it will create new Machines, orphaning the old Machines.

To prevent this, we should deny updates to the selector once the MachineSet has been created. This will then mimic the behaviour of the built in types, eg Deployment, ReplicaSet, StatefulSet and DaemonSet.

Additionally, and inspired by the behaviour of the built in types, the second commit will prevent updates the mean that the selector will not match the labels of the Machines created by the MachineSet. This will prevent a hot loop of Machine creation where the MachineSet creates a Machine that it can't recognise via the selector.