### PR TITLE
Prevent calls to create VMs when objects are stale

### DIFF
--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -441,20 +441,23 @@ func TestReconcileRequest(t *testing.T) {
 			act := newTestActuator()
 			act.ExistsValue = tc.existsValue
 			machinev1.AddToScheme(scheme.Scheme)
+
+			cl := fake.NewFakeClientWithScheme(scheme.Scheme,
+				&machineNoPhase,
+				&machineProvisioning,
+				&machineProvisioned,
+				&machineDeleting,
+				&machineDeletingPreDrainHook,
+				&machineDeletingPreDrainHookWithoutNode,
+				&machineDeletingPreTerminateHook,
+				&machineFailed,
+				&machineRunning,
+			)
 			r := &ReconcileMachine{
-				Client: fake.NewFakeClientWithScheme(scheme.Scheme,
-					&machineNoPhase,
-					&machineProvisioning,
-					&machineProvisioned,
-					&machineDeleting,
-					&machineDeletingPreDrainHook,
-					&machineDeletingPreDrainHookWithoutNode,
-					&machineDeletingPreTerminateHook,
-					&machineFailed,
-					&machineRunning,
-				),
-				scheme:   scheme.Scheme,
-				actuator: act,
+				Client:       cl,
+				directClient: cl,
+				scheme:       scheme.Scheme,
+				actuator:     act,
 			}
 
 			result, err := r.Reconcile(ctx, tc.request)

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -61,7 +61,10 @@ func TestReconcile(t *testing.T) {
 	c = mgr.GetClient()
 
 	a := newTestActuator()
-	recFn := newReconciler(mgr, a)
+	recFn, err := newReconciler(mgr, a)
+	if err != nil {
+		t.Fatalf("error constructing reconciler: %v", err)
+	}
 	if err := add(mgr, recFn); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}


### PR DESCRIPTION
Because we use informers as a read cache, the object we fetch at the beginning of each reconcile may not be the most up to date version. We perform a number of checks on the object as safety measures before we eventually conclude that the machine does not yet exist and should be created.

In the past, we have seen issues where Create can get called multiple times per Machine object. This has lead to various checks and balances within the actuator Create functions to attempt to make sure we detect that we have already created the Machine.

However, often this relies on some status field being set on the Machine object, eg an InstanceID.

We have been seeing instances where the status update from the Create call is not synced to the informer cache before we reconcile it again. In this case, the Create call and the checks/balances we have in place may fail and we may leak instances by creating a second VM.

In an effort to mitigate this, we can use a direct client (one that doesn't use a read cache) to fetch the latest Machine when (and only when) we think we need to create a Machine. By fetching the object so late in the reconcile, we avoid significantly increasing load on the API server as the preceding checks should filter before we get here in most reconciles, ie once a Machine is created we shouldn't need to do this.

Rather than passing the updated object directly to Create, instead requeue the object when the resource version has changed so that we can run through the previosuly mentioned checks with the newer version, eg it may now show as provisioned meaning we wouldn't attempt to Create with the updated version, the decisions tree may change so we must start the reconcile again.

This should reduce the number of invalid calls to Create in a platform agnostic way and reduce the likelihood of leaking instances across multiple platforms.

CC @damdo @mdbooth 