### PR TITLE
add utility functions for windows powershell tags

### DIFF
--- a/pkg/util/windows/helpers.go
+++ b/pkg/util/windows/helpers.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	powershellOpenTag  = "<powershell>"
+	powershellCloseTag = "</powershell>"
+)
+
+// Return the supplied string wrapped with the powershell tags.
+// If the string already has the tags, do not add them a second a time.
+func AddPowershellTags(target string) string {
+	if HasPowershellTags(target) {
+		return target
+	}
+
+	return fmt.Sprintf("%s%s%s", powershellOpenTag, target, powershellCloseTag)
+}
+
+// Returns true if the string is wrapped with open and close tags for powershell.
+func HasPowershellTags(target string) bool {
+	return strings.HasPrefix(target, powershellOpenTag) && strings.HasSuffix(target, powershellCloseTag)
+}
+
+// Return the supplied string with its powershell tags removed.
+// This function will only remove the tags if both open and close exist,
+// otherwise it returns the original.
+func RemovePowershellTags(target string) string {
+	if !HasPowershellTags(target) {
+		return target
+	}
+
+	target = strings.TrimPrefix(target, powershellOpenTag)
+	target = strings.TrimSuffix(target, powershellCloseTag)
+
+	return target
+}

--- a/pkg/util/windows/helpers_test.go
+++ b/pkg/util/windows/helpers_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package windows
+
+import (
+	"testing"
+)
+
+func TestAddPowershellTags(t *testing.T) {
+	testcases := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{
+			name:     "String is wrapped properly",
+			target:   "some stuff",
+			expected: "<powershell>some stuff</powershell>",
+		},
+		{
+			name:     "String is already wrapped, does not wrap a second time",
+			target:   "<powershell>some stuff</powershell>",
+			expected: "<powershell>some stuff</powershell>",
+		},
+		{
+			name:     "String has open tag but no close, does wrap",
+			target:   "<powershell>some stuff",
+			expected: "<powershell><powershell>some stuff</powershell>",
+		},
+		{
+			name:     "String has close tag but no open, does wrap",
+			target:   "some stuff</powershell>",
+			expected: "<powershell>some stuff</powershell></powershell>",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := AddPowershellTags(tc.target)
+			if tc.expected != observed {
+				t.Errorf("observed: \"%v\", expected: \"%v\"", observed, tc.expected)
+			}
+		})
+	}
+}
+
+func TestHasPowershellTags(t *testing.T) {
+	testcases := []struct {
+		name     string
+		target   string
+		expected bool
+	}{
+		{
+			name:     "String has both tags",
+			target:   "<powershell>some stuff</powershell>",
+			expected: true,
+		},
+		{
+			name:     "String has open tag only",
+			target:   "<powershell>some stuff",
+			expected: false,
+		},
+		{
+			name:     "String has close tag only",
+			target:   "some stuff</powershell>",
+			expected: false,
+		},
+		{
+			name:     "String has no tags",
+			target:   "some stuff",
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := HasPowershellTags(tc.target)
+			if tc.expected != observed {
+				t.Errorf("observed: %v, expected: %v", observed, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRemovePowershellTags(t *testing.T) {
+	testcases := []struct {
+		name     string
+		target   string
+		expected string
+	}{
+		{
+			name:     "String has no tags",
+			target:   "some stuff",
+			expected: "some stuff",
+		},
+		{
+			name:     "String has both tags",
+			target:   "<powershell>some stuff</powershell>",
+			expected: "some stuff",
+		},
+		{
+			name:     "String has open tag only, does not remove",
+			target:   "<powershell>some stuff",
+			expected: "<powershell>some stuff",
+		},
+		{
+			name:     "String has close tag only, does not remove",
+			target:   "some stuff</powershell>",
+			expected: "some stuff</powershell>",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := RemovePowershellTags(tc.target)
+			if tc.expected != observed {
+				t.Errorf("observed: %v, expected: %v", observed, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds a set of helper functions that will be used with
Windows machine deployments. When booting a Windows machine, it is
common for the infrastructure provider to have a method for a Powershell
script to run during boot. This is usually supplied in the user data
metadata associated with a new instance. On Azure and AWS, the script is
required to be wrapped in `<powershell></powershell>` tags, but on GCP
this is not required. The helper functions in this commit will be used
by the providers to help in detecting, adding, and removing these tags.