### PR TITLE
Add hyperdisk-extreme disk type

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1327,7 +1327,7 @@ func validateGCPDisks(disks []*machinev1beta1.GCPDisk, parentPath *field.Path) f
 		}
 
 		if disk.Type != "" {
-			diskTypes := sets.NewString("pd-standard", "pd-ssd", "pd-balanced", "hyperdisk-balanced")
+			diskTypes := sets.NewString("pd-standard", "pd-ssd", "pd-balanced", "hyperdisk-balanced", "hyperdisk-extreme")
 			if !diskTypes.Has(disk.Type) {
 				errs = append(errs, field.NotSupported(fldPath.Child("type"), disk.Type, diskTypes.List()))
 			}

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -3365,7 +3365,7 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk:    false,
-			expectedError: "providerSpec.disks[0].type: Unsupported value: \"invalid\": supported values: \"hyperdisk-balanced\", \"pd-balanced\", \"pd-ssd\", \"pd-standard\"",
+			expectedError: "providerSpec.disks[0].type: Unsupported value: \"invalid\": supported values: \"hyperdisk-balanced\", \"hyperdisk-extreme\", \"pd-balanced\", \"pd-ssd\", \"pd-standard\"",
 		},
 		{
 			testCase: "with a disk type that is supported",


### PR DESCRIPTION
Following up on the work of https://github.com/openshift/machine-api-operator/pull/1268 which introduced hyperdisk-balanced support, this PR introduces support for hyperdisk-extreme.

- Add the hyperdisk-extreme disk type for gcp machines.
- Add the test to validate the new type.