### PR TITLE
OCPBUGS-268: vSphere - enable steal time accounting

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -49,6 +49,7 @@ const (
 	GuestInfoIgnitionData     = "guestinfo.ignition.config.data"
 	GuestInfoIgnitionEncoding = "guestinfo.ignition.config.data.encoding"
 	GuestInfoHostname         = "guestinfo.hostname"
+	StealClock                = "stealclock.enable"
 )
 
 // vSphere tasks description IDs, for determinate task types (clone, delete, etc)
@@ -747,6 +748,10 @@ func clone(s *machineScope) (string, error) {
 	extraConfig = append(extraConfig, &types.OptionValue{
 		Key:   GuestInfoHostname,
 		Value: s.machine.GetName(),
+	})
+	extraConfig = append(extraConfig, &types.OptionValue{
+		Key:   StealClock,
+		Value: "TRUE",
 	})
 
 	spec := types.VirtualMachineCloneSpec{


### PR DESCRIPTION
This PR enables steal time accounting on
control plane virtual machines.

From the linux commit:

Steal time is the amount of CPU time needed by a guest virtual machine
that is not provided by the host. Steal time occurs when the host
allocates this CPU time elsewhere, for example, to another guest.

Steal time can be enabled by adding the VM configuration option
stealclock.enable = "TRUE". It is supported by VMs that run hardware
version 13 or newer.