### PR TITLE
Bug 2087981: Change "create" sequence with powering on the vm after clone

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -57,6 +57,10 @@ const (
 	powerOffVmTaskDescriptionId = "VirtualMachine.powerOff"
 )
 
+const (
+	machinePhaseProvisioning = "Provisioning"
+)
+
 // Reconciler runs the logic to reconciles a machine resource towards its desired state
 type Reconciler struct {
 	*machineScope
@@ -134,6 +138,28 @@ func (r *Reconciler) create() error {
 	} else if !taskIsFinished {
 		return fmt.Errorf("%v task %v has not finished", moTask.Info.DescriptionId, moTask.Reference().Value)
 	}
+
+	// if clone task finished successfully, power on the vm
+	if moTask.Info.DescriptionId == cloneVmTaskDescriptionId {
+		klog.Infof("Powering on cloned machine: %v", r.machine.Name)
+		task, err := powerOn(r.machineScope)
+		if err != nil {
+			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
+				Name:      r.machine.Name,
+				Namespace: r.machine.Namespace,
+				Reason:    "PowerOn task finished with error",
+			})
+			conditionFailed := conditionFailed()
+			conditionFailed.Message = err.Error()
+			statusError := setProviderStatus(task, conditionFailed, r.machineScope, nil)
+			if statusError != nil {
+				return fmt.Errorf("Failed to set provider status: %w", err)
+			}
+			return err
+		}
+		return setProviderStatus(task, conditionSuccess(), r.machineScope, nil)
+	}
+
 	// If taskIsFinished then next reconcile should result in update.
 	return nil
 }
@@ -223,6 +249,16 @@ func (r *Reconciler) exists() (bool, error) {
 		klog.Infof("%v: does not exist", r.machine.GetName())
 		return false, nil
 	}
+
+	// Check if machine was powered on after clone.
+	// If it is in poweredOff state and in "Provisioning" phase, treat machine as non-existed yet and requeue for proceed
+	// with creation procedure.
+	powerState := stringPointerDeref(r.machineScope.providerStatus.InstanceState)
+	if stringPointerDeref(r.machine.Status.Phase) == machinePhaseProvisioning && powerState == string(types.VirtualMachinePowerStatePoweredOff) {
+		klog.Infof("%v: already exists, but was not powered on after clone, requeue ", r.machine.GetName())
+		return false, nil
+	}
+
 	klog.Infof("%v: already exists", r.machine.GetName())
 	return true, nil
 }
@@ -722,7 +758,7 @@ func clone(s *machineScope) (string, error) {
 			Pool:         types.NewReference(resourcepool.Reference()),
 			DiskMoveType: diskMoveType,
 		},
-		PowerOn:  true,
+		PowerOn:  false, // Create powered off machine, for power it on later in "create" procedure
 		Snapshot: snapshotRef,
 	}
 
@@ -733,6 +769,37 @@ func clone(s *machineScope) (string, error) {
 	taskVal := task.Reference().Value
 	klog.V(3).Infof("%v: running task: %+v", s.machine.GetName(), taskVal)
 	return taskVal, nil
+}
+
+func powerOn(s *machineScope) (string, error) {
+	vmRef, err := findVM(s)
+	if err != nil {
+		if !isNotFound(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("vm not found during creation for powering on: %w", err)
+	}
+
+	datacenter := s.session.Datacenter
+	if datacenter == nil { // if there is no dataceneter, fallback to old powerOn method via vm object
+		vm := &virtualMachine{
+			Context: s.Context,
+			Obj:     object.NewVirtualMachine(s.session.Client.Client, vmRef),
+			Ref:     vmRef,
+		}
+
+		return vm.powerOnVM()
+	}
+
+	overrideDRS := &types.OptionValue{
+		Key:   string(types.ClusterPowerOnVmOptionOverrideAutomationLevel),
+		Value: string(types.DrsBehaviorFullyAutomated),
+	}
+	task, err := datacenter.PowerOnVM(s.Context, []types.ManagedObjectReference{vmRef}, overrideDRS)
+	if err != nil {
+		return "", fmt.Errorf("error powering on %s vm: %w", s.machine.Name, err)
+	}
+	return task.Reference().Value, nil
 }
 
 func getDiskSpec(s *machineScope, devices object.VirtualDeviceList) (types.BaseVirtualDeviceConfigSpec, error) {

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -181,13 +181,6 @@ func getInsecureFlagFromConfig(config *vSphereConfig) bool {
 	return false
 }
 
-func stringPointerDeref(stringPointer *string) string {
-	if stringPointer != nil {
-		return *stringPointer
-	}
-	return ""
-}
-
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.VSphereMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -181,6 +181,13 @@ func getInsecureFlagFromConfig(config *vSphereConfig) bool {
 	return false
 }
 
+func stringPointerDeref(stringPointer *string) string {
+	if stringPointer != nil {
+		return *stringPointer
+	}
+	return ""
+}
+
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.VSphereMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {


### PR DESCRIPTION
Stop passing PowerOn flag and explicitly power on the vm after
successful clone.

If PowerOn flag set to true, vCenter creates additional power on task
after the clone, which we do not know about. Such nuance leads to
possibility of stucking machine in "Provisioned" state
in case if "power on" task did not finish successfully.
This pr adds explicit powering on the machine with saving task reference
and respective checks later. For achieve vm powering on vm separately, during create procedure - exists method also be altered, if machine powered off and sits in "provisioning" phase, it treats as non existed yet.

Additionally powerOn function tries to use datacenter's method "PowerOnMultiVM"
which respects vSphere DRS. If datacenter not provided, function will fallback
to powering on via old PowerOnVM method.