### PR TITLE
OCPBUGS-37154: Added Permisions for Azure Capacity Reservation

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -93,6 +93,7 @@ spec:
     - Microsoft.Compute/virtualMachines/delete
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Compute/virtualMachines/write
+    - Microsoft.Compute/capacityReservationGroups/deploy/action
     - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
     - Microsoft.Network/applicationSecurityGroups/read
     - Microsoft.Network/loadBalancers/backendAddressPools/join/action


### PR DESCRIPTION
Added `Microsoft.Compute/capacityReservationGroups/deploy/action` Permission to default cred Request for users to use capacity reservation with workload Identity.