### PR TITLE
OCPBUGS-29956: Azure MAO CredentialsRequest Contains Unnecessary virtualMachines/extensions Permissions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -91,9 +91,6 @@ spec:
     - Microsoft.Compute/galleries/images/versions/read
     - Microsoft.Compute/skus/read
     - Microsoft.Compute/virtualMachines/delete
-    - Microsoft.Compute/virtualMachines/extensions/delete
-    - Microsoft.Compute/virtualMachines/extensions/read
-    - Microsoft.Compute/virtualMachines/extensions/write
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Compute/virtualMachines/write
     - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action


### PR DESCRIPTION
ARO team believes these permissions are unnecessary for MAO.  Testing permission removal with e2e.  

[OCPBUGS-29956](https://issues.redhat.com/browse/OCPBUGS-29956) is tracking this.  