### PR TITLE
OCPBUGS-26119: add tools.go to snyk configuration file excludes

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,3 +5,4 @@ exclude:
   global:
     - "vendor/**"
     - "**/vendor/**"
+    - tools.go


### PR DESCRIPTION
This file is only used for bringing in test dependencies it is not used in the final build release artifacts.