### PR TITLE
Release leader election lease when shutting down

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -95,6 +95,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 				klog.Fatalf("Leader election lost")
 			},
 		},
+		ReleaseOnCancel: true,
 	})
 	panic("unreachable")
 }


### PR DESCRIPTION
Our disruptive tests are really really slow. A large portion of this is the 2 minutes that the leader election must wait before reclaiming the lease when we reschedule the Machine API operator pod several times during the test suite.

I want to force `ReleaseOnCancel` which, is an upstream LeaderElection feature which, when shutting down, once all controllers are stopped, releases the lease. This is tried and tested upstream so I'm not too concerned about enabling it and I think the benefit, speeding up the handover and reducing the amount of time our tests take is significant.

Given this operator only manages deployments and webhooks, there shouldn't be any serious issues even if there are bugs in the implementation.