### PR TITLE
MGMT-13425: Don't fail when workers not needed

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -368,10 +368,11 @@ func (optr *Operator) checkDaemonSetRolloutStatus(resource *appsv1.DaemonSet) (r
 	return reconcile.Result{}, nil
 }
 
-// checkMinimumWorkerMachines looks at the worker Machines in the cluster and checks if they are running.
-// If fewer than 2 worker Machines are Running, it will return an error.
-// This is used during initialization of the cluster to prevent the operator from being Available
-// until the minimum required number of worker Machines have started working correctly.
+// checkMinimumWorkerMachines looks at the worker Machines in the cluster and checks if they are
+// running. If fewer than 2 worker Machines are Running and the expected number is higher than 1, it
+// will return an error. This is used during initialization of the cluster to prevent the operator
+// from being Available until the minimum required number of worker Machines have started working
+// correctly.
 func (optr *Operator) checkMinimumWorkerMachines() error {
 	machineSets, err := optr.machineClient.MachineV1beta1().MachineSets(optr.namespace).List(context.Background(), metav1.ListOptions{})
 	if err != nil {
@@ -391,8 +392,12 @@ func (optr *Operator) checkMinimumWorkerMachines() error {
 
 	// If any MachineSet doesn't have the correct number of replicas, we error before this point.
 	// So the running replicas should be (total replicas) - (non-running replicas).
+	// Only error if the number of expected replicas is higher than 1. This is because masters are
+	// epxected to be schedulable when there are fewer than 2 workers expected. A better test would
+	// be to check if masters are schedulable but this favors the worker count over querying the API
+	// Kubernetes API again.
 	runningReplicas := expectedReplicas - int32(len(nonRunningMachines))
-	if runningReplicas < expectedReplicas && runningReplicas < minimumWorkerReplicas {
+	if expectedReplicas > 1 && runningReplicas < minimumWorkerReplicas {
 		return fmt.Errorf("minimum worker replica count (%d) not yet met: current running replicas %d, waiting for %v", minimumWorkerReplicas, runningReplicas, nonRunningMachines)
 	}
 

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -370,6 +370,16 @@ func TestCheckMinimumWorkerMachines(t *testing.T) {
 			expectedError: errors.New("minimum worker replica count (2) not yet met: current running replicas 1, waiting for [provisioned-0 provisioned-1]"),
 		},
 		{
+			name: "with a MachineSet with 1 Machine Provisioned",
+			machineSets: []runtime.Object{
+				newMachineSet("1-provisioned-machine", 1, workerSelector),
+			},
+			machines: []runtime.Object{
+				newMachine("provisioned-0", workerLabels, "Provisioned"),
+			},
+			expectedError: nil,
+		},
+		{
 			name: "with a MachineSet with 2 Machines Running, 1 Machine Provisioned",
 			machineSets: []runtime.Object{
 				newMachineSet("1-running-machine", 3, workerSelector),


### PR DESCRIPTION
Don't fail if expected workers is less than 2 since masters are expected to be schedulable in this architecture, which means there will be enough replicas of the operator scheduled.