### PR TITLE
Bug 1918005: Use known vSphere cluster to uniquely identify networks.

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -638,7 +638,7 @@ func clone(s *machineScope) (string, error) {
 	}
 
 	klog.V(3).Infof("Getting network devices")
-	networkDevices, err := getNetworkDevices(s, devices)
+	networkDevices, err := getNetworkDevices(s, resourcepool, devices)
 	if err != nil {
 		return "", fmt.Errorf("error getting network specs: %v", err)
 	}
@@ -707,8 +707,9 @@ func getDiskSpec(s *machineScope, devices object.VirtualDeviceList) (types.BaseV
 	}, nil
 }
 
-func getNetworkDevices(s *machineScope, devices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
+func getNetworkDevices(s *machineScope, resourcepool *object.ResourcePool, devices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	var networkDevices []types.BaseVirtualDeviceConfigSpec
+	var backing types.BaseVirtualDeviceBackingInfo
 	// Remove any existing NICs
 	for _, dev := range devices.SelectByType((*types.VirtualEthernetCard)(nil)) {
 		networkDevices = append(networkDevices, &types.VirtualDeviceConfigSpec{
@@ -719,20 +720,39 @@ func getNetworkDevices(s *machineScope, devices object.VirtualDeviceList) ([]typ
 
 	// Add new NICs based on the machine config.
 	for i := range s.providerSpec.Network.Devices {
+		var ccrMo mo.ClusterComputeResource
+
 		netSpec := &s.providerSpec.Network.Devices[i]
 		klog.V(3).Infof("Adding device: %v", netSpec.NetworkName)
 
-		ref, err := s.GetSession().Finder.Network(s.Context, netSpec.NetworkName)
+		clusterRef, err := resourcepool.Owner(s.Context)
 		if err != nil {
-			const multipleFoundMsg = "multiple networks found, specify one in config"
-			const notFoundMsg = "network not found, specify valid value"
-			defaultError := fmt.Errorf("unable to get network for %q: %w", netSpec.NetworkName, err)
-			return nil, handleVSphereError(multipleFoundMsg, notFoundMsg, defaultError, err)
+			return nil, fmt.Errorf("unable to find cluster resource: %w", err)
 		}
 
-		backing, err := ref.EthernetCardBackingInfo(s.Context)
+		clusterRes := object.NewClusterComputeResource(s.GetSession().Client.Client, clusterRef.Reference())
+		err = clusterRes.Properties(s.Context, clusterRef.Reference(), []string{"network"}, &ccrMo)
 		if err != nil {
-			return nil, fmt.Errorf("unable to create new ethernet card backing info for network %q: %w", netSpec.NetworkName, err)
+			return nil, fmt.Errorf("unable to get list of networks in cluster: %w", err)
+		}
+
+		for _, netRef := range ccrMo.Network {
+			netObj := object.NewNetwork(s.GetSession().Client.Client, netRef)
+			networkName, err := netObj.ObjectName(s.Context)
+			if err != nil {
+				return nil, fmt.Errorf("unable to get network name: %w", err)
+			}
+			if netSpec.NetworkName == networkName {
+				backing, err = netObj.EthernetCardBackingInfo(s.Context)
+				if err != nil {
+					return nil, fmt.Errorf("unable to create new ethernet card backing info for network %q: %w", netSpec.NetworkName, err)
+				}
+				break
+			}
+		}
+
+		if backing == nil {
+			return nil, fmt.Errorf("unable to get network for %q: %w", netSpec.NetworkName, err)
 		}
 
 		dev, err := object.EthernetCardTypes().CreateEthernetCard(ethCardType, backing)

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -760,7 +760,7 @@ func getNetworkDevices(s *machineScope, resourcepool *object.ResourcePool, devic
 		}
 
 		if backing == nil {
-			return nil, fmt.Errorf("unable to get network for %q: %w", netSpec.NetworkName, err)
+			return nil, fmt.Errorf("unable to get network for %q", netSpec.NetworkName)
 		}
 
 		dev, err := object.EthernetCardTypes().CreateEthernetCard(ethCardType, backing)

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -624,6 +624,11 @@ func TestGetNetworkDevices(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	resourcePool, err := session.Finder.DefaultResourcePool(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	testCases := []struct {
 		testCase     string
 		providerSpec *machinev1.VSphereMachineProviderSpec
@@ -676,7 +681,7 @@ func TestGetNetworkDevices(t *testing.T) {
 				providerSpec: tc.providerSpec,
 				session:      session,
 			}
-			networkDevices, err := getNetworkDevices(machineScope, devices)
+			networkDevices, err := getNetworkDevices(machineScope, resourcePool, devices)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
vSphere Network names are not necessarily unique, especially in NSX-T environments which our CI uses. The vSphere Cluster is known from within the reconciler and can be used to isolate the unique network needed to clone machines. 

Tracking in bz1918005 and [SPLAT-345](https://issues.redhat.com/browse/SPLAT-345)