### PR TITLE
Bug 2083237: Set vCenter client request timeout

### DIFF
--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/vmware/govmomi/vapi/rest"
 	"github.com/vmware/govmomi/vim25/mo"
@@ -40,6 +41,7 @@ var sessionMU sync.Mutex
 
 const (
 	managedObjectTypeTask = "Task"
+	clientTimeout         = 30 * time.Second
 )
 
 // Session is a vSphere session with a configured Finder.
@@ -85,6 +87,7 @@ func GetOrCreate(
 	// See https://github.com/vmware/govmomi/blob/master/client.go#L91
 	soapURL.User = nil
 	client, err := govmomi.NewClient(ctx, soapURL, insecure)
+	client.Timeout = clientTimeout
 	if err != nil {
 		return nil, fmt.Errorf("error setting up new vSphere SOAP client: %w", err)
 	}

--- a/pkg/controller/vsphere/session/session.go
+++ b/pkg/controller/vsphere/session/session.go
@@ -41,7 +41,7 @@ var sessionMU sync.Mutex
 
 const (
 	managedObjectTypeTask = "Task"
-	clientTimeout         = 30 * time.Second
+	clientTimeout         = 15 * time.Second
 )
 
 // Session is a vSphere session with a configured Finder.
@@ -52,6 +52,18 @@ type Session struct {
 
 	username string
 	password string
+}
+
+func newClientWithTimeout(ctx context.Context, u *url.URL, insecure bool, timeout time.Duration) (*govmomi.Client, error) {
+	clientCreateCtx, clientCreateCtxCancel := context.WithTimeout(ctx, timeout)
+	defer clientCreateCtxCancel()
+	// It makes call to vcenter during new client creation, so pass context with timeout there.
+	client, err := govmomi.NewClient(clientCreateCtx, u, insecure)
+	if err != nil {
+		return nil, err
+	}
+	client.Timeout = timeout
+	return client, nil
 }
 
 // GetOrCreate gets a cached session or creates a new one if one does not
@@ -86,12 +98,10 @@ func GetOrCreate(
 	// Set user to nil there for prevent login during client creation.
 	// See https://github.com/vmware/govmomi/blob/master/client.go#L91
 	soapURL.User = nil
-	client, err := govmomi.NewClient(ctx, soapURL, insecure)
-	client.Timeout = clientTimeout
+	client, err := newClientWithTimeout(ctx, soapURL, insecure, clientTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("error setting up new vSphere SOAP client: %w", err)
 	}
-
 	// Set up user agent before login for being able to track mapi component in vcenter sessions list
 	client.UserAgent = "machineAPIvSphereProvider"
 	if err := client.Login(ctx, url.UserPassword(username, password)); err != nil {


### PR DESCRIPTION
Currently there is no request timeout in vCenter client, which might lead to controller blockage in case if vCenter will never respond.