### PR TITLE
reconcile status when the clusteroperator changes

### DIFF
--- a/cmd/machine-api-operator/start.go
+++ b/cmd/machine-api-operator/start.go
@@ -157,6 +157,7 @@ func startControllersOrDie(ctx *ControllerContext) {
 		config,
 		ctx.KubeNamespacedInformerFactory.Apps().V1().Deployments(),
 		ctx.KubeNamespacedInformerFactory.Apps().V1().DaemonSets(),
+		ctx.ConfigInformerFactory.Config().V1().ClusterOperators(),
 		ctx.ConfigInformerFactory.Config().V1().FeatureGates(),
 		ctx.ConfigInformerFactory.Config().V1().ClusterVersions(),
 		ctx.KubeNamespacedInformerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations(),

--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -396,6 +396,8 @@ rules:
     verbs:
       - create
       - get
+      - list
+      - watch
       - update
 
   - apiGroups:


### PR DESCRIPTION
noticed in https://github.com/openshift/cluster-kube-apiserver-operator/pull/1423

operator needs to respond to changes in its self-status.