### PR TITLE
Don't force a requeue after updating Status.Phase

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -380,7 +380,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		if err := r.updateStatus(ctx, m, phaseProvisioning, nil, originalConditions); err != nil {
 			return reconcile.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{}, nil
 	}
 
 	klog.Infof("%v: reconciling machine triggers idempotent create", machineName)

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -312,7 +312,7 @@ func TestReconcileRequest(t *testing.T) {
 				existCallCount:  1,
 				updateCallCount: 0,
 				deleteCallCount: 0,
-				result:          reconcile.Result{Requeue: true},
+				result:          reconcile.Result{},
 				error:           false,
 				phase:           phaseProvisioning,
 			},


### PR DESCRIPTION
The forced requeue is redundant as we just updated Status.Phase so the
informer will call us again anyway when it sees the change.

Worse, forcing the requeue causes us to be called before the informer
sees the Status update, meaning we're called with a stale Machine
object. This will cause a storm of Status updates until the informer
catches up.