### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/install/0000_30_machine-api-operator_11_deployment.yaml
+++ b/install/0000_30_machine-api-operator_11_deployment.yaml
@@ -46,6 +46,7 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: config
           mountPath: /etc/kube-rbac-proxy
@@ -78,6 +79,7 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: images
           mountPath: /etc/machine-api-operator-config/images

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -692,6 +692,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 					},
 				},
 			},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/etc/machine-api-operator/tls",
@@ -743,6 +744,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 					},
 				},
 			},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					MountPath: "/etc/pki/ca-trust/extracted/pem",
@@ -762,12 +764,13 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 			},
 		},
 		{
-			Name:      "nodelink-controller",
-			Image:     config.Controllers.NodeLink,
-			Command:   []string{"/nodelink-controller"},
-			Args:      args,
-			Env:       proxyEnvArgs,
-			Resources: resources,
+			Name:                     "nodelink-controller",
+			Image:                    config.Controllers.NodeLink,
+			Command:                  []string{"/nodelink-controller"},
+			Args:                     args,
+			Env:                      proxyEnvArgs,
+			Resources:                resources,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		},
 	}
 	if config.Controllers.MachineHealthCheck != "" {
@@ -800,6 +803,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 					},
 				},
 			},
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		})
 	}
 	return containers
@@ -843,11 +847,12 @@ func newKubeProxyContainer(image, portName, upstreamPort string, exposePort int3
 	}}
 
 	return corev1.Container{
-		Name:      fmt.Sprintf("kube-rbac-proxy-%s", portName),
-		Image:     image,
-		Args:      args,
-		Resources: resources,
-		Ports:     ports,
+		Name:                     fmt.Sprintf("kube-rbac-proxy-%s", portName),
+		Image:                    image,
+		Args:                     args,
+		Resources:                resources,
+		Ports:                    ports,
+		TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      kubeRBACConfigName,


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.