### PR TITLE
update windows helper functions

### DIFF
--- a/pkg/util/windows/helpers.go
+++ b/pkg/util/windows/helpers.go
@@ -22,8 +22,11 @@ import (
 )
 
 const (
+	// these powershell tag constants are based on the secret creation in WMCO
+	// they should follow how the secret is created there, see
+	// https://github.com/openshift/windows-machine-config-operator/blob/master/pkg/secrets/secrets.go
 	powershellOpenTag  = "<powershell>"
-	powershellCloseTag = "</powershell>"
+	powershellCloseTag = "</powershell>\n<persist>true</persist>"
 )
 
 // Return the supplied string wrapped with the powershell tags.

--- a/pkg/util/windows/helpers_test.go
+++ b/pkg/util/windows/helpers_test.go
@@ -29,22 +29,22 @@ func TestAddPowershellTags(t *testing.T) {
 		{
 			name:     "String is wrapped properly",
 			target:   "some stuff",
-			expected: "<powershell>some stuff</powershell>",
+			expected: "<powershell>some stuff</powershell>\n<persist>true</persist>",
 		},
 		{
 			name:     "String is already wrapped, does not wrap a second time",
-			target:   "<powershell>some stuff</powershell>",
-			expected: "<powershell>some stuff</powershell>",
+			target:   "<powershell>some stuff</powershell>\n<persist>true</persist>",
+			expected: "<powershell>some stuff</powershell>\n<persist>true</persist>",
 		},
 		{
 			name:     "String has open tag but no close, does wrap",
 			target:   "<powershell>some stuff",
-			expected: "<powershell><powershell>some stuff</powershell>",
+			expected: "<powershell><powershell>some stuff</powershell>\n<persist>true</persist>",
 		},
 		{
 			name:     "String has close tag but no open, does wrap",
 			target:   "some stuff</powershell>",
-			expected: "<powershell>some stuff</powershell></powershell>",
+			expected: "<powershell>some stuff</powershell></powershell>\n<persist>true</persist>",
 		},
 	}
 
@@ -66,7 +66,7 @@ func TestHasPowershellTags(t *testing.T) {
 	}{
 		{
 			name:     "String has both tags",
-			target:   "<powershell>some stuff</powershell>",
+			target:   "<powershell>some stuff</powershell>\n<persist>true</persist>",
 			expected: true,
 		},
 		{
@@ -76,7 +76,7 @@ func TestHasPowershellTags(t *testing.T) {
 		},
 		{
 			name:     "String has close tag only",
-			target:   "some stuff</powershell>",
+			target:   "some stuff</powershell>\n<persist>true</persist>",
 			expected: false,
 		},
 		{
@@ -109,7 +109,7 @@ func TestRemovePowershellTags(t *testing.T) {
 		},
 		{
 			name:     "String has both tags",
-			target:   "<powershell>some stuff</powershell>",
+			target:   "<powershell>some stuff</powershell>\n<persist>true</persist>",
 			expected: "some stuff",
 		},
 		{
@@ -119,8 +119,8 @@ func TestRemovePowershellTags(t *testing.T) {
 		},
 		{
 			name:     "String has close tag only, does not remove",
-			target:   "some stuff</powershell>",
-			expected: "some stuff</powershell>",
+			target:   "some stuff</powershell>\n<persist>true</persist>",
+			expected: "some stuff</powershell>\n<persist>true</persist>",
 		},
 	}
 


### PR DESCRIPTION
this change updates the tag identifiers that are used by the WMCO when
creating the secret for the windows boot script. we need to have a
slightly tighter coupling with the WMCO until such time as they drop the
tags from their implementation. once the WMCO removes all the tags, we
should evualte the usefulness of the helper functions and remove or
modify them as necessary. for context, only some of the cloud provider
will need these tags, currently AWS and Azure.