### PR TITLE
[OCPCLOUD-1260] modify prometheus alerts to ignore pod

### DIFF
--- a/docs/user/Alerts.md
+++ b/docs/user/Alerts.md
@@ -5,7 +5,7 @@ persisted for 10 minutes or longer.
 ### Query
 ```
 # for: 60m
-(mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+sum by (name, namespace) (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
 ```
 
 ### Possible Causes
@@ -22,7 +22,7 @@ Machine did not reach the “Running” Phase.  Running phase is when the machin
 ### Query
 ```
 # for: 60m
-(mapi_machine_created_timestamp_seconds{phase!="Running|Deleting"}) > 0
+sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase!="Running|Deleting"}) > 0
 ```
 
 ### Possible Causes

--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -29,7 +29,7 @@ function runTestsCI() {
     JUNIT_LOCATION="$ARTIFACT_DIR"/junit_machine_api_operator.xml
     echo "jUnit location: $JUNIT_LOCATION"
     go install -mod= github.com/jstemmer/go-junit-report@latest
-    go test -v ./pkg/... ./cmd/... | tee >(go-junit-report > "$JUNIT_LOCATION")
+    go test -p 1 -v ./pkg/... ./cmd/... | tee >(go-junit-report > "$JUNIT_LOCATION")
   else
     echo "\$ARTIFACT_DIR not set or does not exists, no jUnit will be published"
     make unit

--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -16,7 +16,7 @@ spec:
       rules:
         - alert: MachineWithoutValidNode
           expr: |
-             (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+             sum by (name, namespace) (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
           for: 60m
           labels:
             severity: warning
@@ -29,7 +29,7 @@ spec:
       rules:
         - alert: MachineWithNoRunningPhase
           expr: |
-            (mapi_machine_created_timestamp_seconds{phase!~"Running|Deleting"}) > 0
+            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase!~"Running|Deleting"}) > 0
           for: 60m
           labels:
             severity: warning


### PR DESCRIPTION
By default prometheus metrics in kubernetes contain labels for the pod and instance that created a metric series. If these labels
change during the metric series then it causes a new metric series to be created. When this happens, a long running alert will get reset even if the target of the alert (eg a machine) is the same.

This has deleterious effects when considering things like machines in "Deleting" phase, or missing a Node reference.

This change makes it so that the alert will ignore changes in the pod label during the duration of the alert. It is being added to account for cases where the machine-api-operator pod might be rescheduled and thus its pod name will change. This should allow the alert to persist.

Related to: https://github.com/openshift/machine-api-operator/pull/913