### PR TITLE
Bug 2001008: Change default cloneMode to fullClone.

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1160,6 +1160,9 @@ func validateVSphere(m *machinev1.Machine, config *admissionConfig) (bool, []str
 	if providerSpec.DiskGiB < minVSphereDiskGiB {
 		warnings = append(warnings, fmt.Sprintf("providerSpec.diskGiB: %d is missing or less than the recommended minimum (%d): nodes may fail to start if disk size is too low", providerSpec.DiskGiB, minVSphereDiskGiB))
 	}
+	if providerSpec.CloneMode == machinev1.LinkedClone && providerSpec.DiskGiB > 0 {
+		warnings = append(warnings, fmt.Sprintf("%s clone mode is set. DiskGiB parameter will be ignored, disk size from template will be used.", machinev1.LinkedClone))
+	}
 
 	if providerSpec.UserDataSecret == nil {
 		errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret"), "userDataSecret must be provided"))

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -2323,6 +2323,15 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			expectedOk:       true,
 			expectedWarnings: []string{"providerSpec.diskGiB: 0 is missing or less than the recommended minimum (120): nodes may fail to start if disk size is too low"},
 		},
+		{
+			testCase: "linked clone mode and disk size warning",
+			modifySpec: func(p *machinev1.VSphereMachineProviderSpec) {
+				p.DiskGiB = 100500
+				p.CloneMode = machinev1.LinkedClone
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"linkedClone clone mode is set. DiskGiB parameter will be ignored, disk size from template will be used."},
+		},
 	}
 
 	secret := &corev1.Secret{


### PR DESCRIPTION
Currently, linkedClone uses by default which cause silent diskGiB parameter ignorance
in case if Snapshot specified or clonee template has snapshots.
Disk size from vm template will be used in this case, which might be undesirable.
This commit changes default behaviour of controller, fullClone will be used by default,
linkedClone should be set explicitly.