### PR TITLE
OCPBUGS-1735: Vsphere: Handle cloned instance with lost taskID fix reproducing PR

### DIFF
--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -147,7 +147,7 @@ func (r *Reconciler) create() error {
 		}
 
 		klog.Infof("%v: cloning", r.machine.GetName())
-		task, err := clone(r.machineScope)
+		_, err := clone(r.machineScope)
 		if err != nil {
 			metrics.RegisterFailedInstanceCreate(&metrics.MachineLabels{
 				Name:      r.machine.Name,
@@ -156,13 +156,13 @@ func (r *Reconciler) create() error {
 			})
 			conditionFailed := conditionFailed()
 			conditionFailed.Message = err.Error()
-			statusError := setProviderStatus(task, conditionFailed, r.machineScope, nil)
+			statusError := setProviderStatus("", conditionFailed, r.machineScope, nil)
 			if statusError != nil {
 				return fmt.Errorf("failed to set provider status: %w", err)
 			}
 			return err
 		}
-		return setProviderStatus(task, conditionSuccess(), r.machineScope, nil)
+		return setProviderStatus("", conditionSuccess(), r.machineScope, nil)
 	}
 
 	moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -2843,7 +2843,14 @@ func TestUpdate(t *testing.T) {
 }
 
 func TestExists(t *testing.T) {
-	model, session, server := initSimulator(t)
+	withPoweredOffVMS := func() simulatorModelOption {
+		return func(m *simulator.Model) {
+			m.Autostart = false
+		}
+	}
+
+	model, server := initSimulatorCustom(t, withPoweredOffVMS())
+	session := getSimulatorSession(t, server)
 	defer model.Remove()
 	defer server.Close()
 	credentialsSecretUsername := fmt.Sprintf("%s.username", server.URL.Host)
@@ -2851,9 +2858,9 @@ func TestExists(t *testing.T) {
 
 	password, _ := server.URL.User.Password()
 	namespace := "test"
-	vm := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
-	instanceUUID := "a5764857-ae35-34dc-8f25-a9c9e73aa898"
-	vm.Config.InstanceUuid = instanceUUID
+	VMs := simulator.Map.All("VirtualMachine")
+	poweredOffVM := VMs[0].(*simulator.VirtualMachine)
+	poweredOnVM := VMs[1].(*simulator.VirtualMachine)
 
 	credentialsSecret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -2866,7 +2873,7 @@ func TestExists(t *testing.T) {
 		},
 	}
 
-	vmObj := object.NewVirtualMachine(session.Client.Client, vm.Reference())
+	vmObj := object.NewVirtualMachine(session.Client.Client, poweredOnVM.Reference())
 	task, err := vmObj.PowerOn(context.TODO())
 	if err != nil {
 		t.Fatal(err)
@@ -2878,11 +2885,12 @@ func TestExists(t *testing.T) {
 		instanceState string
 		exists        bool
 		vmExists      bool
+		vm            *simulator.VirtualMachine
 	}{
 		{
 			name:          "VM doesn't exist",
 			machinePhase:  "Provisioning",
-			instanceState: string(types.VirtualMachinePowerStatePoweredOn),
+			instanceState: "",
 			exists:        false,
 			vmExists:      false,
 		},
@@ -2892,6 +2900,7 @@ func TestExists(t *testing.T) {
 			instanceState: string(types.VirtualMachinePowerStatePoweredOn),
 			exists:        true,
 			vmExists:      true,
+			vm:            poweredOnVM,
 		},
 		{
 			name:          "VM exists but didnt powered on after clone",
@@ -2899,6 +2908,7 @@ func TestExists(t *testing.T) {
 			instanceState: string(types.VirtualMachinePowerStatePoweredOff),
 			exists:        false,
 			vmExists:      true,
+			vm:            poweredOffVM,
 		},
 		{
 			name:          "VM exists, but powered off",
@@ -2906,40 +2916,51 @@ func TestExists(t *testing.T) {
 			instanceState: string(types.VirtualMachinePowerStatePoweredOff),
 			exists:        true,
 			vmExists:      true,
+			vm:            poweredOffVM,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			machineScope := machineScope{
-				Context: context.TODO(),
-				machine: &machinev1.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
-						Labels: map[string]string{
-							machinev1.MachineClusterIDLabel: "CLUSTERID",
-						},
-					},
-					Status: machinev1.MachineStatus{
-						Phase: &tc.machinePhase,
+
+			var name, uuid string
+			if tc.vm != nil {
+				name = tc.vm.Name
+				uuid = tc.vm.Config.InstanceUuid
+			}
+
+			machineObj := &machinev1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+					Labels: map[string]string{
+						machinev1.MachineClusterIDLabel: "CLUSTERID",
 					},
 				},
+				Status: machinev1.MachineStatus{
+					Phase: &tc.machinePhase,
+				},
+			}
+
+			machineScope := machineScope{
+				Context:            context.TODO(),
+				machine:            machineObj,
+				machineToBePatched: runtimeclient.MergeFrom(machineObj.DeepCopy()),
 				providerSpec: &machinev1.VSphereMachineProviderSpec{
-					Template: vm.Name,
+					Template: name,
 				},
 				session: session,
 				providerStatus: &machinev1.VSphereMachineProviderStatus{
 					TaskRef:       task.Reference().Value,
 					InstanceState: &tc.instanceState,
 				},
-				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(&credentialsSecret).Build(),
+				client: fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(&credentialsSecret, machineObj).WithStatusSubresource(machineObj).Build(),
 			}
 
 			reconciler := newReconciler(&machineScope)
 
 			if tc.vmExists {
-				reconciler.machine.UID = apimachinerytypes.UID(instanceUUID)
+				reconciler.machine.UID = apimachinerytypes.UID(uuid)
 			}
 
 			exists, err := reconciler.exists()


### PR DESCRIPTION
/hold

This PR is the same as https://github.com/openshift/machine-api-operator/pull/1223 with an additional commit that discards the machine creation taskID. Simulating the issue to allow QE to verify the fix.

Some unit tests will fail here, but that is expected. Machine creation should still work, leveraging the new logic.

"Powering on cloned machine without taskID: %v", r.machine.Name
%v: already exists, but was not powered on after clone"
Should be present in machine controller logs.
