### PR TITLE
Bug 2101736: Ignore managed fields during finalizer removal

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1851,8 +1851,12 @@ func isDeleting(obj metav1.Object) bool {
 
 // isFinalizerOnlyRemoval checks if the machine update only removes finalizers.
 func isFinalizerOnlyRemoval(m, oldM *machinev1beta1.Machine) (bool, error) {
+	// ignore updated managed fields as they don't affect the result
+	machineCopy := m.DeepCopy()
+	machineCopy.ManagedFields = oldM.ManagedFields
+
 	patchBase := client.MergeFrom(oldM)
-	data, err := patchBase.Data(m)
+	data, err := patchBase.Data(machineCopy)
 	if err != nil {
 		return false, fmt.Errorf("cannot calculate patch data from machine object: %w", err)
 	}


### PR DESCRIPTION
Now if we want just remove the finalizer, for instance with

```sh
oc patch machines -nopenshift-machine-api machine -p '{"metadata":{"finalizers":null}}' --type=merge
```

in some cases client appends managed fields in the patch, which blocks finalizer removal.

To prevent this we ignore managed fields as they don't affect the result.