### PR TITLE
OCPBUGS-31777: Updates message verbs to use %q where appropriate

### DIFF
--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -161,7 +161,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 	// Implement controller logic here
 	machineName := m.GetName()
-	klog.Infof("%v: reconciling Machine", machineName)
+	klog.Infof("%q: reconciling Machine", machineName)
 
 	// Get the original state of conditions now so that they can be used to calculate the patch later.
 	// This must be a copy otherwise the referenced slice will be modified by later machine conditions changes.
@@ -229,14 +229,14 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 			// we can loose instances, e.g. right after request to create one
 			// was sent and before a list of node addresses was set.
 			if len(m.Status.Addresses) > 0 || !isInvalidMachineConfigurationError(err) {
-				klog.Errorf("%v: failed to delete machine: %v", machineName, err)
+				klog.Errorf("%q: failed to delete machine: %v", machineName, err)
 				return delayIfRequeueAfterError(err)
 			}
 		}
 
 		instanceExists, err := r.actuator.Exists(ctx, m)
 		if err != nil {
-			klog.Errorf("%v: failed to check if machine exists: %v", machineName, err)
+			klog.Errorf("%q: failed to check if machine exists: %v", machineName, err)
 			return reconcile.Result{}, err
 		}
 
@@ -271,7 +271,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 	instanceExists, err := r.actuator.Exists(ctx, m)
 	if err != nil {
-		klog.Errorf("%v: failed to check if machine exists: %v", machineName, err)
+		klog.Errorf("%q: failed to check if machine exists: %v", machineName, err)
 
 		conditions.Set(m, conditions.UnknownCondition(
 			machinev1.InstanceExistsCondition,
@@ -289,7 +289,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 	if instanceExists {
 		klog.Infof("%v: reconciling machine triggers idempotent update", machineName)
 		if err := r.actuator.Update(ctx, m); err != nil {
-			klog.Errorf("%v: error updating machine: %v, retrying in %v seconds", machineName, err, requeueAfter)
+			klog.Errorf("%q: error updating machine: %v, retrying in %s seconds", machineName, err, requeueAfter.String())
 
 			if patchErr := r.updateStatus(ctx, m, ptr.Deref(m.Status.Phase, ""), nil, originalConditions); patchErr != nil {
 				klog.Errorf("%v: error patching status: %v", machineName, patchErr)
@@ -356,7 +356,7 @@ func (r *ReconcileMachine) Reconcile(ctx context.Context, request reconcile.Requ
 
 	klog.Infof("%v: reconciling machine triggers idempotent create", machineName)
 	if err := r.actuator.Create(ctx, m); err != nil {
-		klog.Warningf("%v: failed to create machine: %v", machineName, err)
+		klog.Warningf("%q: failed to create machine: %v", machineName, err)
 		if isInvalidMachineConfigurationError(err) {
 			if err := r.updateStatus(ctx, m, machinev1.PhaseFailed, err, originalConditions); err != nil {
 				return reconcile.Result{}, err

--- a/pkg/controller/vsphere/actuator.go
+++ b/pkg/controller/vsphere/actuator.go
@@ -57,7 +57,7 @@ func NewActuator(params ActuatorParams) *Actuator {
 // Set corresponding event based on error. It also returns the original error
 // for convenience, so callers can do "return handleMachineError(...)".
 func (a *Actuator) handleMachineError(machine *machinev1.Machine, err error, eventAction string) error {
-	klog.Errorf("%v error: %v", machine.GetName(), err)
+	klog.Errorf("%q error: %v", machine.GetName(), err)
 	if eventAction != noEventAction {
 		a.eventRecorder.Eventf(machine, corev1.EventTypeWarning, "Failed"+eventAction, "%v", err)
 	}


### PR DESCRIPTION
This change updates the message verbs to use %q instead of %s, where appropriate, to properly escape output. This is to ensure potentially malicious input will be properly escaped.