### PR TITLE
OCPBUGS-6063: Forcefully delete unevicted pods within vSphere machine deletion procedure

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -357,6 +357,18 @@ func (r *Reconciler) delete() error {
 			return fmt.Errorf("failed to determine if node %v has attached volumes: %w", r.machine.Status.NodeRef.Name, err)
 		}
 		if attached {
+			// If there are volumes still attached, it's possible that node draining did not fully finish,
+			// this might happen if the kubelet was non-functional during the draining procedure.
+			// Try forcefully deleting pods in the "Terminating" state to trigger persistent volumes detachment.
+			klog.Warningf(
+				"Attached volumes detected on a powered off node, node draining may not succeed. " +
+					"Attempting to delete unevicted pods",
+			)
+			numPodsDeleted, err := r.machineScope.deleteUnevictedPods()
+			klog.Warningf("Deleted %d pods", numPodsDeleted)
+			if err != nil {
+				return fmt.Errorf("unable to fully drain node, can not delete unevicted pods: %w", err)
+			}
 			return fmt.Errorf("node %v has attached volumes, requeuing", r.machine.Status.NodeRef.Name)
 		}
 	}

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachinerytypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -1869,7 +1870,7 @@ func TestDelete(t *testing.T) {
 			errMessage: "disks were detached, vm will be attempted to destroy in next reconciliation, requeuing",
 		},
 		{
-			name:        "node status contains attached volumes",
+			name:        "node status contains attached volumes, node ready",
 			attachDisks: true,
 			machine: func(t *testing.T, simServerHost string) *machinev1.Machine {
 				machine := getMachineWithStatus(t, machinev1.MachineStatus{
@@ -1884,6 +1885,38 @@ func TestDelete(t *testing.T) {
 					{
 						Type:   corev1.NodeReady,
 						Status: corev1.ConditionTrue,
+					},
+				})
+				node.Status.VolumesAttached = []corev1.AttachedVolume{
+					{
+						Name:       "foo",
+						DevicePath: "bar",
+					},
+					{
+						Name:       "fizz",
+						DevicePath: "bazzz",
+					},
+				}
+				return node
+			},
+			errMessage: "node is in operational state, won't proceed with pods deletion",
+		},
+		{
+			name:        "node status contains attached volumes, node does not reporting ready",
+			attachDisks: true,
+			machine: func(t *testing.T, simServerHost string) *machinev1.Machine {
+				machine := getMachineWithStatus(t, machinev1.MachineStatus{
+					NodeRef: &corev1.ObjectReference{
+						Name: nodeName,
+					},
+				}, simServerHost)
+				return machine
+			},
+			node: func(t *testing.T) *corev1.Node {
+				node := getNodeWithConditions([]corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionUnknown,
 					},
 				})
 				node.Status.VolumesAttached = []corev1.AttachedVolume{
@@ -1952,17 +1985,25 @@ func TestDelete(t *testing.T) {
 				g.Expect(addDiskToVm(context.TODO(), vm, fmt.Sprintf("%s-%s", vm.Name, tc.name), simClient)).To(Succeed())
 			}
 
-			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(
+			nodeNameIndexExtractor := func(rawObj runtimeclient.Object) []string {
+				pod := rawObj.(*corev1.Pod)
+				return []string{pod.Spec.NodeName}
+			}
+
+			cl := fake.NewClientBuilder().WithScheme(
+				scheme.Scheme,
+			).WithIndex(&corev1.Pod{}, "spec.nodeName", nodeNameIndexExtractor).WithRuntimeObjects(
 				simParams.secret,
 				tc.machine(t, simParams.host),
 				simParams.configMap,
 				simParams.infra,
-				tc.node(t)).Build()
+				tc.node(t),
+			).Build()
 			mScope, err := newMachineScope(machineScopeParams{
-				client:    client,
+				client:    cl,
 				Context:   context.Background(),
 				machine:   tc.machine(t, simParams.host),
-				apiReader: client,
+				apiReader: cl,
 			})
 			g.Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Follow up for #1114 

In case the drain procedure was performed on a node where kubelet was not operational for some reason, pods on a such node will be stuck in the "Terminating" state and will be never deleted.
If such pods have volumes attached to them, these volumes will never be detached.

For the case when VM was already drained and powered off, but still has attached volumes
we need to attempt forcefully delete pods in "Terminating" state. This will implicitly trigger attach-detach controller to detach disks from the VM.

This patch might help to reduce workloads disruption since vsphere storage driver has known issue for cases when disks was forcefully detached from the vm:
https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/e67a2de5c93d4c279231812b3ace6f5f2eb471fa/docs/book/known_issues.md#multi-attach-error-for-rwo-block-volume-when-node-vm-is-shutdown-before-pods-are-evicted-and-volumes-are-detached-from-node-vm