### PR TITLE
Bug 2031858: stop using beta pre-defined role for compute.targetPools

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -116,13 +116,9 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    skipServiceCheck: true
     predefinedRoles:
-    - "roles/compute.instanceAdmin.v1"
+    - "roles/compute.admin"
     - "roles/iam.serviceAccountUser"
-    - "roles/compute.loadBalancerAdmin"
-# includes compute.targetPools.* currently used to add masters to LB in DR scenarios.
-# https://cloud.google.com/compute/docs/access/iam#compute.loadBalancerAdmin
 
 ---
 apiVersion: cloudcredential.openshift.io/v1


### PR DESCRIPTION
The roles/compute.loadBalancerAdmin pre-defined GCP Role is listed as Beta:

```
[jdiaz@minigoomba ~]$ gcloud iam roles describe
roles/compute.loadBalancerAdmin | grep stage -B1
name: roles/compute.loadBalancerAdmin
stage: BETA
```

The desired permissions from that role revolve around
compute.targetPools.*.

roles/compute.admin provides compute.targetPools.* (and much more), and
it is not Beta.
```
[jdiaz@minigoomba ~]$ gcloud iam roles describe roles/compute.admin |
grep -E 'compute.targetPools|stage'
- compute.targetPools.addHealthCheck
- compute.targetPools.addInstance
- compute.targetPools.create
- compute.targetPools.delete
- compute.targetPools.get
- compute.targetPools.list
- compute.targetPools.removeHealthCheck
- compute.targetPools.removeInstance
- compute.targetPools.update
- compute.targetPools.use
stage: GA
```
roles/compute.admin provides enough permissions that
roles/compute.instanceAdmin.v1 is no longer necessary, so remove that
role as well.

And back out the skipServiceCheck as it shouldn't be necessary any more.