### PR TITLE
[OCPCLOUD-1384] Allow to remove ec2 placement groups

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -22,6 +22,7 @@ spec:
       action:
       - ec2:CreatePlacementGroup
       - ec2:CreateTags
+      - ec2:DeletePlacementGroup
       - ec2:DescribeAvailabilityZones
       - ec2:DescribeDhcpOptions
       - ec2:DescribeImages


### PR DESCRIPTION
To successfully delete placement groups in AWS we have to grant the permission to machine-api-provider-aws.