### PR TITLE
OCPBUGS-519: update error message for disconnected installation validation

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -935,7 +935,7 @@ func validateAzure(m *machinev1beta1.Machine, config *admissionConfig) (bool, []
 	}
 
 	if providerSpec.PublicIP && config.dnsDisconnected {
-		errs = append(errs, field.Forbidden(field.NewPath("providerSpec", "publicIP"), "publicIP is not allowed in Azure disconnected installation"))
+		errs = append(errs, field.Forbidden(field.NewPath("providerSpec", "publicIP"), "publicIP is not allowed in Azure disconnected installation with publish strategy as internal"))
 	}
 	// Vnet requires Subnet
 	if providerSpec.Vnet != "" && providerSpec.Subnet == "" {

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -270,7 +270,7 @@ func TestMachineCreation(t *testing.T) {
 				},
 			},
 			disconnected:  true,
-			expectedError: "providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation",
+			expectedError: "providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation with publish strategy as internal",
 		},
 		{
 			name:         "with Azure disconnected installation success",

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -167,7 +167,7 @@ func TestMachineSetCreation(t *testing.T) {
 				},
 			},
 			disconnected:  true,
-			expectedError: "providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation",
+			expectedError: "providerSpec.publicIP: Forbidden: publicIP is not allowed in Azure disconnected installation with publish strategy as internal",
 		},
 		{
 			name:         "with Azure disconnected installation success",


### PR DESCRIPTION
We shouldn't allow creating new machines with public IP for disconnected install with Internal publish strategy only. To prevent this confusion we update the message for the error to make it more explicit.