### PR TITLE
Migrate delete annotation to match upstream CAPI annotation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -124,7 +124,7 @@ There is a limited number of features we support on each cloud provider that are
 # MachineSets
 
 ## What decides which Machines to destroy when a MachineSet is scaled down?
-By default, it selects a Machine at random.  You can set **Spec.DeletePolicy** to **“Random”, “Oldest”, or “Newest”**.  You can also designate Machines with an annotation which will override all other selection criteria: **"machine.openshift.io/cluster-api-delete-machine"**
+By default, it selects a Machine at random.  You can set **Spec.DeletePolicy** to **“Random”, “Oldest”, or “Newest”**.  You can also designate Machines with an annotation which will override all other selection criteria: **"machine.openshift.io/delete-machine"**
 
 ## What Happens if I change a MachineSet
 You are free to edit a MachineSet at any time.  Any changes you make will not affect existing Machines, only Machines created after the changes are made.

--- a/pkg/controller/machineset/delete_policy.go
+++ b/pkg/controller/machineset/delete_policy.go
@@ -31,7 +31,12 @@ const (
 
 	// DeleteNodeAnnotation marks nodes that will be given priority for deletion
 	// when a machineset scales down. This annotation is given top priority on all delete policies.
-	DeleteNodeAnnotation = "machine.openshift.io/cluster-api-delete-machine"
+	DeleteNodeAnnotation = "machine.openshift.io/delete-machine"
+
+	// oldDeleteNodeAnnotation is the previous version of the DeleteNodeAnnotation.
+	// This was changed so that the new version, compatible with the cluster api Kubernetes Autoscaler
+	// provider could be preferred.
+	oldDeleteNodeAnnotation = "machine.openshift.io/cluster-api-delete-machine"
 
 	mustDelete    deletePriority = 100.0
 	betterDelete  deletePriority = 50.0
@@ -49,7 +54,7 @@ func oldestDeletePriority(machine *machinev1.Machine) deletePriority {
 	if machine.DeletionTimestamp != nil && !machine.DeletionTimestamp.IsZero() {
 		return mustDelete
 	}
-	if machine.ObjectMeta.Annotations != nil && machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" {
+	if machine.ObjectMeta.Annotations != nil && (machine.ObjectMeta.Annotations[DeleteNodeAnnotation] != "" || machine.ObjectMeta.Annotations[oldDeleteNodeAnnotation] != "") {
 		return mustDelete
 	}
 	if machine.Status.ErrorReason != nil || machine.Status.ErrorMessage != nil {

--- a/pkg/controller/machineset/delete_policy_test.go
+++ b/pkg/controller/machineset/delete_policy_test.go
@@ -31,6 +31,7 @@ func TestMachineToDelete(t *testing.T) {
 	mustDeleteMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now}}
 	betterDeleteMachine := &machinev1.Machine{Status: machinev1.MachineStatus{ErrorMessage: &msg}}
 	deleteMeMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{DeleteNodeAnnotation: "yes"}}}
+	oldDeleteMeMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{oldDeleteNodeAnnotation: "yes"}}}
 	runningMachine := &machinev1.Machine{Status: machinev1.MachineStatus{NodeRef: &corev1.ObjectReference{}}}
 	notYetRunningMachine := &machinev1.Machine{}
 
@@ -149,6 +150,18 @@ func TestMachineToDelete(t *testing.T) {
 			},
 			expect: []*machinev1.Machine{
 				deleteMeMachine,
+			},
+		},
+		{
+			desc: "func=randomDeletePolicy, annotated (old), diff=1",
+			diff: 1,
+			machines: []*machinev1.Machine{
+				runningMachine,
+				oldDeleteMeMachine,
+				runningMachine,
+			},
+			expect: []*machinev1.Machine{
+				oldDeleteMeMachine,
 			},
 		},
 		{


### PR DESCRIPTION
This maintains backwards compatibilty, but migrates to a new annotation value by default so that we can be congruent with the upstream annotations. By doing so, this means we need fewer carry patches on the cluster autoscaler.

This will need a small docs update, https://docs.openshift.com/container-platform/4.10/machine_management/manually-scaling-machineset.html, CC @jeana-redhat 