### PR TITLE
OCPBUGS-34148: manifests: gcp add compute.instanceGroups.use permission

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -173,6 +173,7 @@ spec:
     - "compute.instanceGroups.get"
     - "compute.instanceGroups.list"
     - "compute.instanceGroups.update"
+    - "compute.instanceGroups.use"
     - "compute.instances.create"
     - "compute.instances.createTagBinding"
     - "compute.instances.delete"


### PR DESCRIPTION
For gcp, add compute.instanceGroups.use permission as that is required in some QE environment.