### PR TITLE
OCPCLOUD-1131: Add DescribeInstanceTypes permission for AWS provider

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -25,6 +25,7 @@ spec:
       - ec2:DescribeDhcpOptions
       - ec2:DescribeImages
       - ec2:DescribeInstances
+      - ec2:DescribeInstanceTypes
       - ec2:DescribeInternetGateways
       - ec2:DescribeSecurityGroups
       - ec2:DescribeRegions


### PR DESCRIPTION
I am working on a feature for the AWS provider that will allow it to obtain CPU, Memory, GPU information needed for Autoscaller annotations. This will require new DescribeInstanceTypes permission.
/hold until I have the other PR ready.
I want this PR up so I can use cluster bot to launch cluster with the permission set for testing.