### PR TITLE
SPLAT-1386: reconcile additional tags assigned to machine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 AS builder
 WORKDIR /go/src/github.com/openshift/machine-api-operator
 COPY . .
 RUN NO_DOCKER=1 make build

--- a/docs/user/vsphere/tags.md
+++ b/docs/user/vsphere/tags.md
@@ -1,0 +1,54 @@
+Administrators may wish to attach additional tags to newly provisioned VMs. The cluster API provider for vSphere
+allows for this in the [`VirtualMachineCloneSpec`](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/b9b2c22ea68c13cbf706f2116ced804b5afb124e/apis/v1beta1/types.go#L189-L193).
+A similar provision has been made in the [`VSphereMachineProviderSpec`](https://github.com/openshift/api/blob/6d48d55c0598ec78adacdd847dcf934035ec2e1b/machine/v1beta1/types_vsphereprovider.go#L54-L59).
+
+Up to 10 tags are attachable by their tag URN(for example: `urn:vmomi:InventoryServiceTag:f6dfddfd-b28a-44da-9503-635d3fc245ac:GLOBAL`), not by the name of the tag and tag category. As a result, a given tag must exist before the 
+machine controller will attempt to associate the tag.  The URN can be retrieved from the vCenter UI by accessing the `Tag & Custom Attributes` screen and selecting the desired tag.  The tag URN will be in the URL: 
+```
+https://v8c-2-vcenter.ocp2.dev.cluster.com/ui/app/tags/tag/urn:vmomi:InventoryServiceTag:f6dfddfd-b28a-44da-9503-635d3fc245ac:GLOBAL/permissions
+```
+
+The below example demonstrates a machine spec which defines `tagIDs`:
+
+```yaml
+apiVersion: machine.openshift.io/v1beta1
+kind: Machine
+metadata:
+  generateName: ci-ln-ll0lbgk-c1627-gslcw-worker-0-
+  name: ci-ln-ll0lbgk-c1627-gslcw-worker-0-6nppd
+spec:
+  lifecycleHooks: {}
+  metadata: {}
+  providerID: 'vsphere://421bb8b8-e7da-6bfa-3e1b-cc6ef9945343'
+  providerSpec:
+    value:
+      numCoresPerSocket: 4
+      diskGiB: 120
+      snapshot: ''
+      userDataSecret:
+        name: worker-user-data
+      memoryMiB: 16384
+      credentialsSecret:
+        name: vsphere-cloud-credentials
+      network:
+        devices:
+          - networkName: ci-vlan-1207
+      metadata:
+        creationTimestamp: null
+      numCPUs: 4
+      kind: VSphereMachineProviderSpec
+      workspace:
+        datacenter: IBMCloud
+        datastore: /IBMCloud/datastore/vsanDatastore
+        folder: /IBMCloud/vm/ci-ln-ll0lbgk-c1627-gslcw
+        resourcePool: /IBMCloud/host/vcs-ci-workload/Resources/ipi-ci-clusters
+        server: v8c-2-vcenter.ocp2.dev.cluster.com
+      template: ci-ln-ll0lbgk-c1627-gslcw-rhcos-generated-region-generated-zone
+      tagIDs:
+        - 'urn:vmomi:InventoryServiceTag:8d893b87-28de-4ef0-90d2-af24f21b0f26:GLOBAL'
+      apiVersion: machine.openshift.io/v1beta1
+status: {}
+```
+
+
+`machinesets` may also be defined to attach tags to `machines` created by the `machineset`.

--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -180,7 +180,8 @@ func TestMachineEvents(t *testing.T) {
 		g.Expect(k8sClient.Delete(context.Background(), userDataSecret)).To(Succeed())
 	}()
 
-	g.Expect(createTagAndCategory(session, tagToCategoryName("CLUSTERID"), "CLUSTERID")).To(Succeed())
+	_, err = createTagAndCategory(session, tagToCategoryName("CLUSTERID"), "CLUSTERID")
+	g.Expect(err).ToNot(HaveOccurred())
 
 	ctx := context.Background()
 

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -250,7 +250,7 @@ func (r *Reconciler) update() error {
 		Ref:     vmRef,
 	}
 
-	if err := vm.reconcileTags(r.Context, r.session, r.machine); err != nil {
+	if err := vm.reconcileTags(r.Context, r.session, r.machine, r.providerSpec); err != nil {
 		metrics.RegisterFailedInstanceUpdate(&metrics.MachineLabels{
 			Name:      r.machine.Name,
 			Namespace: r.machine.Namespace,
@@ -1314,25 +1314,28 @@ func (vm *virtualMachine) getPowerState() (types.VirtualMachinePowerState, error
 
 // reconcileTags ensures that the required tags are present on the virtual machine, eg the Cluster ID
 // that is used by the installer on cluster deletion to ensure ther are no leaked resources.
-func (vm *virtualMachine) reconcileTags(ctx context.Context, sessionInstance *session.Session, machine *machinev1.Machine) error {
+func (vm *virtualMachine) reconcileTags(ctx context.Context, sessionInstance *session.Session, machine *machinev1.Machine, providerSpec *machinev1.VSphereMachineProviderSpec) error {
 	if err := sessionInstance.WithCachingTagsManager(vm.Context, func(c *session.CachingTagsManager) error {
 		klog.Infof("%v: Reconciling attached tags", machine.GetName())
 
 		clusterID := machine.Labels[machinev1.MachineClusterIDLabel]
-
-		attached, err := vm.checkAttachedTag(ctx, clusterID, c)
-		if err != nil {
-			return err
-		}
-
-		if !attached {
-			klog.Infof("%v: Attaching %s tag to vm", machine.GetName(), clusterID)
-			// the tag should already be created by installer
-			if err := c.AttachTag(ctx, clusterID, vm.Ref); err != nil {
+		tagIDs := []string{clusterID}
+		tagIDs = append(tagIDs, providerSpec.TagIDs...)
+		klog.Infof("%v: Reconciling %s tags to vm", machine.GetName(), tagIDs)
+		for _, tagID := range tagIDs {
+			attached, err := vm.checkAttachedTag(ctx, tagID, c)
+			if err != nil {
 				return err
 			}
-		}
 
+			if !attached {
+				klog.Infof("%v: Attaching %s tag to vm", machine.GetName(), tagID)
+				// the tag should already be created by installer or the administrator
+				if err := c.AttachTag(ctx, tagID, vm.Ref); err != nil {
+					return err
+				}
+			}
+		}
 		return nil
 	}); err != nil {
 		return err
@@ -1359,9 +1362,16 @@ func (vm *virtualMachine) checkAttachedTag(ctx context.Context, tagName string, 
 	}
 
 	for _, tag := range tags {
-		if tag.Name == tagName {
-			return true, nil
+		if session.IsName(tagName) {
+			if tag.Name == tagName {
+				return true, nil
+			}
+		} else {
+			if tag.ID == tagName {
+				return true, nil
+			}
 		}
+
 	}
 
 	return false, nil
@@ -1377,22 +1387,34 @@ func tagToCategoryName(tagName string) string {
 }
 
 func (vm *virtualMachine) foundTag(ctx context.Context, tagName string, m *session.CachingTagsManager) (bool, error) {
-	tags, err := m.ListTagsForCategory(ctx, tagToCategoryName(tagName))
-	if err != nil {
-		if isNotFoundErr(err) {
-			return false, nil
-		}
-		return false, err
-	}
+	var tags []string
+	var err error
 
+	if session.IsName(tagName) {
+		tags, err = m.ListTagsForCategory(ctx, tagToCategoryName(tagName))
+		if err != nil {
+			if isNotFoundErr(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	} else {
+		tags = []string{tagName}
+	}
+	klog.V(4).Infof("validating the presence of tags: %+v", tags)
 	for _, id := range tags {
 		tag, err := m.GetTag(ctx, id)
 		if err != nil {
 			return false, err
 		}
-
-		if tag.Name == tagName {
-			return true, nil
+		if session.IsName(tagName) {
+			if tag.Name == tagName {
+				return true, nil
+			}
+		} else {
+			if tag.ID == tagName {
+				return true, nil
+			}
 		}
 	}
 

--- a/pkg/controller/vsphere/session/tag_ids_caching_client.go
+++ b/pkg/controller/vsphere/session/tag_ids_caching_client.go
@@ -107,11 +107,11 @@ func newTagsCachingClient(tagsManager *tags.Manager, sessionKey string) *Caching
 	}
 }
 
-// isName returns true if the id is not an urn.
+// IsName returns true if the id is not an urn.
 // this method came from vSphere sdk,
 // see https://github.com/vmware/govmomi/blob/a2fb82dc55a8eb00932233aa8028ce97140df784/vapi/tags/tags.go#L121 for
 // more context.
-func isName(id string) bool {
+func IsName(id string) bool {
 	return !strings.HasPrefix(id, "urn:")
 }
 
@@ -128,7 +128,7 @@ func isObjectNotFoundErr(err error) bool {
 //
 // In case if a tag was not found in vCenter, this would be cached for 12 hours and lookup won't happen till cache expiration.
 func (t *CachingTagsManager) GetTag(ctx context.Context, id string) (*tags.Tag, error) {
-	if !isName(id) { // if id is passed no cache check needed, use original GetTag method instantly
+	if !IsName(id) { // if id is passed no cache check needed, use original GetTag method instantly
 		return t.Manager.GetTag(ctx, id)
 	}
 
@@ -181,7 +181,7 @@ func (t *CachingTagsManager) GetTag(ctx context.Context, id string) (*tags.Tag, 
 //
 // In case if a tag was not found in vCenter, this would be cached for 12 hours and lookup won't happen till cache expiration.
 func (t *CachingTagsManager) GetCategory(ctx context.Context, id string) (*tags.Category, error) {
-	if !isName(id) { // if id is passed no cache check needed, use original GetTag method instantly
+	if !IsName(id) { // if id is passed no cache check needed, use original GetTag method instantly
 		return t.Manager.GetCategory(ctx, id)
 	}
 
@@ -230,7 +230,7 @@ func (t *CachingTagsManager) GetCategory(ctx context.Context, id string) (*tags.
 // The id parameter can be a Category ID or Category Name.
 // Uses caching GetCategory method.
 func (t *CachingTagsManager) ListTagsForCategory(ctx context.Context, id string) ([]string, error) {
-	if isName(id) {
+	if IsName(id) {
 		category, err := t.GetCategory(ctx, id)
 		if err != nil {
 			return nil, err

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -118,6 +118,11 @@ var (
 			maxProcessor:             143,
 		},
 	}
+
+	// VSphere variables
+
+	// tagUrnPattern is helps validate the format of a given tag URN
+	tagUrnPattern = regexp.MustCompile(`^(urn):(vmomi):(InventoryServiceTag):([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}):([^:]+)$`)
 )
 
 const (
@@ -1415,6 +1420,16 @@ func validateVSphere(m *machinev1beta1.Machine, config *admissionConfig) (bool, 
 	} else {
 		if providerSpec.UserDataSecret.Name == "" {
 			errs = append(errs, field.Required(field.NewPath("providerSpec", "userDataSecret", "name"), "name must be provided"))
+		}
+	}
+
+	if len(providerSpec.TagIDs) > 10 {
+		errs = append(errs, field.Invalid(field.NewPath("providerSpec", "tagIDs"), providerSpec.TagIDs, "a maximum of 10 tags are allowed"))
+	}
+
+	for _, tagID := range providerSpec.TagIDs {
+		if tagUrnPattern.FindStringSubmatch(tagID) == nil {
+			errs = append(errs, field.Required(field.NewPath("providerSpec", "tagIDs"), "tag ID must be in the format of urn:vmomi:InventoryServiceTag:<UUID>:GLOBAL"))
 		}
 	}
 

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -1623,6 +1623,59 @@ func TestMachineUpdate(t *testing.T) {
 			expectedError: "",
 		},
 		{
+			name:         "with a valid VSphere ProviderSpec with a tag ID",
+			platformType: osconfigv1.VSpherePlatformType,
+			clusterID:    vsphereClusterID,
+			baseProviderSpecValue: &kruntime.RawExtension{
+				Object: defaultVSphereProviderSpec.DeepCopy(),
+			},
+			updatedProviderSpecValue: func() *kruntime.RawExtension {
+				object := defaultVSphereProviderSpec.DeepCopy()
+				object.TagIDs = []string{"urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9578:GLOBAL"}
+
+				return &kruntime.RawExtension{
+					Object: object,
+				}
+			},
+			expectedError: "",
+		},
+		{
+			name:         "with a valid VSphere ProviderSpec with an invalid tag ID",
+			platformType: osconfigv1.VSpherePlatformType,
+			clusterID:    vsphereClusterID,
+			baseProviderSpecValue: &kruntime.RawExtension{
+				Object: defaultVSphereProviderSpec.DeepCopy(),
+			},
+			updatedProviderSpecValue: func() *kruntime.RawExtension {
+				object := defaultVSphereProviderSpec.DeepCopy()
+				object.TagIDs = []string{"bad:tag:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9578:GLOBAL"}
+
+				return &kruntime.RawExtension{
+					Object: object,
+				}
+			},
+			expectedError: "providerSpec.tagIDs: Required value: tag ID must be in the format of urn:vmomi:InventoryServiceTag:<UUID>:GLOBAL",
+		},
+		{
+			name:         "with a valid VSphere ProviderSpec with too many tag IDs",
+			platformType: osconfigv1.VSpherePlatformType,
+			clusterID:    vsphereClusterID,
+			baseProviderSpecValue: &kruntime.RawExtension{
+				Object: defaultVSphereProviderSpec.DeepCopy(),
+			},
+			updatedProviderSpecValue: func() *kruntime.RawExtension {
+				object := defaultVSphereProviderSpec.DeepCopy()
+
+				for i := 0; i != 12; i++ {
+					object.TagIDs = append(object.TagIDs, fmt.Sprintf("urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc95%02d:GLOBAL", i))
+				}
+				return &kruntime.RawExtension{
+					Object: object,
+				}
+			},
+			expectedError: `providerSpec.tagIDs: Invalid value: []string{"urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9500:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9501:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9502:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9503:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9504:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9505:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9506:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9507:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9508:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9509:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9510:GLOBAL", "urn:vmomi:InventoryServiceTag:5736bf56-49f5-4667-b38c-b97e09dc9511:GLOBAL"}: a maximum of 10 tags are allowed`,
+		},
+		{
 			name:         "with an VSphere ProviderSpec, removing the template",
 			platformType: osconfigv1.VSpherePlatformType,
 			clusterID:    vsphereClusterID,


### PR DESCRIPTION
This PR intends to address RFE https://issues.redhat.com/browse/RFE-1799. Additional tags are provided by the declaring a slice of tags referenced by their URN ID. This is consistent with how [CAPV ingests additional tags](https://github.com/openshift/cluster-api-provider-vsphere/blob/b21c0ba942580e08352ad6b3170ee17a010a2a00/apis/v1beta1/types.go#L190-L193) for a VM.