### PR TITLE
Update default Azure image to use image galleries

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -53,7 +53,10 @@ var (
 		return fmt.Sprintf("%s-rg", clusterID)
 	}
 	defaultAzureImageResourceID = func(clusterID string) string {
-		return fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/images/%s", clusterID+"-rg", clusterID)
+		// image gallery names cannot have dashes
+		galleryName := strings.Replace(clusterID, "-", "_", -1)
+
+		return fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", clusterID+"-rg", galleryName, clusterID, azureRHCOSVersion)
 	}
 	defaultAzureManagedIdentiy = func(clusterID string) string {
 		return fmt.Sprintf("%s-identity", clusterID)
@@ -132,6 +135,7 @@ const (
 	azureCachingTypeNone               = "None"
 	azureCachingTypeReadOnly           = "ReadOnly"
 	azureCachingTypeReadWrite          = "ReadWrite"
+	azureRHCOSVersion                  = "latest" // The installer only sets up one version but its name may vary, using latest will pull it no matter the name.
 
 	// GCP Defaults
 	defaultGCPMachineType       = "n1-standard-4"


### PR DESCRIPTION
Since https://github.com/openshift/installer/pull/6304 merged, our default webhook that defaults the Azure image resource ID has been broken. This PR updates our defaulting logic to match the format in the installer PR which should resolve the recent Azure minimal webhook test failures we've been seeing