### PR TITLE
Bug 2011668: Improve powerOff task handling during machine deletion on vsphere platform

### DIFF
--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -232,7 +232,7 @@ func TestMachineEvents(t *testing.T) {
 			operation: func(actuator *Actuator, machine *machinev1.Machine) {
 				actuator.Delete(ctx, machine)
 			},
-			event: "test: reconciler failed to Delete machine: destroying vm in progress, reconciling",
+			event: "test: reconciler failed to Delete machine: destroying vm in progress, requeuing",
 		},
 		{
 			name: "Delete machine event succeed",

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -126,7 +126,7 @@ func (r *Reconciler) create() error {
 			return fmt.Errorf("Failed to check task status: %w", err)
 		}
 	} else if !taskIsFinished {
-		return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+		return fmt.Errorf("%v task %v has not finished", moTask.Info.DescriptionId, moTask.Reference().Value)
 	}
 	// If taskIsFinished then next reconcile should result in update.
 	return nil
@@ -157,9 +157,9 @@ func (r *Reconciler) update() error {
 					Namespace: r.machine.Namespace,
 					Reason:    "Task finished with error",
 				})
-				return err
+				return fmt.Errorf("%v task %v finished with error: %w", moTask.Info.DescriptionId, moTask.Reference().Value, err)
 			} else if !taskIsFinished {
-				return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+				return fmt.Errorf("%v task %v has not finished", moTask.Info.DescriptionId, moTask.Reference().Value)
 			}
 		}
 	}
@@ -241,15 +241,14 @@ func (r *Reconciler) delete() error {
 						Reason:    "Task finished with error",
 					})
 					klog.Errorf("Delete task finished with error: %w", err)
-					return err
+					return fmt.Errorf("%v task %v finished with error: %w", moTask.Info.DescriptionId, moTask.Reference().Value, err)
 				} else {
 					klog.Warningf(
 						"TaskRef points to clone task which finished with error: %w. Proceeding with machine deletion", err,
 					)
-					return err
 				}
 			} else if !taskIsFinished {
-				return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+				return fmt.Errorf("%v task %v has not finished", moTask.Info.DescriptionId, moTask.Reference().Value)
 			}
 		}
 	}
@@ -296,12 +295,21 @@ func (r *Reconciler) delete() error {
 		}
 	}
 
-	if _, err := vm.powerOffVM(); err != nil {
-		return err
+	powerState, err := vm.getPowerState()
+	if err != nil {
+		return fmt.Errorf("can not determine %v vm power state", r.machine.GetName())
+	}
+	if powerState != types.VirtualMachinePowerStatePoweredOff {
+		powerOffTaskRef, err := vm.powerOffVM()
+		if err != nil {
+			return fmt.Errorf("%v: failed to power off vm: %w", r.machine.GetName(), err)
+		}
+		if err := setProviderStatus(powerOffTaskRef, conditionSuccess(), r.machineScope, vm); err != nil {
+			return fmt.Errorf("Failed to set provider status: %w", err)
+		}
+		return fmt.Errorf("powering off vm is in progress, reconciling")
 	}
 
-	// Will this error if VM not all the way powered off yet?  Don't want to
-	// emit an event for a transient condition.
 	task, err := vm.Obj.Destroy(r.Context)
 	if err != nil {
 		metrics.RegisterFailedInstanceDelete(&metrics.MachineLabels{

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -299,7 +299,7 @@ func (r *Reconciler) delete() error {
 
 	powerState, err := vm.getPowerState()
 	if err != nil {
-		return fmt.Errorf("can not determine %v vm power state", r.machine.GetName())
+		return fmt.Errorf("can not determine %v vm power state: %w", r.machine.GetName(), err)
 	}
 	if powerState != types.VirtualMachinePowerStatePoweredOff {
 		powerOffTaskRef, err := vm.powerOffVM()
@@ -307,9 +307,9 @@ func (r *Reconciler) delete() error {
 			return fmt.Errorf("%v: failed to power off vm: %w", r.machine.GetName(), err)
 		}
 		if err := setProviderStatus(powerOffTaskRef, conditionSuccess(), r.machineScope, vm); err != nil {
-			return fmt.Errorf("Failed to set provider status: %w", err)
+			return fmt.Errorf("failed to set provider status: %w", err)
 		}
-		return fmt.Errorf("powering off vm is in progress, reconciling")
+		return fmt.Errorf("powering off vm is in progress, requeuing")
 	}
 
 	task, err := vm.Obj.Destroy(r.Context)
@@ -327,7 +327,7 @@ func (r *Reconciler) delete() error {
 	}
 
 	// TODO: consider returning an error to specify retry time here
-	return fmt.Errorf("destroying vm in progress, reconciling")
+	return fmt.Errorf("destroying vm in progress, requeuing")
 }
 
 // nodeHasVolumesAttached returns true if node status still have volumes attached

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -48,7 +48,9 @@ const (
 
 // vSphere tasks description IDs, for determinate task types (clone, delete, etc)
 const (
-	cloneVmTaskDescriptionId = "VirtualMachine.clone"
+	cloneVmTaskDescriptionId    = "VirtualMachine.clone"
+	destroyVmTaskDescriptionId  = "VirtualMachine.destroy"
+	powerOffVmTaskDescriptionId = "VirtualMachine.powerOff"
 )
 
 // Reconciler runs the logic to reconciles a machine resource towards its desired state

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1407,8 +1407,8 @@ func TestDelete(t *testing.T) {
 				}
 			}
 			// first run should schedule power off
-			if powerOffTask.Info.DescriptionId != "VirtualMachine.powerOff" {
-				t.Errorf("task description expected: VirtualMachine.powerOff, got: %v", powerOffTask.Info.DescriptionId)
+			if powerOffTask.Info.DescriptionId != powerOffVmTaskDescriptionId {
+				t.Errorf("task description expected: %v, got: %v", powerOffVmTaskDescriptionId, powerOffTask.Info.DescriptionId)
 			}
 
 			if err := reconciler.delete(); err == nil {
@@ -1421,8 +1421,8 @@ func TestDelete(t *testing.T) {
 				}
 			}
 			// second run should destroy vm
-			if destroyTask.Info.DescriptionId != "VirtualMachine.destroy" {
-				t.Errorf("task description expected: VirtualMachine.destroy, got: %v", destroyTask.Info.DescriptionId)
+			if destroyTask.Info.DescriptionId != destroyVmTaskDescriptionId {
+				t.Errorf("task description expected: %v, got: %v", destroyVmTaskDescriptionId, destroyTask.Info.DescriptionId)
 			}
 
 			// expect the third call to not find the vm and succeed


### PR DESCRIPTION
Adds powerOff ref saving to machine status for more determenistic handling.
Before in case if powerOff task would lag for some reason,
machine deletion would stuck.
Now powerOff task will be checked before destroy task will be created.

By the way, error messages was extended with adding task type there
in order to provide more information in machine events.