### PR TITLE
OCPCLOUD-2493: Bug fix in unit test

### DIFF
--- a/pkg/util/machineset/util_test.go
+++ b/pkg/util/machineset/util_test.go
@@ -88,7 +88,7 @@ func TestSettingAnnotations(t *testing.T) {
 		},
 		{
 			name:  "replaces GpuType annotation",
-			value: "1",
+			value: "nvidia.com/gpu",
 			fn:    SetGpuTypeAnnotation,
 			suppliedAnnotations: map[string]string{
 				GpuTypeKey: "",
@@ -99,7 +99,7 @@ func TestSettingAnnotations(t *testing.T) {
 		},
 		{
 			name:                "adds GpuType annotation",
-			value:               "1",
+			value:               "nvidia.com/gpu",
 			fn:                  SetGpuTypeAnnotation,
 			suppliedAnnotations: map[string]string{},
 			expectedAnnotations: map[string]string{


### PR DESCRIPTION
Hello, this is a bug fix to update an incorrect passed value for a unit test added i[n a previous PR.](https://github.com/openshift/machine-api-operator/pull/1227) Thanks!