### PR TITLE
Bug 2110505: revert: Bug 2101880: operator NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -10,7 +10,6 @@ metadata:
   name: openshift-machine-api
   labels:
     name: openshift-machine-api
-    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
revert of https://github.com/openshift/machine-api-operator/pull/1031