### PR TITLE
Bug 2107578: Fix while setting default processor value for Power VS platform

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1683,7 +1683,7 @@ func defaultPowerVS(m *machinev1beta1.Machine, config *admissionConfig) (bool, [
 	if providerSpec.ProcessorType == "" {
 		providerSpec.ProcessorType = defaultPowerVSProcType
 	}
-	if providerSpec.Processors.IntVal == 0 || providerSpec.Processors.StrVal == "" {
+	if providerSpec.Processors.IntVal == 0 && providerSpec.Processors.StrVal == "" {
 		switch providerSpec.ProcessorType {
 		case machinev1.PowerVSProcessorTypeDedicated:
 			providerSpec.Processors = intstr.IntOrString{Type: intstr.Int, IntVal: 1}

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -4308,6 +4308,19 @@ func TestDefaultPowerVSProviderSpec(t *testing.T) {
 			expectedOk:    true,
 			expectedError: "",
 		},
+		{
+			testCase: "it does not override the set values",
+			providerSpec: &machinev1.PowerVSMachineProviderConfig{
+				Processors: intstr.FromString("1.5"),
+				MemoryGiB:  35,
+			},
+			modifyDefault: func(providerConfig *machinev1.PowerVSMachineProviderConfig) {
+				providerConfig.Processors = intstr.FromString("1.5")
+				providerConfig.MemoryGiB = 35
+			},
+			expectedOk:    true,
+			expectedError: "",
+		},
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.PowerVSPlatformType}


### PR DESCRIPTION
Avoid setting default values for processor when either int or string values are set