### PR TITLE
[release-4.10] OCPBUGS-957: Change "create" sequence with powering on the vm after clone

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -27,6 +27,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -238,7 +239,8 @@ func (r *Reconciler) exists() (bool, error) {
 		return false, fmt.Errorf("%v: failed validating machine provider spec: %w", r.machine.GetName(), err)
 	}
 
-	if _, err := findVM(r.machineScope); err != nil {
+	vmRef, err := findVM(r.machineScope)
+	if err != nil {
 		if !isNotFound(err) {
 			return false, err
 		}
@@ -247,10 +249,19 @@ func (r *Reconciler) exists() (bool, error) {
 	}
 
 	// Check if machine was powered on after clone.
-	// If it is in poweredOff state and in "Provisioning" phase, treat machine as non-existed yet and requeue for proceed
+	// If it is powered off and in "Provisioning" phase, treat machine as non-existed yet and requeue for proceed
 	// with creation procedure.
-	powerState := stringPointerDeref(r.machineScope.providerStatus.InstanceState)
-	if stringPointerDeref(r.machine.Status.Phase) == machinePhaseProvisioning && powerState == string(types.VirtualMachinePowerStatePoweredOff) {
+	powerState := types.VirtualMachinePowerState(pointer.StringDeref(r.machineScope.providerStatus.InstanceState, ""))
+	if powerState == "" {
+		vm := &virtualMachine{
+			Context: r.machineScope.Context,
+			Obj:     object.NewVirtualMachine(r.machineScope.session.Client.Client, vmRef),
+			Ref:     vmRef,
+		}
+		powerState, err = vm.getPowerState()
+	}
+
+	if pointer.StringDeref(r.machine.Status.Phase, "") == machinePhaseProvisioning && powerState == types.VirtualMachinePowerStatePoweredOff {
 		klog.Infof("%v: already exists, but was not powered on after clone, requeue ", r.machine.GetName())
 		return false, nil
 	}

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -447,6 +447,91 @@ func TestClone(t *testing.T) {
 	}
 }
 
+func TestPowerOn(t *testing.T) {
+	model, simSession, server := initSimulator(t)
+	defer model.Remove()
+	defer server.Close()
+
+	getMinimalProviderSpec := func() *machinev1.VSphereMachineProviderSpec {
+		return &machinev1.VSphereMachineProviderSpec{
+			CredentialsSecret: &corev1.LocalObjectReference{
+				Name: "test",
+			},
+			Workspace: &machinev1.Workspace{
+				Server: server.URL.Host,
+			},
+			DiskGiB:  int32(5),
+			Template: "template",
+			UserDataSecret: &corev1.LocalObjectReference{
+				Name: "foo",
+			},
+		}
+	}
+
+	getMachineScope := func(providerSpec *machinev1.VSphereMachineProviderSpec, name string) *machineScope {
+		return &machineScope{
+			Context: context.TODO(),
+			machine: &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: "test",
+					Labels: map[string]string{
+						machinev1.MachineClusterIDLabel: "CLUSTERID",
+					},
+				},
+			},
+			providerSpec:   providerSpec,
+			session:        simSession,
+			providerStatus: &machinev1.VSphereMachineProviderStatus{},
+			client:         fake.NewFakeClientWithScheme(scheme.Scheme),
+		}
+	}
+
+	t.Run("powerOn should fail if there is no machine found", func(t *testing.T) {
+		g := NewWithT(t)
+
+		scope := getMachineScope(getMinimalProviderSpec(), "test")
+		taskId, err := powerOn(scope)
+
+		g.Expect(err).Should(HaveOccurred())
+		g.Expect(taskId).To(BeEmpty())
+		g.Expect(err.Error()).Should(ContainSubstring("vm not found during creation for powering on"))
+	})
+
+	t.Run("Test powering on vm with RDS (via datacenter)", func(t *testing.T) {
+		g := NewWithT(t)
+		vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+		object.NewVirtualMachine(simSession.Client.Client, vm.Reference())
+
+		scope := getMachineScope(getMinimalProviderSpec(), vm.Name)
+		taskId, err := powerOn(scope)
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(taskId).NotTo(BeEmpty())
+
+		task, err := simSession.GetTask(context.TODO(), taskId)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(task.Info.DescriptionId).Should(BeEquivalentTo("Datacenter.powerOnMultiVM"))
+	})
+
+	t.Run("Test powering on vm without a datacenter", func(t *testing.T) {
+		g := NewWithT(t)
+		vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+		object.NewVirtualMachine(simSession.Client.Client, vm.Reference())
+
+		scope := getMachineScope(getMinimalProviderSpec(), vm.Name)
+		scope.session.Datacenter = nil
+		taskId, err := powerOn(scope)
+
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(taskId).NotTo(BeEmpty())
+
+		task, err := simSession.GetTask(context.TODO(), taskId)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		g.Expect(task.Info.DescriptionId).Should(BeEquivalentTo("VirtualMachine.powerOn"))
+	})
+}
+
 func TestGetPowerState(t *testing.T) {
 	model, session, server := initSimulator(t)
 	defer model.Remove()
@@ -1849,16 +1934,39 @@ func TestExists(t *testing.T) {
 	}
 
 	cases := []struct {
-		name   string
-		exists bool
+		name          string
+		machinePhase  string
+		instanceState string
+		exists        bool
+		vmExists      bool
 	}{
 		{
-			name:   "VM doesn't exist",
-			exists: false,
+			name:          "VM doesn't exist",
+			machinePhase:  "Provisioning",
+			instanceState: string(types.VirtualMachinePowerStatePoweredOn),
+			exists:        false,
+			vmExists:      false,
 		},
 		{
-			name:   "VM already exists",
-			exists: true,
+			name:          "VM already exists",
+			machinePhase:  "Provisioning",
+			instanceState: string(types.VirtualMachinePowerStatePoweredOn),
+			exists:        true,
+			vmExists:      true,
+		},
+		{
+			name:          "VM exists but didnt powered on after clone",
+			machinePhase:  "Provisioning",
+			instanceState: string(types.VirtualMachinePowerStatePoweredOff),
+			exists:        false,
+			vmExists:      true,
+		},
+		{
+			name:          "VM exists, but powered off",
+			machinePhase:  "Provisioned",
+			instanceState: string(types.VirtualMachinePowerStatePoweredOff),
+			exists:        true,
+			vmExists:      true,
 		},
 	}
 
@@ -1874,20 +1982,24 @@ func TestExists(t *testing.T) {
 							machinev1.MachineClusterIDLabel: "CLUSTERID",
 						},
 					},
+					Status: machinev1.MachineStatus{
+						Phase: &tc.machinePhase,
+					},
 				},
 				providerSpec: &machinev1.VSphereMachineProviderSpec{
 					Template: vm.Name,
 				},
 				session: session,
 				providerStatus: &machinev1.VSphereMachineProviderStatus{
-					TaskRef: task.Reference().Value,
+					TaskRef:       task.Reference().Value,
+					InstanceState: &tc.instanceState,
 				},
 				client: fake.NewFakeClientWithScheme(scheme.Scheme, &credentialsSecret),
 			}
 
 			reconciler := newReconciler(&machineScope)
 
-			if tc.exists {
+			if tc.vmExists {
 				reconciler.machine.UID = apimachinerytypes.UID(instanceUUID)
 			}
 

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -183,6 +183,13 @@ func getInsecureFlagFromConfig(config *vSphereConfig) bool {
 	return false
 }
 
+func stringPointerDeref(stringPointer *string) string {
+	if stringPointer != nil {
+		return *stringPointer
+	}
+	return ""
+}
+
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.VSphereMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -183,13 +183,6 @@ func getInsecureFlagFromConfig(config *vSphereConfig) bool {
 	return false
 }
 
-func stringPointerDeref(stringPointer *string) string {
-	if stringPointer != nil {
-		return *stringPointer
-	}
-	return ""
-}
-
 // RawExtensionFromProviderSpec marshals the machine provider spec.
 func RawExtensionFromProviderSpec(spec *machinev1.VSphereMachineProviderSpec) (*runtime.RawExtension, error) {
 	if spec == nil {


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/machine-api-operator/pull/1047

Did it manually due to conflicts in the imports section.

respective 4.11 backport: https://github.com/openshift/machine-api-operator/pull/1064