### PR TITLE
OCPBUGS-26119:  Add build tags to tools.go file to solve linting issues when running Snyk scans

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -1,3 +1,6 @@
+//go:build tools
+// +build tools
+
 package tools
 
 import (


### PR DESCRIPTION
Hello! Running Snyk scans manually in this repo was causing some linting errors due to the tools.go file in the top level of the repo not having build tags. Making this change fixes this and allows scans to be done manually in this repo now. Thanks!