### PR TITLE
Bug 2111972: operator NS manifest: Set empty openshift.io/run-level

### DIFF
--- a/install/0000_30_machine-api-operator_00_namespace.yaml
+++ b/install/0000_30_machine-api-operator_00_namespace.yaml
@@ -10,6 +10,7 @@ metadata:
   name: openshift-machine-api
   labels:
     name: openshift-machine-api
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
     # allow openshift-monitoring to look for ServiceMonitor objects in this namespace
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged


### PR DESCRIPTION
This reverts commit 401fe30b5a3b4c3c536081639c8ee99edf0fe715.

Reintroducing #1031 since it was reverted in #1044.

This should no longer cause any issues since https://github.com/openshift/cluster-version-operator/pull/804 was merged to solve the issue presented by removing the run-level annotation