### PR TITLE
MIXEDARCH-129: Adds the MergeCommaSeparatedKeyValues method in the util package

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package util
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Filter filters a list for a string.
 func Filter(list []string, strToFilter string) (newList []string) {
 	for _, item := range list {
@@ -34,4 +39,26 @@ func Contains(list []string, strToSearch string) bool {
 		}
 	}
 	return false
+}
+
+// MergeCommaSeparatedKeyValuePairs merges multiple comma separated lists of key=value pairs into a single, comma-separated, list
+// of key=value pairs. If a key is present in multiple lists, the value from the last list is used.
+func MergeCommaSeparatedKeyValuePairs(lists ...string) string {
+	merged := make(map[string]string)
+	for _, list := range lists {
+		for _, kv := range strings.Split(list, ",") {
+			kv := strings.Split(kv, "=")
+			if len(kv) != 2 {
+				// ignore invalid key=value pairs
+				continue
+			}
+			merged[kv[0]] = kv[1]
+		}
+	}
+	// convert the map back to a comma separated list
+	var result []string
+	for k, v := range merged {
+		result = append(result, fmt.Sprintf("%s=%s", k, v))
+	}
+	return strings.Join(result, ",")
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestMergeCommaSeparatedKeyValues(t *testing.T) {
+	testCases := []struct {
+		lists              []string
+		sortedExpectedList []string // The list of key=value pairs string in the alphabetically sorted order
+		name               string
+	}{
+		{
+			name: "with three lists and two overlapping keys",
+			lists: []string{
+				"foo=bar,bar=baz,io.k8s.something=else-value_1,kubernetes.io/arch=arm64",
+				"bar=overwritten",
+				"io.k8s.something=else-value_2",
+			},
+			sortedExpectedList: []string{
+				"bar=overwritten",
+				"foo=bar",
+				"io.k8s.something=else-value_2",
+				"kubernetes.io/arch=arm64",
+			},
+		},
+		{
+			name: "with three lists and overwriting the kubernetes.io/arch label too",
+			lists: []string{
+				"foo=bar,bar=baz,io.k8s.something=else-value_1,kubernetes.io/arch=amd64",
+				"bar=overwritten",
+				"io.k8s.something=else-value_2,kubernetes.io/arch=arm64",
+			},
+			sortedExpectedList: []string{
+				"bar=overwritten",
+				"foo=bar",
+				"io.k8s.something=else-value_2",
+				"kubernetes.io/arch=arm64",
+			},
+		},
+		{name: "with three lists and a wrong key-value pair (missing the `=`)",
+			lists: []string{
+				"foo=bar,bar=baz,io.k8s.something=else-value_1,kubernetes.io/arch=amd64",
+				"bar=overwritten,wrong-key-value-pair",
+				"io.k8s.something=else-value_2,kubernetes.io/arch=arm64",
+			},
+			sortedExpectedList: []string{
+				"bar=overwritten",
+				"foo=bar",
+				"io.k8s.something=else-value_2",
+				"kubernetes.io/arch=arm64",
+			},
+		},
+		{name: "with three lists and an empty value for the key `bar`",
+			lists: []string{
+				"foo=bar,bar=baz,io.k8s.something=else-value_1,kubernetes.io/arch=amd64",
+				"bar=",
+				"io.k8s.something=else-value_2,kubernetes.io/arch=arm64",
+			},
+			sortedExpectedList: []string{
+				"bar=",
+				"foo=bar",
+				"io.k8s.something=else-value_2",
+				"kubernetes.io/arch=arm64",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(tt *testing.T) {
+			g := NewWithT(tt)
+			mergedList := strings.Split(MergeCommaSeparatedKeyValuePairs(tc.lists...), ",")
+			// As we use maps, the order of key-value pairs in the final string is not guaranteed:
+			// we must ensure the equality check is done against the sorted list
+			sort.Strings(mergedList)
+			g.Expect(mergedList).To(Equal(tc.sortedExpectedList))
+		})
+	}
+}


### PR DESCRIPTION
In the efforts for [MIXEDARCH-129](https://issues.redhat.com//browse/MIXEDARCH-129), we will need to change several cloud providers' actuators to get the kubernetes.io/arch label considered for scaling from zero. The upstream changes introduced by kubernetes/autoscaler/pull/5382 allow us to use an annotation to instruct the autoscaler about the node labels. The actuators will consume the method introduced by this commit to merge the comma-separated list of key-value pairs stored in that annotation with any others the actuators want to add.

cc @elmiko @JoelSpeed @Prashanth684 