### PR TITLE
allow DeleteTags action for openshift-machine-api-aws user

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -22,6 +22,7 @@ spec:
       action:
       - ec2:CreatePlacementGroup
       - ec2:CreateTags
+      - ec2:DeleteTags
       - ec2:DeletePlacementGroup
       - ec2:DescribeAvailabilityZones
       - ec2:DescribeDhcpOptions


### PR DESCRIPTION
Currently AWS credentials created for openshift-machine-api-aws user has access to create tags and for [RFE-2012](https://issues.redhat.com/browse/RFE-2012) requires permission for deleting tags of ec2 instances, adding DeleteTags capability for openshift-machine-api-aws user.