### PR TITLE
handle nodes without UID

### DIFF
--- a/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
+++ b/pkg/controller/machinehealthcheck/machinehealthcheck_controller.go
@@ -788,7 +788,8 @@ func (t *target) needsRemediation(timeoutForMachineToHaveNode time.Duration) (bo
 	}
 
 	// the node does not exist
-	if t.Node != nil && t.Node.UID == "" {
+	if t.Node != nil && t.Node.UID == "" && t.Node.Name == "" {
+		klog.V(3).Infof("%s: unhealthy: node does not exist", t.string())
 		return true, time.Duration(0), nil
 	}
 


### PR DESCRIPTION
On a large deployment on OpenStack, with high latency, we observe the mhc controller remediating nodes immediately after their creation.  The remediation happens without any log for its cause, and the only path in the code where that is the case is when the node.UID is empty.  We do see a node Name in the target string() that is logged, so we know that a node.Name is present at that time.

Change the code so that a node is considered to be existing when it has a name and no UID, even if the circumstances by which this happens are blurry.

Also add a log so that all code paths leading to remediation are clearly seen.