### PR TITLE
Bug 2095274: vSphere, fix network existence check for network devices during machine creation

### DIFF
--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -901,6 +901,50 @@ func testGetNetworkDevicesWithSimulator(t *testing.T, model *simulator.Model, se
 				return true
 			},
 		},
+		{
+			testCase: "two Networks with non existed first one",
+			providerSpec: &machinev1.VSphereMachineProviderSpec{
+				Network: machinev1.NetworkSpec{
+					Devices: []machinev1.NetworkDeviceSpec{
+						{
+							NetworkName: "Not Existed",
+						},
+						{
+							NetworkName: "VM Network",
+						},
+					},
+				},
+			},
+			expected: func(gotDevices []types.BaseVirtualDeviceConfigSpec, err error) bool {
+				if err == nil {
+					t.Fatal("Error expected")
+					return false
+				}
+				return true
+			},
+		},
+		{
+			testCase: "two Networks with non existed second one",
+			providerSpec: &machinev1.VSphereMachineProviderSpec{
+				Network: machinev1.NetworkSpec{
+					Devices: []machinev1.NetworkDeviceSpec{
+						{
+							NetworkName: "VM Network",
+						},
+						{
+							NetworkName: "Non Existed",
+						},
+					},
+				},
+			},
+			expected: func(gotDevices []types.BaseVirtualDeviceConfigSpec, err error) bool {
+				if err == nil {
+					t.Fatal("Error expected")
+					return false
+				}
+				return true
+			},
+		},
 	}
 	// TODO: verify GetVirtualDeviceConfigSpec().Device values
 


### PR DESCRIPTION
In case of multiple network devices in machine's
provider spec it was possible to wrongly use device Backing info
from the previously handled network device instead of returning error
in situation when Network specified for the device does not exist.
This might lead to creating machines which does not comply with the spec.