### PR TITLE
Bug 2101736: allow to remove finalizers

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1685,5 +1685,5 @@ func isFinalizerOnlyRemoval(m, oldM *machinev1beta1.Machine) (bool, error) {
 		return false, fmt.Errorf("cannot calculate patch data from machine object: %w", err)
 	}
 
-	return string(data) == `{"metadata":{"finalizers":[""]}}`, nil
+	return string(data) == `{"metadata":{"finalizers":null}}`, nil
 }

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -3685,7 +3685,7 @@ func TestUpdateFinalizer(t *testing.T) {
 		{
 			testCase:             "deleting the finalizer from a valid machine",
 			oldMachineFinalizers: []string{"machine-finalizer"},
-			newMachineFinalizers: []string{""},
+			newMachineFinalizers: nil,
 			expectedOk:           true,
 		},
 		{
@@ -3752,7 +3752,7 @@ func TestUpdateFinalizer(t *testing.T) {
 				return p
 			},
 			oldMachineFinalizers: []string{"machine-finalizer"},
-			newMachineFinalizers: []string{""},
+			newMachineFinalizers: nil,
 			expectedError:        "providerSpec.credentialsSecret: Required value: expected providerSpec.credentialsSecret to be populated",
 		},
 		{
@@ -3766,7 +3766,7 @@ func TestUpdateFinalizer(t *testing.T) {
 				return p
 			},
 			oldMachineFinalizers:  []string{"machine-finalizer"},
-			newMachineFinalizers:  []string{""},
+			newMachineFinalizers:  nil,
 			withDeletionTimestamp: true,
 			expectedOk:            true,
 		},
@@ -3777,7 +3777,7 @@ func TestUpdateFinalizer(t *testing.T) {
 				return p
 			},
 			oldMachineFinalizers: []string{"machine-finalizer"},
-			newMachineFinalizers: []string{""},
+			newMachineFinalizers: nil,
 			expectedError:        "providerSpec.credentialsSecret: Required value: expected providerSpec.credentialsSecret to be populated",
 		},
 		{
@@ -3791,7 +3791,7 @@ func TestUpdateFinalizer(t *testing.T) {
 				return p
 			},
 			oldMachineFinalizers: []string{"machine-finalizer"},
-			newMachineFinalizers: []string{""},
+			newMachineFinalizers: nil,
 			expectedOk:           true,
 		},
 	}


### PR DESCRIPTION
This PR changes the behavior of the operator when users try to remove finalizers. Now we expect to get `{"metadata":{"finalizers":null}}` patch.