### PR TITLE
Bug 2082667: Separate controller for the node draining

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -33,11 +33,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"k8s.io/kubectl/pkg/drain"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -102,7 +100,13 @@ const (
 var DefaultActuator Actuator
 
 func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
-	return add(mgr, newReconciler(mgr, actuator))
+	if err := add(mgr, newReconciler(mgr, actuator), "machine-controller"); err != nil {
+		return err
+	}
+	if err := add(mgr, newDrainController(mgr), "machine-drain-controller"); err != nil {
+		return err
+	}
+	return nil
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -125,9 +129,9 @@ func stringPointerDeref(stringPointer *string) string {
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, controllerName string) error {
 	// Create a new controller
-	c, err := controller.New("machine_controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
@@ -217,30 +221,12 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 		}
 
 		klog.Infof("%v: reconciling machine triggers delete", machineName)
-		// Drain node before deletion
-		// If a machine is not linked to a node, just delete the machine. Since a node
-		// can be unlinked from a machine when the node goes NotReady and is removed
-		// by cloud controller manager. In that case some machines would never get
-		// deleted without a manual intervention.
-		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {
-			// pre-drain.delete lifecycle hook
-			// Return early without error, will requeue if/when the hook owner removes the annotation.
-			if len(m.Spec.LifecycleHooks.PreDrain) > 0 {
-				klog.Infof("%v: not draining machine: lifecycle blocked by pre-drain hook", machineName)
-				return reconcile.Result{}, nil
-			}
-
-			if err := r.drainNode(ctx, m); err != nil {
-				klog.Errorf("%v: failed to drain node for machine: %v", machineName, err)
-				conditions.Set(m, conditions.FalseCondition(
-					machinev1.MachineDrained,
-					machinev1.MachineDrainError,
-					machinev1.ConditionSeverityWarning,
-					"could not drain machine: %v", err,
-				))
-				return delayIfRequeueAfterError(err)
-			}
-			conditions.Set(m, conditions.TrueCondition(machinev1.MachineDrained))
+		// check if machine was already drained
+		drainedCondition := conditions.Get(m, machinev1.MachineDrained)
+		if drainedCondition == nil || drainedCondition.Status != corev1.ConditionTrue {
+			klog.Infof("%s: waiting for node to be drained before deleting instance", machineName)
+			// this will requeue and proceed when drain controller will set the condition
+			return reconcile.Result{}, nil
 		}
 
 		// pre-term.delete lifecycle hook
@@ -397,70 +383,6 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 	klog.Infof("%v: created instance, requeuing", machineName)
 	return reconcile.Result{RequeueAfter: requeueAfter}, nil
-}
-
-func (r *ReconcileMachine) drainNode(ctx context.Context, machine *machinev1.Machine) error {
-	kubeClient, err := kubernetes.NewForConfig(r.config)
-	if err != nil {
-		return fmt.Errorf("unable to build kube client: %v", err)
-	}
-	node, err := kubeClient.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// If an admin deletes the node directly, we'll end up here.
-			klog.Infof("Could not find node from noderef, it may have already been deleted: %v", machine.Status.NodeRef.Name)
-			return nil
-		}
-		return fmt.Errorf("unable to get node %q: %v", machine.Status.NodeRef.Name, err)
-	}
-
-	drainer := &drain.Helper{
-		Ctx:                 ctx,
-		Client:              kubeClient,
-		Force:               true,
-		IgnoreAllDaemonSets: true,
-		DeleteEmptyDirData:  true,
-		GracePeriodSeconds:  -1,
-		// If a pod is not evicted in 20 seconds, retry the eviction next time the
-		// machine gets reconciled again (to allow other machines to be reconciled).
-		Timeout: 20 * time.Second,
-		OnPodDeletedOrEvicted: func(pod *corev1.Pod, usingEviction bool) {
-			verbStr := "Deleted"
-			if usingEviction {
-				verbStr = "Evicted"
-			}
-			klog.Info(fmt.Sprintf("%s pod from Node", verbStr),
-				"pod", fmt.Sprintf("%s/%s", pod.Name, pod.Namespace))
-		},
-		Out:    writer{klog.Info},
-		ErrOut: writer{klog.Error},
-	}
-
-	if nodeIsUnreachable(node) {
-		klog.Infof("%q: Node %q is unreachable, draining will ignore gracePeriod. PDBs are still honored.",
-			machine.Name, node.Name)
-		// Since kubelet is unreachable, pods will never disappear and we still
-		// need SkipWaitForDeleteTimeoutSeconds so we don't wait for them.
-		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
-		drainer.GracePeriodSeconds = 1
-	}
-
-	if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {
-		// Can't cordon a node
-		klog.Warningf("cordon failed for node %q: %v", node.Name, err)
-		return &RequeueAfterError{RequeueAfter: 20 * time.Second}
-	}
-
-	if err := drain.RunNodeDrain(drainer, node.Name); err != nil {
-		// Machine still tries to terminate after drain failure
-		klog.Warningf("drain failed for machine %q: %v", machine.Name, err)
-		return &RequeueAfterError{RequeueAfter: 20 * time.Second}
-	}
-
-	klog.Infof("drain successful for machine %q", machine.Name)
-	r.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Deleted", "Node %q drained", node.Name)
-
-	return nil
 }
 
 func (r *ReconcileMachine) deleteNode(ctx context.Context, name string) error {

--- a/pkg/controller/machine/drain_controller.go
+++ b/pkg/controller/machine/drain_controller.go
@@ -1,0 +1,164 @@
+package machine
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"k8s.io/kubectl/pkg/drain"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+
+	"github.com/openshift/machine-api-operator/pkg/util/conditions"
+)
+
+// DrainController performs pods eviction for deleting node
+type machineDrainController struct {
+	client.Client
+	config *rest.Config
+	scheme *runtime.Scheme
+
+	eventRecorder record.EventRecorder
+}
+
+// newDrainController returns a new reconcile.Reconciler for machine-drain-controller
+func newDrainController(mgr manager.Manager) reconcile.Reconciler {
+	d := &machineDrainController{
+		Client:        mgr.GetClient(),
+		eventRecorder: mgr.GetEventRecorderFor("machine-drain-controller"),
+		config:        mgr.GetConfig(),
+		scheme:        mgr.GetScheme(),
+	}
+	return d
+}
+
+func (d *machineDrainController) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	m := &machinev1.Machine{}
+	if err := d.Client.Get(ctx, request.NamespacedName, m); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Object not found, return.
+			return reconcile.Result{}, nil
+		}
+
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	existingDrainedCondition := conditions.Get(m, machinev1.MachineDrained)
+	alreadyDrained := existingDrainedCondition != nil && existingDrainedCondition.Status == corev1.ConditionTrue
+
+	if !m.ObjectMeta.DeletionTimestamp.IsZero() && *m.Status.Phase == phaseDeleting && !alreadyDrained {
+		drainFinishedCondition := conditions.TrueCondition(machinev1.MachineDrained)
+
+		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {
+			// pre-drain.delete lifecycle hook
+			// Return early without error, will requeue if/when the hook owner removes the annotation.
+			if len(m.Spec.LifecycleHooks.PreDrain) > 0 {
+				klog.Infof("%v: not draining machine: lifecycle blocked by pre-drain hook", m.Name)
+				d.eventRecorder.Eventf(m, corev1.EventTypeNormal, "DrainBlocked", "Drain blocked by pre-drain hook")
+				return reconcile.Result{}, nil
+			}
+			d.eventRecorder.Eventf(m, corev1.EventTypeNormal, "DrainProceeds", "Node drain proceeds")
+			if err := d.drainNode(ctx, m); err != nil {
+				klog.Errorf("%v: failed to drain node for machine: %v", m.Name, err)
+				conditions.Set(m, conditions.FalseCondition(
+					machinev1.MachineDrained,
+					machinev1.MachineDrainError,
+					machinev1.ConditionSeverityWarning,
+					"could not drain machine: %v", err,
+				))
+				d.eventRecorder.Eventf(m, corev1.EventTypeNormal, "DrainRequeued", "Node drain requeued: %v", err.Error())
+				return delayIfRequeueAfterError(err)
+			}
+			d.eventRecorder.Eventf(m, corev1.EventTypeNormal, "DrainSucceeded", "Node drain succeeded")
+			drainFinishedCondition.Message = "Drain finished successfully"
+		} else {
+			d.eventRecorder.Eventf(m, corev1.EventTypeNormal, "DrainSkipped", "Node drain skipped")
+			drainFinishedCondition.Message = "Node drain skipped"
+		}
+
+		conditions.Set(m, drainFinishedCondition)
+		// requeue request in case of failed update
+		if err := d.Client.Status().Update(ctx, m); err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not update machine status: %w", err)
+		}
+		return reconcile.Result{}, nil
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (d *machineDrainController) drainNode(ctx context.Context, machine *machinev1.Machine) error {
+	kubeClient, err := kubernetes.NewForConfig(d.config)
+	if err != nil {
+		return fmt.Errorf("unable to build kube client: %v", err)
+	}
+	node, err := kubeClient.CoreV1().Nodes().Get(ctx, machine.Status.NodeRef.Name, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// If an admin deletes the node directly, we'll end up here.
+			klog.Infof("Could not find node from noderef, it may have already been deleted: %v", machine.Status.NodeRef.Name)
+			return nil
+		}
+		return fmt.Errorf("unable to get node %q: %v", machine.Status.NodeRef.Name, err)
+	}
+
+	drainer := &drain.Helper{
+		Ctx:                 ctx,
+		Client:              kubeClient,
+		Force:               true,
+		IgnoreAllDaemonSets: true,
+		DeleteEmptyDirData:  true,
+		GracePeriodSeconds:  -1,
+		// If a pod is not evicted in 20 seconds, retry the eviction next time the
+		// machine gets reconciled again (to allow other machines to be reconciled).
+		Timeout: 20 * time.Second,
+		OnPodDeletedOrEvicted: func(pod *corev1.Pod, usingEviction bool) {
+			verbStr := "Deleted"
+			if usingEviction {
+				verbStr = "Evicted"
+			}
+			klog.Info(fmt.Sprintf("%s pod from Node", verbStr),
+				"pod", fmt.Sprintf("%s/%s", pod.Name, pod.Namespace))
+		},
+		Out:    writer{klog.Info},
+		ErrOut: writer{klog.Error},
+	}
+
+	if nodeIsUnreachable(node) {
+		klog.Infof("%q: Node %q is unreachable, draining will ignore gracePeriod. PDBs are still honored.",
+			machine.Name, node.Name)
+		// Since kubelet is unreachable, pods will never disappear and we still
+		// need SkipWaitForDeleteTimeoutSeconds so we don't wait for them.
+		drainer.SkipWaitForDeleteTimeoutSeconds = skipWaitForDeleteTimeoutSeconds
+		drainer.GracePeriodSeconds = 1
+	}
+
+	if err := drain.RunCordonOrUncordon(drainer, node, true); err != nil {
+		// Can't cordon a node
+		klog.Warningf("cordon failed for node %q: %v", node.Name, err)
+		return &RequeueAfterError{RequeueAfter: 20 * time.Second}
+	}
+
+	if err := drain.RunNodeDrain(drainer, node.Name); err != nil {
+		// Machine still tries to terminate after drain failure
+		klog.Warningf("drain failed for machine %q: %v", machine.Name, err)
+		return &RequeueAfterError{RequeueAfter: 20 * time.Second}
+	}
+
+	klog.Infof("drain successful for machine %q", machine.Name)
+	d.eventRecorder.Eventf(machine, corev1.EventTypeNormal, "Deleted", "Node %q drained", node.Name)
+
+	return nil
+}

--- a/pkg/controller/machine/drain_controller.go
+++ b/pkg/controller/machine/drain_controller.go
@@ -58,7 +58,7 @@ func (d *machineDrainController) Reconcile(ctx context.Context, request reconcil
 	existingDrainedCondition := conditions.Get(m, machinev1.MachineDrained)
 	alreadyDrained := existingDrainedCondition != nil && existingDrainedCondition.Status == corev1.ConditionTrue
 
-	if !m.ObjectMeta.DeletionTimestamp.IsZero() && *m.Status.Phase == phaseDeleting && !alreadyDrained {
+	if !m.ObjectMeta.DeletionTimestamp.IsZero() && stringPointerDeref(m.Status.Phase) == phaseDeleting && !alreadyDrained {
 		drainFinishedCondition := conditions.TrueCondition(machinev1.MachineDrained)
 
 		if _, exists := m.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation]; !exists && m.Status.NodeRef != nil {

--- a/pkg/controller/machine/drain_controller_test.go
+++ b/pkg/controller/machine/drain_controller_test.go
@@ -1,0 +1,179 @@
+package machine
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/machine-api-operator/pkg/util/conditions"
+)
+
+func getMachine(name string, phase string) *machinev1.Machine {
+	now := metav1.Now()
+	machine := &machinev1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "Machine",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Finalizers:  []string{machinev1.MachineFinalizer, metav1.FinalizerDeleteDependents},
+			Annotations: map[string]string{},
+			Labels: map[string]string{
+				machinev1.MachineClusterIDLabel: "testcluster",
+			},
+		},
+		Spec: machinev1.MachineSpec{
+			ProviderSpec: machinev1.ProviderSpec{
+				Value: &runtime.RawExtension{
+					Raw: []byte("{}"),
+				},
+			},
+		},
+		Status: machinev1.MachineStatus{
+			NodeRef: &corev1.ObjectReference{
+				Name: "foo",
+			},
+		},
+	}
+
+	machine.Status.Phase = pointer.StringPtr(phase)
+	if phase == phaseDeleting {
+		machine.ObjectMeta.DeletionTimestamp = &now
+	}
+
+	return machine
+}
+
+func TestDrainControllerReconcileRequest(t *testing.T) {
+
+	getDrainControllerReconciler := func(fakeObjs ...runtime.Object) (*machineDrainController, *record.FakeRecorder) {
+		recorder := record.NewFakeRecorder(10)
+		return &machineDrainController{
+			Client:        fake.NewFakeClientWithScheme(scheme.Scheme, fakeObjs...),
+			scheme:        scheme.Scheme,
+			eventRecorder: recorder,
+		}, recorder
+	}
+
+	getDrainedConditions := func(msg string) machinev1.Conditions {
+		condition := conditions.TrueCondition(machinev1.MachineDrained)
+		condition.Message = msg
+		return machinev1.Conditions{*condition}
+	}
+
+	t.Run("ignore machine not in the deleting phase", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		cases := []struct {
+			phase string
+		}{
+			{phase: phaseRunning},
+			{phase: phaseFailed},
+			{phase: phaseProvisioning},
+			{phase: phaseProvisioned},
+			{phase: "some_random_thing_there"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.phase, func(t *testing.T) {
+				machine := getMachine(tc.phase, tc.phase)
+				drainController, recorder := getDrainControllerReconciler(machine)
+				request := reconcile.Request{NamespacedName: types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}}
+
+				_, err := drainController.Reconcile(context.TODO(), request)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Consistently(recorder.Events).ShouldNot(Receive())
+
+				updatedMachine := &machinev1.Machine{}
+				g.Expect(drainController.Client.Get(context.TODO(), request.NamespacedName, updatedMachine)).To(Succeed())
+				g.Expect(len(updatedMachine.Status.Conditions)).To(BeZero())
+			})
+		}
+	})
+
+	t.Run("hold machine with pre-drain hook", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		machine := getMachine("deleting", phaseDeleting)
+		machine.Spec.LifecycleHooks.PreDrain = []machinev1.LifecycleHook{{Name: "stop", Owner: "drain"}}
+
+		drainController, recorder := getDrainControllerReconciler(machine)
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}}
+
+		_, err := drainController.Reconcile(context.TODO(), request)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Eventually(recorder.Events).Should(Receive(ContainSubstring("Drain blocked by pre-drain hook")))
+
+		updatedMachine := &machinev1.Machine{}
+		g.Expect(drainController.Client.Get(context.TODO(), request.NamespacedName, updatedMachine)).To(Succeed())
+		g.Expect(len(updatedMachine.Status.Conditions)).To(BeZero())
+	})
+
+	t.Run("skip machine without node", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		machine := getMachine("no-node", phaseDeleting)
+		machine.Status.NodeRef = nil
+
+		drainController, recorder := getDrainControllerReconciler(machine)
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}}
+
+		_, err := drainController.Reconcile(context.TODO(), request)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Eventually(recorder.Events).Should(Receive(ContainSubstring("Node drain skipped")))
+
+		updatedMachine := &machinev1.Machine{}
+		g.Expect(drainController.Client.Get(context.TODO(), request.NamespacedName, updatedMachine)).To(Succeed())
+		expectedConditions := getDrainedConditions("Node drain skipped")
+		g.Expect(updatedMachine.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+	})
+
+	t.Run("skip machine with proper annotation", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		machine := getMachine("annotated", phaseDeleting)
+		machine.ObjectMeta.Annotations[ExcludeNodeDrainingAnnotation] = "here"
+
+		drainController, recorder := getDrainControllerReconciler(machine)
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}}
+
+		_, err := drainController.Reconcile(context.TODO(), request)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Eventually(recorder.Events).Should(Receive(ContainSubstring("Node drain skipped")))
+
+		updatedMachine := &machinev1.Machine{}
+		g.Expect(drainController.Client.Get(context.TODO(), request.NamespacedName, updatedMachine)).To(Succeed())
+		expectedConditions := getDrainedConditions("Node drain skipped")
+		g.Expect(updatedMachine.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+	})
+
+	t.Run("ignore already drained machine", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		machine := getMachine("drained", phaseDeleting)
+		machine.Status.Conditions = getDrainedConditions("Drained")
+
+		drainController, recorder := getDrainControllerReconciler(machine)
+		request := reconcile.Request{NamespacedName: types.NamespacedName{Name: machine.Name, Namespace: machine.Namespace}}
+
+		_, err := drainController.Reconcile(context.TODO(), request)
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Consistently(recorder.Events).ShouldNot(Receive())
+
+		updatedMachine := &machinev1.Machine{}
+		g.Expect(drainController.Client.Get(context.TODO(), request.NamespacedName, updatedMachine)).To(Succeed())
+		expectedConditions := getDrainedConditions("Drained")
+		g.Expect(updatedMachine.Status.Conditions).To(conditions.MatchConditions(expectedConditions))
+	})
+}

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -62,7 +62,7 @@ func TestReconcile(t *testing.T) {
 
 	a := newTestActuator()
 	recFn := newReconciler(mgr, a)
-	if err := add(mgr, recFn); err != nil {
+	if err := add(mgr, recFn, "dummy"); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}
 


### PR DESCRIPTION
Introduces new controller which responsible for node draining.
Basically drain logic was moved out to separate controller, running by the same manager. Now machine-controller will block machine deletion until "Drained" condition will not be set to "True" by the "machine-drain-controller". Logic there was mostly untouched and extracted as is, except some events emission was added.

Tested manually on vSphere.