### PR TITLE
OCPBUGS-17919: [Azure] MAO Missing DiskEncryptionSet read permissions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -86,6 +86,7 @@ spec:
     - Microsoft.Compute/availabilitySets/delete
     - Microsoft.Compute/availabilitySets/read
     - Microsoft.Compute/availabilitySets/write
+    - Microsoft.Compute/diskEncryptionSets/read
     - Microsoft.Compute/disks/delete
     - Microsoft.Compute/galleries/images/versions/read
     - Microsoft.Compute/skus/read


### PR DESCRIPTION
Missing permission in credentialsrequest for Azure workload identity needed by MAO.  

OCPBUGS-17919