### PR TITLE
Remove openstack-machine-controllers from image-references

### DIFF
--- a/install/image-references
+++ b/install/image-references
@@ -10,10 +10,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-aws-machine-controllers
-  - name: openstack-machine-controllers
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-openstack-machine-controllers
   - name: openstack-machine-api-provider
     from:
       kind: DockerImage


### PR DESCRIPTION
In support of https://github.com/openshift/ocp-build-data/pull/1817