### PR TITLE
OCPBUGS-17872: Azure MAO CredentialsRequest contains unnecessary network write permissions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -96,11 +96,8 @@ spec:
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Compute/virtualMachines/write
     - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
-    - Microsoft.Network/applicationSecurityGroups/delete
     - Microsoft.Network/applicationSecurityGroups/read
-    - Microsoft.Network/applicationSecurityGroups/write
     - Microsoft.Network/loadBalancers/backendAddressPools/join/action
-    - Microsoft.Network/loadBalancers/delete
     - Microsoft.Network/loadBalancers/read
     - Microsoft.Network/loadBalancers/write
     - Microsoft.Network/networkInterfaces/delete
@@ -108,26 +105,18 @@ spec:
     - Microsoft.Network/networkInterfaces/loadBalancers/read
     - Microsoft.Network/networkInterfaces/read
     - Microsoft.Network/networkInterfaces/write
-    - Microsoft.Network/networkSecurityGroups/delete
     - Microsoft.Network/networkSecurityGroups/read
     - Microsoft.Network/networkSecurityGroups/write
     - Microsoft.Network/publicIPAddresses/delete
     - Microsoft.Network/publicIPAddresses/join/action
     - Microsoft.Network/publicIPAddresses/read
     - Microsoft.Network/publicIPAddresses/write
-    - Microsoft.Network/routeTables/delete
     - Microsoft.Network/routeTables/read
-    - Microsoft.Network/routeTables/write
     - Microsoft.Network/virtualNetworks/delete
     - Microsoft.Network/virtualNetworks/read
-    - Microsoft.Network/virtualNetworks/subnets/delete
     - Microsoft.Network/virtualNetworks/subnets/join/action
     - Microsoft.Network/virtualNetworks/subnets/read
-    - Microsoft.Network/virtualNetworks/subnets/write
-    - Microsoft.Network/virtualNetworks/write
-    - Microsoft.Resources/subscriptions/resourceGroups/delete
     - Microsoft.Resources/subscriptions/resourceGroups/read
-    - Microsoft.Resources/subscriptions/resourceGroups/write
 ---
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest


### PR DESCRIPTION
ARO suspects these permissions may only be utilized by the installer and are not needed by MAO. Testing removing the permission with e2e.

EDIT: e2e tests were successful with the permissions removed. Created OCPBUGS-17872 to track.