### PR TITLE
Show warnings if provider specs have invalid GroupVersionKind

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -713,6 +714,10 @@ func validateAWS(m *machinev1beta1.Machine, config *admissionConfig) (bool, []st
 		return false, warnings, utilerrors.NewAggregate(errs)
 	}
 
+	if !validateGVK(providerSpec.GroupVersionKind(), osconfigv1.AWSPlatformType) {
+		warnings = append(warnings, fmt.Sprintf("incorrect GroupVersionKind for AWSMachineProviderConfig object: %s", providerSpec.GroupVersionKind()))
+	}
+
 	if providerSpec.AMI.ID == nil {
 		errs = append(
 			errs,
@@ -928,6 +933,10 @@ func validateAzure(m *machinev1beta1.Machine, config *admissionConfig) (bool, []
 	if err := unmarshalInto(m, providerSpec); err != nil {
 		errs = append(errs, err)
 		return false, warnings, utilerrors.NewAggregate(errs)
+	}
+
+	if !validateGVK(providerSpec.GroupVersionKind(), osconfigv1.AzurePlatformType) {
+		warnings = append(warnings, fmt.Sprintf("incorrect GroupVersionKind for AzureMachineProviderSpec object: %s", providerSpec.GroupVersionKind()))
 	}
 
 	if providerSpec.VMSize == "" {
@@ -1162,6 +1171,10 @@ func validateGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []st
 		return false, warnings, utilerrors.NewAggregate(errs)
 	}
 
+	if !validateGVK(providerSpec.GroupVersionKind(), osconfigv1.GCPPlatformType) {
+		warnings = append(warnings, fmt.Sprintf("incorrect GroupVersionKind for GCPMachineProviderSpec object: %s", providerSpec.GroupVersionKind()))
+	}
+
 	if providerSpec.Region == "" {
 		errs = append(errs, field.Required(field.NewPath("providerSpec", "region"), "region is required"))
 	}
@@ -1353,6 +1366,10 @@ func validateVSphere(m *machinev1beta1.Machine, config *admissionConfig) (bool, 
 	if err := unmarshalInto(m, providerSpec); err != nil {
 		errs = append(errs, err)
 		return false, warnings, utilerrors.NewAggregate(errs)
+	}
+
+	if !validateGVK(providerSpec.GroupVersionKind(), osconfigv1.VSpherePlatformType) {
+		warnings = append(warnings, fmt.Sprintf("incorrect GroupVersionKind for VSphereMachineProviderSpec object: %s", providerSpec.GroupVersionKind()))
 	}
 
 	if providerSpec.Template == "" {
@@ -1858,4 +1875,19 @@ func isFinalizerOnlyRemoval(m, oldM *machinev1beta1.Machine) (bool, error) {
 	}
 
 	return string(data) == `{"metadata":{"finalizers":null}}`, nil
+}
+
+func validateGVK(gvk schema.GroupVersionKind, platform osconfigv1.PlatformType) bool {
+	switch platform {
+	case osconfigv1.AWSPlatformType:
+		return gvk.Kind == "AWSMachineProviderConfig" && gvk.Group == "awsproviderconfig.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+	case osconfigv1.AzurePlatformType:
+		return gvk.Kind == "AzureMachineProviderSpec" && gvk.Group == "azureproviderconfig.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+	case osconfigv1.GCPPlatformType:
+		return gvk.Kind == "GCPMachineProviderSpec" && gvk.Group == "gcpprovider.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+	case osconfigv1.VSpherePlatformType:
+		return gvk.Kind == "VSphereMachineProviderSpec" && gvk.Group == "vsphereprovider.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+	default:
+		return true
+	}
 }

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -2142,6 +2142,15 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			expectedOk:    false,
 			expectedError: "providerSpec.metadataServiceOptions.authentication: Invalid value: \"Boom\": Allowed values are either 'Optional' or 'Required'",
 		},
+		{
+			testCase: "with invalid GroupVersionKind",
+			modifySpec: func(p *machinev1beta1.AWSMachineProviderConfig) {
+				p.Kind = "INVALID"
+				p.APIVersion = "INVALID/v1"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"incorrect GroupVersionKind for AWSMachineProviderConfig object: INVALID/v1, Kind=INVALID"},
+		},
 	}
 
 	secret := &corev1.Secret{
@@ -2183,6 +2192,10 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 				},
 				Subnet: machinev1beta1.AWSResourceReference{
 					ID: pointer.StringPtr("subnet"),
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AWSMachineProviderConfig",
+					APIVersion: "awsproviderconfig.openshift.io/v1beta1",
 				},
 			}
 			if tc.modifySpec != nil {
@@ -2600,6 +2613,15 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			expectedOk:    false,
 			expectedError: "providerSpec.diagnostics.boot.storageAccountType: Invalid value: \"invalid\": storageAccountType must be one of: AzureManaged, CustomerManaged",
 		},
+		{
+			testCase: "with invalid GroupVersionKind",
+			modifySpec: func(p *machinev1beta1.AzureMachineProviderSpec) {
+				p.Kind = "INVALID"
+				p.APIVersion = "INVALID/v1"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"incorrect GroupVersionKind for AzureMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2633,6 +2655,10 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 				},
 				OSDisk: machinev1beta1.OSDisk{
 					DiskSizeGB: 1,
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "AzureMachineProviderSpec",
+					APIVersion: "azureproviderconfig.openshift.io/v1beta1",
 				},
 			}
 			if tc.modifySpec != nil {
@@ -3150,6 +3176,15 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			expectedOk:    false,
 			expectedError: "providerSpec.onHostMaintenance: Forbidden: When GPUs are specified or using machineType with pre-attached GPUs(A2 machine family), onHostMaintenance must be set to Terminate.",
 		},
+		{
+			testCase: "with invalid GroupVersionKind",
+			modifySpec: func(p *machinev1beta1.GCPMachineProviderSpec) {
+				p.Kind = "INVALID"
+				p.APIVersion = "INVALID/v1"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"incorrect GroupVersionKind for GCPMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
+		},
 	}
 
 	secret := &corev1.Secret{
@@ -3198,6 +3233,10 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			},
 			CredentialsSecret: &corev1.LocalObjectReference{
 				Name: "name",
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "GCPMachineProviderSpec",
+				APIVersion: "gcpprovider.openshift.io/v1beta1",
 			},
 		}
 		if tc.modifySpec != nil {
@@ -3572,6 +3611,15 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			expectedOk:       true,
 			expectedWarnings: []string{"linkedClone clone mode is set. DiskGiB parameter will be ignored, disk size from template will be used."},
 		},
+		{
+			testCase: "with invalid GroupVersionKind",
+			modifySpec: func(p *machinev1beta1.VSphereMachineProviderSpec) {
+				p.Kind = "INVALID"
+				p.APIVersion = "INVALID/v1"
+			},
+			expectedOk:       true,
+			expectedWarnings: []string{"incorrect GroupVersionKind for VSphereMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
+		},
 	}
 
 	secret := &corev1.Secret{
@@ -3610,6 +3658,10 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 				NumCPUs:   minVSphereCPU,
 				MemoryMiB: minVSphereMemoryMiB,
 				DiskGiB:   minVSphereDiskGiB,
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "VSphereMachineProviderSpec",
+					APIVersion: "vsphereprovider.openshift.io/v1beta1",
+				},
 			}
 			if tc.modifySpec != nil {
 				tc.modifySpec(providerSpec)


### PR DESCRIPTION
This PR adds webhook validations that report warnings if machine provider specs have invalid GroupVersionKind.