### PR TITLE
Updating ose-machine-api-operator images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.18-openshift-4.11
+  tag: rhel-8-release-golang-1.19-openshift-4.12

--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.12 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-operator
 COPY . .
 RUN NO_DOCKER=1 make build
 
-FROM registry.ci.openshift.org/ocp/4.11:base
+FROM registry.ci.openshift.org/ocp/4.12:base
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/install manifests
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/machine-api-operator .
 COPY --from=builder /go/src/github.com/openshift/machine-api-operator/bin/nodelink-controller .

--- a/pkg/controller/machine/actuator.go
+++ b/pkg/controller/machine/actuator.go
@@ -22,7 +22,6 @@ import (
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 )
 
-/// [Actuator]
 // Actuator controls machines on a specific infrastructure. All
 // methods should be idempotent unless otherwise specified.
 type Actuator interface {
@@ -35,5 +34,3 @@ type Actuator interface {
 	// Checks if the machine currently exists.
 	Exists(context.Context, *machinev1.Machine) (bool, error)
 }
-
-/// [Actuator]

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -203,15 +203,16 @@ func (s *machineScope) GetUserData() ([]byte, error) {
 //
 // Assuming the vcenter is our dev server vcsa.vmware.devcluster.openshift.com,
 // the secret would be in this format:
-//apiVersion: v1
-//kind: Secret
-//metadata:
-//  name: vsphere
-//  namespace: openshift-machine-api
-//type: Opaque
-//data:
-//  vcsa.vmware.devcluster.openshift.com.username: base64 string
-//  vcsa.vmware.devcluster.openshift.com.password: base64 string
+//
+//	apiVersion: v1
+//	kind: Secret
+//	metadata:
+//	  name: vsphere
+//	  namespace: openshift-machine-api
+//	type: Opaque
+//	data:
+//	  vcsa.vmware.devcluster.openshift.com.username: base64 string
+//	  vcsa.vmware.devcluster.openshift.com.password: base64 string
 func getCredentialsSecret(client runtimeclient.Client, namespace string, spec machinev1.VSphereMachineProviderSpec) (string, string, error) {
 	if spec.CredentialsSecret == nil {
 		return "", "", nil

--- a/pkg/metrics/machinehealthcheck.go
+++ b/pkg/metrics/machinehealthcheck.go
@@ -1,18 +1,19 @@
 /*
-   Copyright 2020 The Machine API Operator authors
+Copyright 2020 The Machine API Operator authors
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
+
 package metrics
 
 import (

--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -145,7 +145,7 @@ func newClusterOperatorStatusCondition(conditionType osconfigv1.ClusterStatusCon
 	}
 }
 
-//syncStatus applies the new condition to the mao ClusterOperator object.
+// syncStatus applies the new condition to the mao ClusterOperator object.
 func (optr *Operator) syncStatus(co *osconfigv1.ClusterOperator, conds []osconfigv1.ClusterOperatorStatusCondition) error {
 	for _, c := range conds {
 		v1helpers.SetStatusCondition(&co.Status.Conditions, c)


### PR DESCRIPTION
Cherry-picked from #1035 

Apply `go fmt` related changes in follow up commit