### PR TITLE
OCPBUGS-18339: Update reference URL

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -835,7 +835,7 @@ func clone(s *machineScope) (string, error) {
 			fmt.Sprintf(
 				"Hardware lower than %d is not supported, clone stopped. "+
 					"Detected machine template version is %d. "+
-					"Please update machine template: https://docs.openshift.com/container-platform/latest/updating/updating-hardware-on-nodes-running-on-vsphere.html",
+					"Please update machine template: https://docs.openshift.com/container-platform/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html",
 				minimumHWVersion, hwVersion,
 			),
 		)


### PR DESCRIPTION
The [original PR](https://github.com/openshift/machine-api-operator/pull/1172) uses a docs URL instead of a KCS one. However, https://github.com/openshift/openshift-docs/pull/63315 changed the location of the documentation.