### PR TITLE
Bug 2041971: Bump library-go to fix mutating webhook reconcile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/onsi/gomega v1.17.0
 	github.com/openshift/api v0.0.0-20220119132100-58db72a40994
 	github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3
-	github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492
+	github.com/openshift/library-go v0.0.0-20220121154930-b7889002d63e
 	github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b
 	github.com/prometheus/client_golang v1.11.0
 	github.com/spf13/cobra v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/openshift/build-machinery-go v0.0.0-20210712174854-1bb7fd1518d3/go.mo
 github.com/openshift/build-machinery-go v0.0.0-20211213093930-7e33a7eb4ce3/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3 h1:SG1aqwleU6bGD0X4mhkTNupjVnByMYYuW4XbnCPavQU=
 github.com/openshift/client-go v0.0.0-20211209144617-7385dd6338e3/go.mod h1:cwhyki5lqBmrT0m8Im+9I7PGFaraOzcYPtEz93RcsGY=
-github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492 h1:oj/rSQqVWVj6YJUydZwLz2frrJreiyI4oa9g/YPgMsM=
-github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492/go.mod h1:4UQ9snU1vg53fyTpHQw3vLPiAxI8ub5xrc+y8KPQQFs=
+github.com/openshift/library-go v0.0.0-20220121154930-b7889002d63e h1:XDK1ZB6Q1YmYkxfEkRq9z92yzinaJMf+vvjeELKj+2I=
+github.com/openshift/library-go v0.0.0-20220121154930-b7889002d63e/go.mod h1:6AmNM4N4nHftckybV/U7bQW+5AvK5TW81ndSI6KEidw=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b h1:Q1q8w51pAZdx6LEkaYdSbUaaEOHXTyTXLhtGgIiKaiA=
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -12,6 +12,7 @@ import (
 	osclientset "github.com/openshift/client-go/config/clientset/versioned"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -63,9 +64,11 @@ type Operator struct {
 	proxyLister       configlistersv1.ProxyLister
 	proxyListerSynced cache.InformerSynced
 
+	validatingWebhookCache        resourceapply.ResourceCache
 	validatingWebhookLister       admissionlisterv1.ValidatingWebhookConfigurationLister
 	validatingWebhookListerSynced cache.InformerSynced
 
+	mutatingWebhookCache        resourceapply.ResourceCache
 	mutatingWebhookLister       admissionlisterv1.MutatingWebhookConfigurationLister
 	mutatingWebhookListerSynced cache.InformerSynced
 
@@ -135,9 +138,11 @@ func New(
 	optr.proxyLister = proxyInformer.Lister()
 	optr.proxyListerSynced = proxyInformer.Informer().HasSynced
 
+	optr.validatingWebhookCache = resourceapply.NewResourceCache()
 	optr.validatingWebhookLister = validatingWebhookInformer.Lister()
 	optr.validatingWebhookListerSynced = validatingWebhookInformer.Informer().HasSynced
 
+	optr.mutatingWebhookCache = resourceapply.NewResourceCache()
 	optr.mutatingWebhookLister = mutatingWebhookInformer.Lister()
 	optr.mutatingWebhookListerSynced = mutatingWebhookInformer.Informer().HasSynced
 

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -15,6 +15,7 @@ import (
 	openshiftv1 "github.com/openshift/api/config/v1"
 	fakeos "github.com/openshift/client-go/config/clientset/versioned/fake"
 	configinformersv1 "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -68,7 +69,9 @@ func newFakeOperator(kubeObjects []runtime.Object, osObjects []runtime.Object, s
 		proxyListerSynced:             proxyInformer.Informer().HasSynced,
 		daemonsetListerSynced:         daemonsetInformer.Informer().HasSynced,
 		featureGateCacheSynced:        featureGateInformer.Informer().HasSynced,
+		mutatingWebhookCache:          resourceapply.NewResourceCache(),
 		mutatingWebhookListerSynced:   mutatingWebhookInformer.Informer().HasSynced,
+		validatingWebhookCache:        resourceapply.NewResourceCache(),
 		validatingWebhookListerSynced: validatingWebhookInformer.Informer().HasSynced,
 	}
 

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -195,9 +195,10 @@ func (optr *Operator) syncWebhookConfiguration() error {
 }
 
 func (optr *Operator) syncValidatingWebhook() error {
-	validatingWebhook, updated, err := resourceapply.ApplyValidatingWebhookConfiguration(context.TODO(), optr.kubeClient.AdmissionregistrationV1(),
+	validatingWebhook, updated, err := resourceapply.ApplyValidatingWebhookConfigurationImproved(context.TODO(), optr.kubeClient.AdmissionregistrationV1(),
 		events.NewLoggingEventRecorder(optr.name),
-		mapiwebhooks.NewValidatingWebhookConfiguration())
+		mapiwebhooks.NewValidatingWebhookConfiguration(),
+		optr.validatingWebhookCache)
 	if err != nil {
 		return err
 	}
@@ -209,9 +210,10 @@ func (optr *Operator) syncValidatingWebhook() error {
 }
 
 func (optr *Operator) syncMutatingWebhook() error {
-	validatingWebhook, updated, err := resourceapply.ApplyMutatingWebhookConfiguration(context.TODO(), optr.kubeClient.AdmissionregistrationV1(),
+	validatingWebhook, updated, err := resourceapply.ApplyMutatingWebhookConfigurationImproved(context.TODO(), optr.kubeClient.AdmissionregistrationV1(),
 		events.NewLoggingEventRecorder(optr.name),
-		mapiwebhooks.NewMutatingWebhookConfiguration())
+		mapiwebhooks.NewMutatingWebhookConfiguration(),
+		optr.mutatingWebhookCache)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourceapply/generic.go
@@ -206,13 +206,13 @@ func ApplyDirectly(ctx context.Context, clients *ClientHolder, recorder events.R
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyValidatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *admissionregistrationv1.MutatingWebhookConfiguration:
 			if clients.kubeClient == nil {
 				result.Error = fmt.Errorf("missing kubeClient")
 			} else {
-				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfiguration(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t)
+				result.Result, result.Changed, result.Error = ApplyMutatingWebhookConfigurationImproved(ctx, clients.kubeClient.AdmissionregistrationV1(), recorder, t, cache)
 			}
 		case *storagev1.CSIDriver:
 			if clients.kubeClient == nil {

--- a/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/v1helpers/helpers.go
@@ -383,3 +383,42 @@ func InjectObservedProxyIntoContainers(podSpec *corev1.PodSpec, containerNames [
 
 	return nil
 }
+
+func InjectTrustedCAIntoContainers(podSpec *corev1.PodSpec, configMapName string, containerNames []string) error {
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: "non-standard-root-system-trust-ca-bundle",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: configMapName,
+				},
+				Items: []corev1.KeyToPath{
+					{Key: "ca-bundle.crt", Path: "tls-ca-bundle.pem"},
+				},
+			},
+		},
+	})
+
+	for _, containerName := range containerNames {
+		for i := range podSpec.InitContainers {
+			if podSpec.InitContainers[i].Name == containerName {
+				podSpec.InitContainers[i].VolumeMounts = append(podSpec.InitContainers[i].VolumeMounts, corev1.VolumeMount{
+					Name:      "non-standard-root-system-trust-ca-bundle",
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly:  true,
+				})
+			}
+		}
+		for i := range podSpec.Containers {
+			if podSpec.Containers[i].Name == containerName {
+				podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, corev1.VolumeMount{
+					Name:      "non-standard-root-system-trust-ca-bundle",
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					ReadOnly:  true,
+				})
+			}
+		}
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -269,7 +269,7 @@ github.com/openshift/client-go/machine/informers/externalversions/internalinterf
 github.com/openshift/client-go/machine/informers/externalversions/machine
 github.com/openshift/client-go/machine/informers/externalversions/machine/v1beta1
 github.com/openshift/client-go/machine/listers/machine/v1beta1
-# github.com/openshift/library-go v0.0.0-20211220195323-eca2c467c492
+# github.com/openshift/library-go v0.0.0-20220121154930-b7889002d63e
 ## explicit; go 1.17
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
 github.com/openshift/library-go/pkg/config/clusterstatus


### PR DESCRIPTION
To include the fix in https://github.com/openshift/library-go/pull/1293 for an issue causing the reconciliation of mutating webhooks to not happen.
Also uses the improved version of `Apply*WebhookConfiguration` with cache.
For more details on the bug: https://bugzilla.redhat.com/show_bug.cgi?id=2041971

Here is an attempt to reproduce the issue with this fix
(the reproduction steps are available on the linked Bugzilla issue):
```
# check the paths of the mutatingwebhookconfiguration machine-api config
[~] $ oc -n openshift-machine-api get mutatingwebhookconfiguration machine-api -o yaml | grep path
      path: /mutate-machine-openshift-io-v1beta1-machine
      path: /mutate-machine-openshift-io-v1beta1-machineset
      
[~] $ oc -n openshift-machine-api get pods
NAME                                          READY   STATUS    RESTARTS   AGE
cluster-autoscaler-operator-f8f5c6d79-hx5qn   2/2     Running   0          143m
cluster-baremetal-operator-86d698c796-hq6vw   2/2     Running   0          143m
machine-api-controllers-676954949c-8w5rc      7/7     Running   0          142m
machine-api-operator-869df657b8-mwrns         2/2     Running   0          143m

# scale down the machine-api-operator
[~] $ oc scale deployment machine-api-operator -n openshift-machine-api --replicas=0
deployment.apps/machine-api-operator scaled

# edit the machine-api mutatingwebhookconfiguration to change some bits of the config to check the reconciliation mechanism
[~] $ oc -n openshift-machine-api edit mutatingwebhookconfiguration machine-api
mutatingwebhookconfiguration.admissionregistration.k8s.io/machine-api edited

# the two paths of the mutatingwebhookconfiguration  have been changed with the editor to: 
# path: /mutate-machine-openshift-io-v1beta1-machineset2
# path: /mutate-machine-openshift-io-v1beta1-machine2

# check that the change has happened
[~] $ oc -n openshift-machine-api get mutatingwebhookconfiguration machine-api -o yaml | grep path
      path: /mutate-machine-openshift-io-v1beta1-machine2
      path: /mutate-machine-openshift-io-v1beta1-machineset2

# scale the machine-api-operator back up
[~] $ oc scale deployment machine-api-operator -n openshift-machine-api --replicas=1
deployment.apps/machine-api-operator scaled

# wait some time for the operator to come back and get leadership
# then check again the machine-api mutatingwebhookconfiguration
[~] $ oc -n openshift-machine-api get mutatingwebhookconfiguration machine-api -o yaml | grep path
      path: /mutate-machine-openshift-io-v1beta1-machine
      path: /mutate-machine-openshift-io-v1beta1-machineset

# the paths have been brought back to the default values by the machine-api-operator
```
After the fix, the issue is no longer reproducible.