### PR TITLE
OCPBUGS-18338: Fix CI by running tests natively by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
 .PHONY: all
 all: check build test
 
-NO_DOCKER ?= 0
+NO_DOCKER ?= 1
 
 ifeq ($(shell command -v podman > /dev/null 2>&1 ; echo $$? ), 0)
 	ENGINE=podman
@@ -38,7 +38,7 @@ endif
 
 USE_DOCKER ?= 0
 ifeq ($(USE_DOCKER), 1)
-	ENGINE=docker	
+	ENGINE=docker
 endif
 
 ifeq ($(NO_DOCKER), 1)
@@ -47,7 +47,6 @@ ifeq ($(NO_DOCKER), 1)
 else
   DOCKER_CMD := $(ENGINE) run --env GO111MODULE=$(GO111MODULE) --env GOFLAGS=$(GOFLAGS) --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-operator:Z  -w /go/src/github.com/openshift/machine-api-operator $(BUILD_IMAGE)
   # The command below is for building/testing with the actual image that Openshift uses. Uncomment/comment out to use instead of above command. CI registry pull secret is required to use this image.
-  # DOCKER_CMD := $(ENGINE) run --env GO111MODULE=$(GO111MODULE) --env GOFLAGS=$(GOFLAGS) --rm -v "$(PWD)":/go/src/github.com/openshift/machine-api-operator:Z -w /go/src/github.com/openshift/machine-api-operator registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.19-openshift-4.11
   IMAGE_BUILD_CMD = $(ENGINE) build
 endif
 


### PR DESCRIPTION
Tests like lint and vet used to be ran within a container engine by
default if an engine was detected, both locally and in CI.

Up until now no container engine was detected in CI, so tests would run natively there.

Now that the base image we use in CI has now started
shipping `podman`, a container engine is detected by default and tests
are run within podman by default. But creating nested containers doesn't
work in CI at the moment and thus results in a test failure.

As such we are switching the default behaviour for tests (both locally
and in CI), where now by
default no container engine is used to run tests, even if one is
detected, but instead tests are run natively unless otherwise specifi
