### PR TITLE
OCPBUGS-25304: Update Reference URL

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -678,7 +678,7 @@ func clone(s *machineScope) (string, error) {
 			fmt.Sprintf(
 				"Hardware lower than %d is not supported, clone stopped. "+
 					"Detected machine template version is %d. "+
-					"Please update machine template: https://access.redhat.com/articles/6090681",
+					"Please update machine template: https://docs.openshift.com/container-platform/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.html",
 				minimumHWVersion, hwVersion,
 			),
 		)


### PR DESCRIPTION
Manual back port since the docs URL changed in the process of backporting originally.