### PR TITLE
OCPBUGS-26119: Fix formatting in snyk vendor exclusions

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -3,5 +3,5 @@
 # https://docs.snyk.io/snyk-cli/commands/ignore
 exclude:
   global:
-    - vendor/**
-    - **/vendor/**
+    - "vendor/**"
+    - "**/vendor/**"


### PR DESCRIPTION
Hello! Quick PR to update the formatting in the exclusion of the vendor files in Snyk, as the scans weren't understanding the double *'s without quotation marks. Thanks!