### PR TITLE
OCPBUGS-6063: Add missed permission for a pod deletion on vsphere platform

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -188,6 +188,9 @@ rules:
       - get
       - list
       - watch
+      # Delete is needed for the case when eviction did not finish properly due to the kubelet is not operational on a node
+      # see https://github.com/openshift/machine-api-operator/pull/1118 for the context.
+      - delete
 
   - apiGroups:
       - ""


### PR DESCRIPTION
Follow up for https://github.com/openshift/machine-api-operator/pull/1118 with missing permission.

Machine deletion stucks due to vpshere machine controller trying to delete unevicted pods after machine was powered off and drained.