### PR TITLE
CCO-321: Add support for feature-gating specific providers

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -237,6 +237,8 @@ rules:
     resources:
     - infrastructures
     - dnses
+    - clusterversions
+    - featuregates
     verbs:
     - get
     - list

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -700,6 +701,9 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 						FieldPath: "spec.nodeName",
 					},
 				},
+			}, corev1.EnvVar{
+				Name:  "RELEASE_VERSION",
+				Value: os.Getenv("RELEASE_VERSION"),
 			}),
 			Ports: []corev1.ContainerPort{
 				{


### PR DESCRIPTION
xref: [CCO-321](https://issues.redhat.com//browse/CCO-321)

Value is being read here: https://github.com/openshift/machine-api-provider-azure/pull/55/commits/b317300432a2b37ada7fcd3ece06fba75afd216f#diff-435eecb1d2af40ee96747f88ab71eb2758da989c92f76dcb1f714fc1b300c633R135