### PR TITLE
add a helper function to detect windows os

### DIFF
--- a/pkg/util/windows/helpers.go
+++ b/pkg/util/windows/helpers.go
@@ -19,6 +19,8 @@ package windows
 import (
 	"fmt"
 	"strings"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
 )
 
 const (
@@ -39,6 +41,15 @@ func AddPowershellTags(target string) string {
 // Returns true if the string is wrapped with open and close tags for powershell.
 func HasPowershellTags(target string) bool {
 	return strings.HasPrefix(target, powershellOpenTag) && strings.HasSuffix(target, powershellCloseTag)
+}
+
+// Returns true if the Machine has the operating system label for a Windows instance.
+func IsMachineOSWindows(machine machinev1.Machine) bool {
+	osid, found := machine.Labels["machine.openshift.io/os-id"]
+	if found && osid == "Windows" {
+		return true
+	}
+	return false
 }
 
 // Return the supplied string with its powershell tags removed.

--- a/pkg/util/windows/helpers_test.go
+++ b/pkg/util/windows/helpers_test.go
@@ -18,6 +18,9 @@ package windows
 
 import (
 	"testing"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestAddPowershellTags(t *testing.T) {
@@ -89,6 +92,51 @@ func TestHasPowershellTags(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			observed := HasPowershellTags(tc.target)
+			if tc.expected != observed {
+				t.Errorf("observed: %v, expected: %v", observed, tc.expected)
+			}
+		})
+	}
+}
+
+func TestIsMachineOSWindows(t *testing.T) {
+	testcases := []struct {
+		name     string
+		machine  machinev1.Machine
+		expected bool
+	}{
+		{
+			name: "Machine has Windows OS label",
+			machine: machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"machine.openshift.io/os-id": "Windows",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Machine has Linux OS label",
+			machine: machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"machine.openshift.io/os-id": "Linux",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "Machine has no OS label",
+			machine:  machinev1.Machine{},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			observed := IsMachineOSWindows(tc.machine)
 			if tc.expected != observed {
 				t.Errorf("observed: %v, expected: %v", observed, tc.expected)
 			}


### PR DESCRIPTION
this change adds the function `IsMachineOSWindows` to the windows
utility functions. this logic will repeated in many providers and as
such it makes sense to centralize it, this will also make future changes
easier if the windows labels change.