### PR TITLE
Remove 30s wait before creating a machine

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -380,7 +380,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		if err := r.updateStatus(ctx, m, phaseProvisioning, nil, originalConditions); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{RequeueAfter: requeueAfter}, nil
+		return reconcile.Result{Requeue: true}, nil
 	}
 
 	klog.Infof("%v: reconciling machine triggers idempotent create", machineName)

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -312,7 +312,7 @@ func TestReconcileRequest(t *testing.T) {
 				existCallCount:  1,
 				updateCallCount: 0,
 				deleteCallCount: 0,
-				result:          reconcile.Result{RequeueAfter: requeueAfter},
+				result:          reconcile.Result{Requeue: true},
 				error:           false,
 				phase:           phaseProvisioning,
 			},


### PR DESCRIPTION
In the machine create workflow we were setting the phase to Provisioning
and then requeuing with the default 30s delay before starting the actual
machine creation. This delay is unnecessary in this case. We let the
default rate limiter handle it instead, which will requeue after 5ms.