### PR TITLE
Increase timeout for machineset tests

### DIFF
--- a/pkg/controller/machineset/machineset_controller_test.go
+++ b/pkg/controller/machineset/machineset_controller_test.go
@@ -18,6 +18,7 @@ package machineset
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -71,7 +72,7 @@ var _ = Describe("MachineSet Reconciler", func() {
 
 		By("Closing the manager")
 		mgrCtxCancel()
-		Eventually(mgrStopped, timeout).Should(BeClosed())
+		Eventually(mgrStopped, timeout).WithTimeout(20 * time.Second).Should(BeClosed())
 	})
 
 	It("Should reconcile a MachineSet", func() {


### PR DESCRIPTION
Currently, when running in CI, machineset tests sometimes fail with timeout error. 
```txt
• Failure in Spec Teardown (AfterEach) [12.059 seconds]
MachineSet Reconciler
/go/src/github.com/openshift/machine-api-operator/pkg/controller/machineset/machineset_controller_test.go:31
  Should reconcile a MachineSet [AfterEach]
  /go/src/github.com/openshift/machine-api-operator/pkg/controller/machineset/machineset_controller_test.go:77
  Timed out after 10.000s.
```

To prevent this we increase the timeout to 20 seconds.