### PR TITLE
OCPCLOUD-2501: Update to set GpuType annotation to remove hardcoded value

### DIFF
--- a/pkg/util/machineset/util.go
+++ b/pkg/util/machineset/util.go
@@ -77,9 +77,8 @@ func SetGpuCountAnnotation(annotations map[string]string, value string) map[stri
 
 // SetGpuTypeAnnotation sets a value for gpu type in the annotations of a MachineSet.
 // Currently, we only support nvidia as a gpu type.
-func SetGpuTypeAnnotation(annotations map[string]string, _ string) map[string]string {
-	// TODO: Once we introduce proper gpu types, this needs to be changed.
-	annotations[GpuTypeKey] = GpuNvidiaType
+func SetGpuTypeAnnotation(annotations map[string]string, value string) map[string]string {
+	annotations[GpuTypeKey] = value
 
 	return annotations
 }


### PR DESCRIPTION
Hello! This is a PR to remove the hardcoded value for the GpuType annotation, so that we can use the one passed in from the CAO instead. Thanks!