### PR TITLE
Fix data race conditions in unit tests

### DIFF
--- a/cmd/machine-healthcheck/main.go
+++ b/cmd/machine-healthcheck/main.go
@@ -113,7 +113,7 @@ func main() {
 	klog.Infof("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := machinev1.Install(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)
 	}
 

--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -174,7 +174,7 @@ func main() {
 	log.Printf("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := machinev1.Install(mgr.GetScheme()); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/nodelink-controller/main.go
+++ b/cmd/nodelink-controller/main.go
@@ -99,7 +99,7 @@ func main() {
 	klog.Infof("Registering Components.")
 
 	// Setup Scheme for all resources
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := machinev1.Install(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)
 	}
 

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -126,15 +126,15 @@ func main() {
 		TaskIDCache:   taskIDCache,
 	})
 
-	if err := configv1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := configv1.Install(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)
 	}
 
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := machinev1.Install(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)
 	}
 
-	if err := machinev1.AddToScheme(mgr.GetScheme()); err != nil {
+	if err := machinev1.Install(mgr.GetScheme()); err != nil {
 		klog.Fatal(err)
 	}
 

--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -508,10 +508,6 @@ func TestReconcileRequest(t *testing.T) {
 		t.Run(tc.request.Name, func(t *testing.T) {
 			act := newTestActuator()
 			act.ExistsValue = tc.existsValue
-			if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
-				t.Fatalf("cannot add scheme: %v", err)
-			}
-
 			r := &ReconcileMachine{
 				Client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(
 					&machineNoPhase,
@@ -690,7 +686,6 @@ func TestUpdateStatus(t *testing.T) {
 
 			k8sClient, err := client.New(cfg, client.Options{})
 			g.Expect(err).ToNot(HaveOccurred())
-			g.Expect(machinev1.AddToScheme(scheme.Scheme)).ToNot(HaveOccurred())
 			reconciler := &ReconcileMachine{
 				Client: k8sClient,
 				scheme: scheme.Scheme,

--- a/pkg/controller/machine/machine_controller_suite_test.go
+++ b/pkg/controller/machine/machine_controller_suite_test.go
@@ -39,7 +39,7 @@ func TestMain(m *testing.M) {
 	t := &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "install")},
 	}
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
+	if err := machinev1.Install(scheme.Scheme); err != nil {
 		log.Fatalf("cannot add scheme: %v", err)
 	}
 

--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller_test.go
@@ -62,7 +62,7 @@ type expectedReconcile struct {
 
 func init() {
 	// Add types to scheme
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
+	if err := machinev1.Install(scheme.Scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/controller/machineset/controller_test.go
+++ b/pkg/controller/machineset/controller_test.go
@@ -131,10 +131,6 @@ func TestMachineSetToMachines(t *testing.T) {
 		},
 	}
 
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("cannot add scheme: %v", err)
-	}
-
 	r := &ReconcileMachineSet{
 		Client: fake.NewClientBuilder().WithRuntimeObjects(&m, &m2, &m3, machineSetList).WithStatusSubresource(&machinev1.MachineSet{}).Build(),
 		scheme: scheme.Scheme,
@@ -252,10 +248,6 @@ func TestAdoptOrphan(t *testing.T) {
 		},
 	}
 
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("cannot add scheme: %v", err)
-	}
-
 	for _, tc := range testCases {
 		r := &ReconcileMachineSet{
 			Client: fake.NewClientBuilder().WithRuntimeObjects(&tc.machineSet, &tc.machine).Build(),
@@ -280,7 +272,6 @@ var _ = Describe("MachineSet Reconcile", func() {
 	var rec *record.FakeRecorder
 
 	BeforeEach(func() {
-		Expect(machinev1.AddToScheme(scheme.Scheme)).To(Succeed())
 		rec = record.NewFakeRecorder(32)
 
 		r = &ReconcileMachineSet{

--- a/pkg/controller/machineset/machineset_controller_suite_test.go
+++ b/pkg/controller/machineset/machineset_controller_suite_test.go
@@ -39,7 +39,7 @@ func init() {
 	logf.SetLogger(klogr.New())
 
 	// Register required object kinds with global scheme.
-	_ = machinev1.AddToScheme(scheme.Scheme)
+	_ = machinev1.Install(scheme.Scheme)
 }
 
 const (

--- a/pkg/controller/nodelink/nodelink_controller_test.go
+++ b/pkg/controller/nodelink/nodelink_controller_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func init() {
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
+	if err := machinev1.Install(scheme.Scheme); err != nil {
 		klog.Fatal(err)
 	}
 }

--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -24,11 +24,11 @@ import (
 
 func init() {
 	// Add types to scheme
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
+	if err := machinev1.Install(scheme.Scheme); err != nil {
 		panic(err)
 	}
 
-	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
+	if err := configv1.Install(scheme.Scheme); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/controller/vsphere/machineset/controller_suite_test.go
+++ b/pkg/controller/vsphere/machineset/controller_suite_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -52,8 +53,8 @@ var _ = BeforeSuite(func() {
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "install")},
 	}
-	Expect(machinev1.AddToScheme(scheme.Scheme)).ToNot(HaveOccurred())
-
+	Expect(machinev1.Install(scheme.Scheme)).ToNot(HaveOccurred())
+	Expect(configv1.Install(scheme.Scheme)).ToNot(HaveOccurred())
 	var err error
 	cfg, err = testEnv.Start()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1700,10 +1700,6 @@ func TestDelete(t *testing.T) {
 		},
 	}
 
-	if err := machinev1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("cannot add scheme: %v", err)
-	}
-
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
 			vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -57,7 +57,7 @@ const (
 
 func init() {
 	// Add types to scheme
-	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
+	if err := configv1.Install(scheme.Scheme); err != nil {
 		panic(fmt.Sprintf("cannot add scheme: %v", err))
 	}
 }

--- a/pkg/controller/vsphere/util_test.go
+++ b/pkg/controller/vsphere/util_test.go
@@ -50,9 +50,6 @@ func TestGetVSphereConfig(t *testing.T) {
 		},
 	}
 
-	if err := configv1.AddToScheme(scheme.Scheme); err != nil {
-		t.Fatalf("cannot add scheme: %v", err)
-	}
 	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(infra, configMap).Build()
 
 	vSphereConfig, err := getVSphereConfig(client)

--- a/pkg/webhooks/v1beta1_suite_test.go
+++ b/pkg/webhooks/v1beta1_suite_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	err = osconfigv1.AddToScheme(scheme.Scheme)
+	err = osconfigv1.Install(scheme.Scheme)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
__**tentative**\__

This PR proposes (1) a fix for the MachineSet unit tests suite, affected by data races due to several concurrent executions of the AddToScheme method, (2) the removal of other non-needed executions of the AddToScheme method across other code of the test suite, and (3) the replacement for both the unit tests code and the other code of AddToScheme (deprecated) with Install