### PR TITLE
OCPBUGS-23544: Add AddWithActuatorOpts to allow overriding Machine controller options

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -76,9 +76,17 @@ const (
 var DefaultActuator Actuator
 
 func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
-	if err := add(mgr, newReconciler(mgr, actuator), "machine-controller"); err != nil {
+	return AddWithActuatorOpts(mgr, actuator, controller.Options{})
+}
+
+func AddWithActuatorOpts(mgr manager.Manager, actuator Actuator, opts controller.Options) error {
+	machineControllerOpts := opts
+	machineControllerOpts.Reconciler = newReconciler(mgr, actuator)
+
+	if err := addWithOpts(mgr, machineControllerOpts, "machine-controller"); err != nil {
 		return err
 	}
+
 	if err := addWithOpts(mgr, controller.Options{
 		Reconciler:  newDrainController(mgr),
 		RateLimiter: newDrainRateLimiter(),


### PR DESCRIPTION
Adding, in a backwards compatible way, a way for the different actuators to influence the options for the machine controller. Primarily so that we can influence the max concurrent reconciles of the machine controller to handle large scaling events.