### PR TITLE
Bug 2034879: Enforce unique names for lifecycle hooks via webhooks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/uuid v1.1.2
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/openshift/api v0.0.0-20211215120111-7c47a5f63470
+	github.com/openshift/api v0.0.0-20211222145011-3bf13cf5081a
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
 	github.com/openshift/library-go v0.0.0-20211214183058-58531ccbde67
 	github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b

--- a/go.sum
+++ b/go.sum
@@ -534,8 +534,8 @@ github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQ
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/openshift/api v0.0.0-20211209135129-c58d9f695577/go.mod h1:DoslCwtqUpr3d/gsbq4ZlkaMEdYqKxuypsDjorcHhME=
-github.com/openshift/api v0.0.0-20211215120111-7c47a5f63470 h1:kYVTSbYsfLxSBnK8Z2ZN+qgAdclXAf2mYVDyHDfxTZ0=
-github.com/openshift/api v0.0.0-20211215120111-7c47a5f63470/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
+github.com/openshift/api v0.0.0-20211222145011-3bf13cf5081a h1:lJQ6mKlpoUn19dmaLY/ldRm2Mwi+WtTJ2MD6bteLa4o=
+github.com/openshift/api v0.0.0-20211222145011-3bf13cf5081a/go.mod h1:F/eU6jgr6Q2VhMu1mSpMmygxAELd7+BUxs3NHZ25jV4=
 github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20210806203541-4ea9b6da3a37/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/install/0000_30_machine-api-operator_02_machine.crd.yaml
+++ b/install/0000_30_machine-api-operator_02_machine.crd.yaml
@@ -80,6 +80,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -98,6 +101,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/install/0000_30_machine-api-operator_03_machineset.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.crd.yaml
@@ -173,6 +173,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -191,6 +194,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1276,18 +1276,40 @@ func isAzureGovCloud(platformStatus *osconfigv1.PlatformStatus) bool {
 
 func validateMachineLifecycleHooks(m, oldM *machinev1.Machine) []error {
 	var errs []error
-	if !isDeleting(m) || oldM == nil {
-		return errs
+
+	if nameErrs := checkUniqueHookNames(m.Spec.LifecycleHooks.PreDrain, field.NewPath("spec", "lifecycleHooks", "preDrain")); len(nameErrs) > 0 {
+		errs = append(errs, nameErrs...)
+	}
+	if nameErrs := checkUniqueHookNames(m.Spec.LifecycleHooks.PreTerminate, field.NewPath("spec", "lifecycleHooks", "preTerminate")); len(nameErrs) > 0 {
+		errs = append(errs, nameErrs...)
 	}
 
-	changedPreDrain := lifecyclehooks.GetChangedLifecycleHooks(oldM.Spec.LifecycleHooks.PreDrain, m.Spec.LifecycleHooks.PreDrain)
-	if len(changedPreDrain) > 0 {
-		errs = append(errs, field.Forbidden(field.NewPath("spec", "lifecycleHooks", "preDrain"), fmt.Sprintf("pre-drain hooks are immutable when machine is marked for deletion: the following hooks are new or changed: %+v", changedPreDrain)))
+	if isDeleting(m) && oldM != nil {
+		changedPreDrain := lifecyclehooks.GetChangedLifecycleHooks(oldM.Spec.LifecycleHooks.PreDrain, m.Spec.LifecycleHooks.PreDrain)
+		if len(changedPreDrain) > 0 {
+			errs = append(errs, field.Forbidden(field.NewPath("spec", "lifecycleHooks", "preDrain"), fmt.Sprintf("pre-drain hooks are immutable when machine is marked for deletion: the following hooks are new or changed: %+v", changedPreDrain)))
+		}
+
+		changedPreTerminate := lifecyclehooks.GetChangedLifecycleHooks(oldM.Spec.LifecycleHooks.PreTerminate, m.Spec.LifecycleHooks.PreTerminate)
+		if len(changedPreTerminate) > 0 {
+			errs = append(errs, field.Forbidden(field.NewPath("spec", "lifecycleHooks", "preTerminate"), fmt.Sprintf("pre-terminate hooks are immutable when machine is marked for deletion: the following hooks are new or changed: %+v", changedPreTerminate)))
+		}
 	}
 
-	changedPreTerminate := lifecyclehooks.GetChangedLifecycleHooks(oldM.Spec.LifecycleHooks.PreTerminate, m.Spec.LifecycleHooks.PreTerminate)
-	if len(changedPreTerminate) > 0 {
-		errs = append(errs, field.Forbidden(field.NewPath("spec", "lifecycleHooks", "preTerminate"), fmt.Sprintf("pre-terminate hooks are immutable when machine is marked for deletion: the following hooks are new or changed: %+v", changedPreTerminate)))
+	return errs
+}
+
+// checkUniqueHookNames checks that the names of hooks within a lifecycle stage are unique
+func checkUniqueHookNames(hooks []machinev1.LifecycleHook, parent *field.Path) []error {
+	errs := []error{}
+	names := make(map[string]struct{})
+
+	for i, hook := range hooks {
+		if _, found := names[hook.Name]; found {
+			errs = append(errs, field.Forbidden(parent.Index(i).Child("name"), fmt.Sprintf("hook names must be unique within a lifecycle stage, the following hook name is already set: %s", hook.Name)))
+		} else {
+			names[hook.Name] = struct{}{}
+		}
 	}
 
 	return errs

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -817,6 +817,18 @@ func TestMachineUpdate(t *testing.T) {
 				m.Spec.LifecycleHooks = machinev1.LifecycleHooks{}
 			},
 		},
+		{
+			name:         "when duplicating a lifecycle hook",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    awsClusterID,
+			baseProviderSpecValue: &kruntime.RawExtension{
+				Object: defaultAWSProviderSpec.DeepCopy(),
+			},
+			updateMachine: func(m *machinev1.Machine) {
+				m.Spec.LifecycleHooks.PreDrain = []machinev1.LifecycleHook{preDrainHook, preDrainHook}
+			},
+			expectedError: "spec.lifecycleHooks.preDrain[1].name: Forbidden: hook names must be unique within a lifecycle stage, the following hook name is already set: pre-drain",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure.crd.yaml
@@ -210,7 +210,7 @@ spec:
                         resourceGroupID:
                           description: resourceGroupID is the ID of the resource group for the cluster.
                           type: string
-                          pattern: ^rg-[0-9A-Za-z]+$
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
                         resourceTags:
                           description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
                           type: array

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -665,7 +665,7 @@ type AlibabaCloudPlatformStatus struct {
 	// +required
 	Region string `json:"region"`
 	// resourceGroupID is the ID of the resource group for the cluster.
-	// +kubebuilder:validation:Pattern=`^rg-[0-9A-Za-z]+$`
+	// +kubebuilder:validation:Pattern=`^(rg-[0-9A-Za-z]+)?$`
 	// +optional
 	ResourceGroupID string `json:"resourceGroupID,omitempty"`
 	// resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.

--- a/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machine.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machine.crd.yaml
@@ -80,6 +80,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -98,6 +101,9 @@ spec:
                       items:
                         description: LifecycleHook represents a single instance of a lifecycle hook
                         type: object
+                        required:
+                          - name
+                          - owner
                         properties:
                           name:
                             description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machineset.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/0000_10_machineset.crd.yaml
@@ -173,6 +173,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.
@@ -191,6 +194,9 @@ spec:
                               items:
                                 description: LifecycleHook represents a single instance of a lifecycle hook
                                 type: object
+                                required:
+                                  - name
+                                  - owner
                                 properties:
                                   name:
                                     description: Name defines a unique name for the lifcycle hook. The name should be unique and descriptive, ideally 1-3 words, in CamelCase or it may be namespaced, eg. foo.example.com/CamelCase. Names must be unique and should only be managed by a single entity.

--- a/vendor/github.com/openshift/api/machine/v1beta1/types_machine.go
+++ b/vendor/github.com/openshift/api/machine/v1beta1/types_machine.go
@@ -222,7 +222,7 @@ type LifecycleHook struct {
 	// +kubebuilder:validation:Pattern=`^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$`
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=256
-	// +required
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 
 	// Owner defines the owner of the lifecycle hook.
@@ -232,7 +232,7 @@ type LifecycleHook struct {
 	// or an administrator managing the hook.
 	// +kubebuilder:validation:MinLength:=3
 	// +kubebuilder:validation:MaxLength:=512
-	// +required
+	// +kubebuilder:validation:Required
 	Owner string `json:"owner"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -187,7 +187,7 @@ github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
-# github.com/openshift/api v0.0.0-20211215120111-7c47a5f63470
+# github.com/openshift/api v0.0.0-20211222145011-3bf13cf5081a
 ## explicit; go 1.16
 github.com/openshift/api
 github.com/openshift/api/apiserver


### PR DESCRIPTION
As part of the Machine Deletion Hooks proposal, we specify that the hook names should be unique with a lifecycle stage. There is no way currently to do that within open api schemas so this must be done using webhooks.

The following PR updates the lifecycle hook checks to check the names for uniqueness and denies any create/update request should the names be duplicated