### PR TITLE
[OCPCLOUD-1381] Add IAM permissions required for AWS Placement Group enhancement

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -20,12 +20,14 @@ spec:
     statementEntries:
     - effect: Allow
       action:
+      - ec2:CreatePlacementGroup
       - ec2:CreateTags
       - ec2:DescribeAvailabilityZones
       - ec2:DescribeDhcpOptions
       - ec2:DescribeImages
       - ec2:DescribeInstances
       - ec2:DescribeInternetGateways
+      - ec2:DescribePlacementGroups
       - ec2:DescribeSecurityGroups
       - ec2:DescribeSubnets
       - ec2:DescribeVpcs


### PR DESCRIPTION
To enable the changes in https://github.com/openshift/machine-api-provider-aws/pull/16, we need these new permissions within the credentials request.

This has been manually tested and allows the MAPA PR to function as expected