### PR TITLE
OCPBUGS-3275: Update machinehealthcheck dropping log from Error to Warning

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -577,7 +577,7 @@ func (r *ReconcileMachineHealthCheck) mhcRequestsFromNode(o client.Object) []rec
 
 	machine, err := r.getMachineFromNode(node.Name)
 	if machine == nil || err != nil {
-		klog.Errorf("No-op: Unable to retrieve machine from node %q: %v", namespacedName(node).String(), err)
+		klog.Warningf("No-op: Unable to retrieve machine from node %q: %v", namespacedName(node).String(), err)
 		return nil
 	}
 


### PR DESCRIPTION
"Unable to retrieve machine from node" is mentioned as `ERROR` but its a warning. It confuses user when it occurs , so better to keep it as warning.

https://issues.redhat.com/browse/OCPBUGS-3275