### PR TITLE
[OCPCLOUD-1419] Add pd-balanced disks support for GCP

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1139,7 +1139,7 @@ func validateGCPDisks(disks []*machinev1.GCPDisk, parentPath *field.Path) []erro
 		}
 
 		if disk.Type != "" {
-			diskTypes := sets.NewString("pd-standard", "pd-ssd")
+			diskTypes := sets.NewString("pd-standard", "pd-ssd", "pd-balanced")
 			if !diskTypes.Has(disk.Type) {
 				errs = append(errs, field.NotSupported(fldPath.Child("type"), disk.Type, diskTypes.List()))
 			}

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -2448,7 +2448,19 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk:    false,
-			expectedError: "providerSpec.disks[0].type: Unsupported value: \"invalid\": supported values: \"pd-ssd\", \"pd-standard\"",
+			expectedError: "providerSpec.disks[0].type: Unsupported value: \"invalid\": supported values: \"pd-balanced\", \"pd-ssd\", \"pd-standard\"",
+		},
+		{
+			testCase: "with a disk type that is supported",
+			modifySpec: func(p *machinev1.GCPMachineProviderSpec) {
+				p.Disks = []*machinev1.GCPDisk{
+					{
+						SizeGB: 16,
+						Type:   "pd-balanced",
+					},
+				}
+			},
+			expectedOk: true,
 		},
 		{
 			testCase: "with no service accounts",


### PR DESCRIPTION
This commit updates the webhook validation, allowing to set "pd-balanced" disk type for GCP platform.