### PR TITLE
Allow to use machine.openshift.io API in provider specs

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1887,13 +1887,13 @@ func isFinalizerOnlyRemoval(m, oldM *machinev1beta1.Machine) (bool, error) {
 func validateGVK(gvk schema.GroupVersionKind, platform osconfigv1.PlatformType) bool {
 	switch platform {
 	case osconfigv1.AWSPlatformType:
-		return gvk.Kind == "AWSMachineProviderConfig" && gvk.Group == "awsproviderconfig.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+		return gvk.Kind == "AWSMachineProviderConfig" && (gvk.Group == "awsproviderconfig.openshift.io" || gvk.Group == "machine.openshift.io") && (gvk.Version == "v1beta1" || gvk.Version == "v1")
 	case osconfigv1.AzurePlatformType:
-		return gvk.Kind == "AzureMachineProviderSpec" && gvk.Group == "azureproviderconfig.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+		return gvk.Kind == "AzureMachineProviderSpec" && (gvk.Group == "azureproviderconfig.openshift.io" || gvk.Group == "machine.openshift.io") && (gvk.Version == "v1beta1" || gvk.Version == "v1")
 	case osconfigv1.GCPPlatformType:
-		return gvk.Kind == "GCPMachineProviderSpec" && gvk.Group == "gcpprovider.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+		return gvk.Kind == "GCPMachineProviderSpec" && (gvk.Group == "gcpprovider.openshift.io" || gvk.Group == "machine.openshift.io") && (gvk.Version == "v1beta1" || gvk.Version == "v1")
 	case osconfigv1.VSpherePlatformType:
-		return gvk.Kind == "VSphereMachineProviderSpec" && gvk.Group == "vsphereprovider.openshift.io" && (gvk.Version == "v1beta1" || gvk.Version == "v1")
+		return gvk.Kind == "VSphereMachineProviderSpec" && (gvk.Group == "vsphereprovider.openshift.io" || gvk.Group == "machine.openshift.io") && (gvk.Version == "v1beta1" || gvk.Version == "v1")
 	default:
 		return true
 	}

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -2151,6 +2151,14 @@ func TestValidateAWSProviderSpec(t *testing.T) {
 			expectedOk:       true,
 			expectedWarnings: []string{"incorrect GroupVersionKind for AWSMachineProviderConfig object: INVALID/v1, Kind=INVALID"},
 		},
+		{
+			testCase: "with machine.openshift.io API group",
+			modifySpec: func(p *machinev1beta1.AWSMachineProviderConfig) {
+				p.Kind = "AWSMachineProviderConfig"
+				p.APIVersion = "machine.openshift.io/v1beta1"
+			},
+			expectedOk: true,
+		},
 	}
 
 	secret := &corev1.Secret{
@@ -2621,6 +2629,14 @@ func TestValidateAzureProviderSpec(t *testing.T) {
 			},
 			expectedOk:       true,
 			expectedWarnings: []string{"incorrect GroupVersionKind for AzureMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
+		},
+		{
+			testCase: "with machine.openshift.io API group",
+			modifySpec: func(p *machinev1beta1.AzureMachineProviderSpec) {
+				p.Kind = "AzureMachineProviderSpec"
+				p.APIVersion = "machine.openshift.io/v1beta1"
+			},
+			expectedOk: true,
 		},
 	}
 
@@ -3185,6 +3201,14 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			expectedOk:       true,
 			expectedWarnings: []string{"incorrect GroupVersionKind for GCPMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
 		},
+		{
+			testCase: "with machine.openshift.io API group",
+			modifySpec: func(p *machinev1beta1.GCPMachineProviderSpec) {
+				p.Kind = "GCPMachineProviderSpec"
+				p.APIVersion = "machine.openshift.io/v1beta1"
+			},
+			expectedOk: true,
+		},
 	}
 
 	secret := &corev1.Secret{
@@ -3619,6 +3643,14 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			},
 			expectedOk:       true,
 			expectedWarnings: []string{"incorrect GroupVersionKind for VSphereMachineProviderSpec object: INVALID/v1, Kind=INVALID"},
+		},
+		{
+			testCase: "with machine.openshift.io API group",
+			modifySpec: func(p *machinev1beta1.VSphereMachineProviderSpec) {
+				p.Kind = "VSphereMachineProviderSpec"
+				p.APIVersion = "machine.openshift.io/v1beta1"
+			},
+			expectedOk: true,
 		},
 	}
 


### PR DESCRIPTION
Despite the fact the documentation says to use `awsproviderconfig.openshift.io` and related APIs for different platforms, it's also possible to use `machine.openshift.io`

This PR updates the webhook to allow this API as well.