### PR TITLE
OCPCLOUD-2493: Add case in unit test to check for empty GpuType Value if GpuCount is 0

### DIFF
--- a/pkg/util/machineset/util_test.go
+++ b/pkg/util/machineset/util_test.go
@@ -106,6 +106,18 @@ func TestSettingAnnotations(t *testing.T) {
 				GpuTypeKey: "nvidia.com/gpu",
 			},
 		},
+		{
+			name:  "adds empty GpuType annotation value if GpuCount is empty",
+			value: "",
+			fn:    SetGpuTypeAnnotation,
+			suppliedAnnotations: map[string]string{
+				GpuCountKey: "0",
+			},
+			expectedAnnotations: map[string]string{
+				GpuCountKey: "0",
+				GpuTypeKey:  "",
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Hello! This is a PR to add a case to the unit test to make sure that if the GpuCount annotation is set to 0, that the GpuType annotation should return an empty string. Thanks!