### PR TITLE
OCPCLOUD-1778: Add None and External platform type explicit handling

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -103,6 +103,8 @@ func getProviderControllerFromImages(platform configv1.PlatformType, featureGate
 		return images.ClusterAPIControllerNutanix, nil
 	case kubemarkPlatform:
 		return clusterAPIControllerKubemark, nil
+	case configv1.NonePlatformType, configv1.ExternalPlatformType:
+		return clusterAPIControllerNoOp, nil
 	default:
 		return clusterAPIControllerNoOp, nil
 	}

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -328,6 +328,10 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 			provider:      configv1.NutanixPlatformType,
 			expectedImage: expectedNutanixImage,
 		},
+		{
+			provider:      configv1.ExternalPlatformType,
+			expectedImage: clusterAPIControllerNoOp,
+		},
 	}
 
 	imagesJSONFile, err := createImagesJSONFromManifest()


### PR DESCRIPTION
Handle None and External platform types explicitly. Add extra test for the External platform.