### PR TITLE
[OCPCLOUD-1708]: Set default container for machine-api-operator

### DIFF
--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        kubectl.kubernetes.io/default-container: machine-api-operator
       labels:
         k8s-app: machine-api-operator
     spec:


### PR DESCRIPTION
This PR sets a default container for MAO with a well-defined k8s annotation.