### PR TITLE
[4.11] Bug 2102633: operator NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -10,6 +10,7 @@ metadata:
   name: openshift-machine-api
   labels:
     name: openshift-machine-api
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
We dropped the run-level label from this namespace back in 4.5
but because of how the cluster-version operator reconciles manifest
labels, dropping a label from the manifest does not remove it from the
in-cluster resource when old clusters are updated into the new
manifest.  This commit uses the approach the cluster-version
operator used to drop its run-level, by setting the value to an
empty string, which the run-level-consuming code treats identically to
an unset label.

This avoids errors about:

  ...container has runAsNonRoot and image will run as root...

when updating to 4.11 in case the operator deployment  manifest specifically
requests runAsNonRoot: true.