### PR TITLE
[WIP] adding MachineWithoutValidNode and MachineWithNoRunningPhase critical alert for master nodes

### DIFF
--- a/install/0000_90_machine-api-operator_04_alertrules.yaml
+++ b/install/0000_90_machine-api-operator_04_alertrules.yaml
@@ -16,7 +16,17 @@ spec:
       rules:
         - alert: MachineWithoutValidNode
           expr: |
-             sum by (name, namespace) (mapi_machine_created_timestamp_seconds unless on(node) kube_node_info) > 0
+             sum by (name, namespace) (mapi_machine_created_timestamp_seconds{name=~".*master.*"} unless on(node) kube_node_info) > 0
+          for: 60m
+          labels:
+            severity: critical
+          annotations:
+            summary: "master machine {{ $labels.name }} does not have valid node reference"
+            description: |
+              This could indicate that the master node has been unexpectedly terminated.
+        - alert: MachineWithoutValidNode
+          expr: |
+             sum by (name, namespace) (mapi_machine_created_timestamp_seconds{name!~".*master.*"} unless on(node) kube_node_info) > 0
           for: 60m
           labels:
             severity: warning
@@ -29,7 +39,18 @@ spec:
       rules:
         - alert: MachineWithNoRunningPhase
           expr: |
-            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{phase!~"Running|Deleting"}) > 0
+            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{name=~".*master.*", phase!~"Running|Deleting"}) > 0
+          for: 60m
+          labels:
+            severity: critical
+          annotations:
+            summary: "master machine {{ $labels.name }} is in phase: {{ $labels.phase }}"
+            description: |
+              The machine has been without a Running or Deleting phase for more than 60 minutes.
+              This could indicate that the master node has been unexpectedly terminated.
+        - alert: MachineWithNoRunningPhase
+          expr: |
+            sum by (name, namespace) (mapi_machine_created_timestamp_seconds{name!~".*master.*", phase!~"Running|Deleting"}) > 0
           for: 60m
           labels:
             severity: warning


### PR DESCRIPTION
Closes [OSD-11298](https://issues.redhat.com//browse/OSD-11298)

Testing:

So far I have only been able to verify the syntax/semantics of the promql queries.

For testing the old queries I updated, I found a cluster that had both alerts fire recently, connected to it and ran the updated queries in Prometheus to make sure they returned the same result set as the unmodified query (no shareable link so youll have to ):
- [MachineWithNoRunningPhase](https://redhat.pagerduty.com/alerts/Q3G2IMH7JUE3XA) - [cluster backplane proxy](http://127.0.0.1:56309/graph?g0.expr=sum%20by%20(name%2C%20namespace)%20(mapi_machine_created_timestamp_seconds%7Bname!~%22.*master.*%22%7D%20unless%20on(node)%20kube_node_info)%20%3E%200&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g0.end_input=2022-05-04%2000%3A20%3A38&g0.moment_input=2022-05-04%2000%3A20%3A38)
- [MachineWithoutValidNode](https://redhat.pagerduty.com/incidents/Q1TSS9O0Y1NZNW) - [cluster backplane proxy](http://127.0.0.1:56309/graph?g0.expr=sum%20by%20(name%2C%20namespace)%20(mapi_machine_created_timestamp_seconds%7Bname!~%22.*master.*%22%2C%20phase!~%22Running%7CDeleting%22%7D)%20%3E%200&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h&g0.end_input=2022-05-04%2000%3A20%3A38&g0.moment_input=2022-05-04%2000%3A20%3A38)

New queries were harder. The cluster we know was showing these symptoms no longer exists. So far all I have been able to do is verify slightly modified versions of the queries against hive shards: 
- [Promlens query master nodes](https://promlens.devshift.net/?l=HQPAB1L6_3I)

I'm going to write up the sop for dealing with them first then see about getting something deployed to stage where i can create a test cluster.