### PR TITLE
OCPBUGS-2151: Don't degrade when workers not expected

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -336,15 +336,10 @@ func (optr *Operator) checkMinimumWorkerMachines() error {
 		nonRunningMachines = append(nonRunningMachines, nonRunningMachineSetMachines...)
 	}
 
-	if expectedReplicas == 0 {
-		// This means there are no MachineSets in the cluster, so we are ok to proceed.
-		return nil
-	}
-
 	// If any MachineSet doesn't have the correct number of replicas, we error before this point.
 	// So the running replicas should be (total replicas) - (non-running replicas).
 	runningReplicas := expectedReplicas - int32(len(nonRunningMachines))
-	if runningReplicas < minimumWorkerReplicas {
+	if runningReplicas < expectedReplicas && runningReplicas < minimumWorkerReplicas {
 		return fmt.Errorf("minimum worker replica count (%d) not yet met: current running replicas %d, waiting for %v", minimumWorkerReplicas, runningReplicas, nonRunningMachines)
 	}
 

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -329,6 +329,16 @@ func TestCheckMinimumWorkerMachines(t *testing.T) {
 			expectedError: errors.New("could not determine running Machines in MachineSet \"no-machines\": replicas not satisfied for MachineSet: expected 3 replicas, got 0 current replicas"),
 		},
 		{
+			name: "with a single-machine MachineSet with one Machine",
+			machineSets: []runtime.Object{
+				newMachineSet("one-machines", 1, workerSelector),
+			},
+			machines: []runtime.Object{
+				newMachine("running-0", workerLabels, "Running"),
+			},
+			expectedError: nil,
+		},
+		{
 			name: "with a MachineSet with not enough Machines",
 			machineSets: []runtime.Object{
 				newMachineSet("no-machines", 3, workerSelector),


### PR DESCRIPTION
Since 28853af469d6e3e6c40454de85baa7084d3165c0 we mark the MAO degraded when two workers have not come up (and we ignore this constraint if zero workers are expected), but this will never succeed if exactly one worker has been requested. This was previously an invalid configuration, but since [MGMT-8987](https://issues.redhat.com//browse/MGMT-8987) it is permitted to create a compact cluster with exactly one worker, since the control plane nodes are schedulable.

To handle this case, only remain degraded when we have fewer than two workers *and* all of the expected workers have not yet come up. Leave it to installers to validate which configurations are and are not supported on Day 1.

This does mean that the operator can report that it is degraded even when there are sufficient machines to run e.g. the Ingress operator due to schedulable masters (which could be changed only by checking the scheduler config). However, given that in IPI workers and masters are provisioned by entirely different methods, it makes sense to report degraded so long as any workers have been requested but none created.