### PR TITLE
[WIP] Added vsphere namespace fix

### DIFF
--- a/hack/ci-test.sh
+++ b/hack/ci-test.sh
@@ -29,6 +29,7 @@ GINKGO_EXTRA_ARGS=${GINKGO_EXTRA_ARGS:-""}
 # Ensure that some home var is set and that it's not the root.
 # This is required for the kubebuilder cache.
 export HOME=${HOME:=/tmp/kubebuilder-testing}
+export IS_TEST="true"
 if [ $HOME == "/" ]; then
   export HOME=/tmp/kubebuilder-testing
 fi
@@ -54,5 +55,6 @@ if [ -f "${ARTIFACT_DIR}/test-unit-coverage.out" ]; then
   echo
 fi
 
+unset IS_TEST
 # Ensure we exit based on the test result, coverage results are supplementary.
 exit ${TEST_RESULT}

--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -96,7 +96,7 @@ func TestMachineEvents(t *testing.T) {
 
 	configNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: openshiftConfigNamespace,
+			Name: getOpenshiftConfigNamespace(),
 		},
 	}
 	g.Expect(k8sClient.Create(context.Background(), configNamespace)).To(Succeed())
@@ -136,7 +136,7 @@ func TestMachineEvents(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testname",
-			Namespace: openshiftConfigNamespace,
+			Namespace: getOpenshiftConfigNamespace(),
 		},
 		Data: map[string]string{
 			"testkey": testConfig,

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -316,7 +316,7 @@ func TestPatchMachine(t *testing.T) {
 
 	configNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: openshiftConfigNamespace,
+			Name: getOpenshiftConfigNamespace(),
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, configNamespace)).To(Succeed())
@@ -356,7 +356,7 @@ func TestPatchMachine(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testname",
-			Namespace: openshiftConfigNamespace,
+			Namespace: getOpenshiftConfigNamespace(),
 		},
 		Data: map[string]string{
 			"testkey": testConfig,

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1778,7 +1778,7 @@ func TestDelete(t *testing.T) {
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "testName",
-				Namespace: openshiftConfigNamespace,
+				Namespace: getOpenshiftConfigNamespace(),
 			},
 			Data: map[string]string{
 				"testKey": testConfig,
@@ -2285,7 +2285,7 @@ func TestCreate(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testName",
-			Namespace: openshiftConfigNamespace,
+			Namespace: getOpenshiftConfigNamespace(),
 		},
 		Data: map[string]string{
 			"testKey": testConfig,
@@ -2699,7 +2699,7 @@ func TestUpdate(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testName",
-			Namespace: openshiftConfigNamespace,
+			Namespace: getOpenshiftConfigNamespace(),
 		},
 		Data: map[string]string{
 			"testKey": testConfig,

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"gopkg.in/gcfg.v1"
@@ -21,8 +22,9 @@ import (
 )
 
 const (
-	globalInfrastuctureName  = "cluster"
-	openshiftConfigNamespace = "openshift-config-1"
+	globalInfrastuctureName         = "cluster"
+	openshiftConfigNamespace        = "openshift-config"
+	openshiftConfigNamespaceForTest = "openshift-config-test"
 )
 
 // vSphereConfig is a copy of the Kubernetes vSphere cloud provider config type
@@ -90,7 +92,7 @@ func getVSphereConfig(c runtimeclient.Reader) (*vSphereConfig, error) {
 	cm := &corev1.ConfigMap{}
 	cmName := runtimeclient.ObjectKey{
 		Name:      infra.Spec.CloudConfig.Name,
-		Namespace: openshiftConfigNamespace,
+		Namespace: getOpenshiftConfigNamespace(),
 	}
 
 	if err := c.Get(context.Background(), cmName, cm); err != nil {
@@ -296,4 +298,11 @@ func getPodList(ctx context.Context, apiReader runtimeclient.Reader, n *corev1.N
 	}
 
 	return filterPods(allPods, filters...), nil
+}
+
+func getOpenshiftConfigNamespace() string {
+	if os.Getenv("IS_TEST") == "true" {
+		return openshiftConfigNamespaceForTest
+	}
+	return openshiftConfigNamespace
 }

--- a/pkg/controller/vsphere/util_test.go
+++ b/pkg/controller/vsphere/util_test.go
@@ -31,7 +31,7 @@ func TestGetVSphereConfig(t *testing.T) {
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testName",
-			Namespace: openshiftConfigNamespace,
+			Namespace: getOpenshiftConfigNamespace(),
 		},
 		Data: map[string]string{
 			"testKey": testConfig,


### PR DESCRIPTION
This is to fix the vsphere CI test failure due to openshift-config namespace is forbidden.