### PR TITLE
Bug 2097153: change ListTags call to ListTagsForCategory

### DIFF
--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -166,7 +166,7 @@ func TestMachineEvents(t *testing.T) {
 		g.Expect(k8sClient.Delete(context.Background(), userDataSecret)).To(Succeed())
 	}()
 
-	createTagAndCategory(session, "CLUSTERID", "CLUSTERID")
+	createTagAndCategory(session, "openshift-CLUSTERID", "CLUSTERID")
 
 	ctx := context.Background()
 

--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -166,7 +166,7 @@ func TestMachineEvents(t *testing.T) {
 		g.Expect(k8sClient.Delete(context.Background(), userDataSecret)).To(Succeed())
 	}()
 
-	createTagAndCategory(session, "openshift-CLUSTERID", "CLUSTERID")
+	createTagAndCategory(session, tagToCategoryName("CLUSTERID"), "CLUSTERID")
 
 	ctx := context.Background()
 

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -1066,8 +1066,17 @@ func (vm *virtualMachine) checkAttachedTag(ctx context.Context, tagName string, 
 	return false, nil
 }
 
+// tagToCategoryName converts the tag name to the category name based upon the format set up by the installer.
+// Note this is only valid in IPI clusters as typically a UPI cluster won't have the cluster ID tag, in which case the
+// controller skips tag creation.
+// Ref: https://github.com/openshift/installer/blob/f912534f12491721e3874e2bf64f7fa8d44aa7f5/data/data/vsphere/pre-bootstrap/main.tf#L57
+// Ref: https://github.com/openshift/installer/blob/f912534f12491721e3874e2bf64f7fa8d44aa7f5/pkg/destroy/vsphere/vsphere.go#L231
+func tagToCategoryName(tagName string) string {
+	return fmt.Sprintf("openshift-%s", tagName)
+}
+
 func (vm *virtualMachine) foundTag(ctx context.Context, tagName string, m *tags.Manager) (bool, error) {
-	tags, err := m.ListTagsForCategory(ctx, "openshift-"+tagName)
+	tags, err := m.ListTagsForCategory(ctx, tagToCategoryName(tagName))
 	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			return false, nil

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -1067,7 +1067,7 @@ func (vm *virtualMachine) checkAttachedTag(ctx context.Context, tagName string, 
 }
 
 func (vm *virtualMachine) foundTag(ctx context.Context, tagName string, m *tags.Manager) (bool, error) {
-	tags, err := m.ListTags(ctx)
+	tags, err := m.ListTagsForCategory(ctx,"openshift-"+tagName)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -1067,8 +1067,11 @@ func (vm *virtualMachine) checkAttachedTag(ctx context.Context, tagName string, 
 }
 
 func (vm *virtualMachine) foundTag(ctx context.Context, tagName string, m *tags.Manager) (bool, error) {
-	tags, err := m.ListTagsForCategory(ctx,"openshift-"+tagName)
+	tags, err := m.ListTagsForCategory(ctx, "openshift-"+tagName)
 	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return false, nil
+		}
 		return false, err
 	}
 

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1067,7 +1067,7 @@ func TestReconcileTags(t *testing.T) {
 			expectedError: false,
 			attachTag:     true,
 			testCondition: func() {
-				createTagAndCategory(session, "CLUSTERID_CATEGORY", tagName)
+				createTagAndCategory(session, "openshift-CLUSTERID", tagName)
 			},
 		},
 		{
@@ -1148,7 +1148,7 @@ func TestCheckAttachedTag(t *testing.T) {
 		id, err := tagsMgr.CreateCategory(context.TODO(), &tags.Category{
 			AssociableTypes: []string{"VirtualMachine"},
 			Cardinality:     "SINGLE",
-			Name:            "CLUSTERID_CATEGORY",
+			Name:            "openshift-" + tagName,
 		})
 		if err != nil {
 			return err
@@ -1166,8 +1166,18 @@ func TestCheckAttachedTag(t *testing.T) {
 			return err
 		}
 
+		nonAttachedCategoryId, err := tagsMgr.CreateCategory(context.TODO(), &tags.Category{
+			AssociableTypes: []string{"VirtualMachine"},
+			Cardinality:     "SINGLE",
+			Name:            "openshift-" + nonAttachedTagName,
+		})
+
+		if err != nil {
+			return err
+		}
+
 		_, err = tagsMgr.CreateTag(context.TODO(), &tags.Tag{
-			CategoryID: id,
+			CategoryID: nonAttachedCategoryId,
 			Name:       nonAttachedTagName,
 		})
 		if err != nil {
@@ -1836,7 +1846,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	createTagAndCategory(session, "CLUSTERID_CATEGORY", "CLUSTERID")
+	createTagAndCategory(session, "openshift-CLUSTERID", "CLUSTERID")
 
 	cases := []struct {
 		name          string

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1067,7 +1067,7 @@ func TestReconcileTags(t *testing.T) {
 			expectedError: false,
 			attachTag:     true,
 			testCondition: func() {
-				createTagAndCategory(session, "openshift-CLUSTERID", tagName)
+				createTagAndCategory(session, tagToCategoryName(tagName), tagName)
 			},
 		},
 		{
@@ -1148,7 +1148,7 @@ func TestCheckAttachedTag(t *testing.T) {
 		id, err := tagsMgr.CreateCategory(context.TODO(), &tags.Category{
 			AssociableTypes: []string{"VirtualMachine"},
 			Cardinality:     "SINGLE",
-			Name:            "openshift-" + tagName,
+			Name:            tagToCategoryName(tagName),
 		})
 		if err != nil {
 			return err
@@ -1169,7 +1169,7 @@ func TestCheckAttachedTag(t *testing.T) {
 		nonAttachedCategoryId, err := tagsMgr.CreateCategory(context.TODO(), &tags.Category{
 			AssociableTypes: []string{"VirtualMachine"},
 			Cardinality:     "SINGLE",
-			Name:            "openshift-" + nonAttachedTagName,
+			Name:            tagToCategoryName(nonAttachedTagName),
 		})
 
 		if err != nil {
@@ -1846,7 +1846,7 @@ func TestUpdate(t *testing.T) {
 		},
 	}
 
-	createTagAndCategory(session, "openshift-CLUSTERID", "CLUSTERID")
+	createTagAndCategory(session, tagToCategoryName("CLUSTERID"), "CLUSTERID")
 
 	cases := []struct {
 		name          string


### PR DESCRIPTION
Improves performance in vCenter clusters with thousands of tags and heavy API loads. There should be no reason we need to query for all tags unrelated to a particular install.