### PR TITLE
OCPBUGS-1274: add tolerations to termination handler

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -823,6 +823,12 @@ func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSp
 					},
 				},
 			},
+			Tolerations: []corev1.Toleration{
+				corev1.Toleration{
+					Operator: corev1.TolerationOpExists,
+					Effect:   corev1.TaintEffectNoSchedule,
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
this change adds an `Exists` toleration to the termination handler, it is being added to help mitigate scenarios where a node is added with taints on it, but where the termination handler will be needed. an example of this is with spot instances that join the cluster with existing taints. in these cases the termination handler will not deploy but should be deployed.