### PR TITLE
OCPBUGS-7249: Fix zone tag value reconciliation for vSphere machines

### DIFF
--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -2511,6 +2511,9 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cluster := simulator.Map.Any("ClusterComputeResource").(*simulator.ClusterComputeResource)
+	dc := simulator.Map.Any("Datacenter").(*simulator.Datacenter)
+
 	if err := createTagAndCategory(session, zoneKey, testZone); err != nil {
 		t.Fatalf("cannot create tag and category: %v", err)
 	}
@@ -2522,12 +2525,12 @@ func TestReconcileMachineWithCloudState(t *testing.T) {
 	if err := session.WithRestClient(context.TODO(), func(c *rest.Client) error {
 		tagsMgr := tags.NewManager(c)
 
-		err = tagsMgr.AttachTag(context.TODO(), testZone, vmObj.Reference())
+		err = tagsMgr.AttachTag(context.TODO(), testZone, cluster.Reference())
 		if err != nil {
 			return err
 		}
 
-		err = tagsMgr.AttachTag(context.TODO(), testRegion, vmObj.Reference())
+		err = tagsMgr.AttachTag(context.TODO(), testRegion, dc.Reference())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
VCenter does not return 'Cluster' object as a VM ancestor, use VM's host system instead.

Also, this commit introduces using of CachingTagsManager for region/zone tags info obtaining, instead of constructing a non-caching one.