### PR TITLE
OCPBUGS-27385: Add useExternalIp gcp permission

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -193,6 +193,7 @@ spec:
     - "compute.regions.get"
     - "compute.regions.list"
     - "compute.subnetworks.use"
+    - "compute.subnetworks.useExternalIp"
     - "compute.targetPools.addInstance"
     - "compute.targetPools.delete"
     - "compute.targetPools.get"


### PR DESCRIPTION
This required permission was missed when migrating from roles.