### PR TITLE
OCPCLOUD-2565: Machine controller feature gating

### DIFF
--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -193,7 +193,7 @@ func main() {
 		klog.Fatalf("unable to add ipamv1beta1 to scheme: %v", err)
 	}
 
-	if err := capimachine.AddWithActuator(mgr, machineActuator); err != nil {
+	if err := capimachine.AddWithActuator(mgr, machineActuator, defaultMutableGate); err != nil {
 		klog.Fatal(err)
 	}
 

--- a/pkg/controller/machine/controller.go
+++ b/pkg/controller/machine/controller.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/featuregate"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,13 +76,13 @@ const (
 
 var DefaultActuator Actuator
 
-func AddWithActuator(mgr manager.Manager, actuator Actuator) error {
-	return AddWithActuatorOpts(mgr, actuator, controller.Options{})
+func AddWithActuator(mgr manager.Manager, actuator Actuator, gate featuregate.MutableFeatureGate) error {
+	return AddWithActuatorOpts(mgr, actuator, controller.Options{}, gate)
 }
 
-func AddWithActuatorOpts(mgr manager.Manager, actuator Actuator, opts controller.Options) error {
+func AddWithActuatorOpts(mgr manager.Manager, actuator Actuator, opts controller.Options, gate featuregate.MutableFeatureGate) error {
 	machineControllerOpts := opts
-	machineControllerOpts.Reconciler = newReconciler(mgr, actuator)
+	machineControllerOpts.Reconciler = newReconciler(mgr, actuator, gate)
 
 	if err := addWithOpts(mgr, machineControllerOpts, "machine-controller"); err != nil {
 		return err
@@ -96,14 +97,14 @@ func AddWithActuatorOpts(mgr manager.Manager, actuator Actuator, opts controller
 	return nil
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager, actuator Actuator) reconcile.Reconciler {
+func newReconciler(mgr manager.Manager, actuator Actuator, gate featuregate.MutableFeatureGate) reconcile.Reconciler {
 	r := &ReconcileMachine{
 		Client:        mgr.GetClient(),
 		eventRecorder: mgr.GetEventRecorderFor("machine-controller"),
 		config:        mgr.GetConfig(),
 		scheme:        mgr.GetScheme(),
 		actuator:      actuator,
+		gate:          gate,
 	}
 	return r
 }
@@ -137,6 +138,7 @@ type ReconcileMachine struct {
 	eventRecorder record.EventRecorder
 
 	actuator Actuator
+	gate     featuregate.MutableFeatureGate
 
 	// nowFunc is used to mock time in testing. It should be nil in production.
 	nowFunc func() time.Time

--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -29,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	testutils "github.com/openshift/machine-api-operator/pkg/util/testing"
 )
 
 var c client.Client
@@ -66,7 +68,12 @@ func TestReconcile(t *testing.T) {
 	c = mgr.GetClient()
 
 	a := newTestActuator()
-	recFn := newReconciler(mgr, a)
+	gate, err := testutils.NewDefaultMutableFeatureGate()
+	if err != nil {
+		t.Errorf("Unexpected error setting up feature gates: %v", err)
+	}
+
+	recFn := newReconciler(mgr, a, gate)
 	if err := add(mgr, recFn, "dummy"); err != nil {
 		t.Fatalf("error adding controller to manager: %v", err)
 	}


### PR DESCRIPTION
This change adds feature gating to the Machine Controller. The interface is the same as used by the MachineSet controller, where features are passed as flags via `--feature-gates=<name>=<bool>`

This is a breaking change, as we change `AddWithActuator` to expect a feature gate. This means each MAPI provider will need updating to do this.


https://github.com/openshift/machine-api-operator/pull/1269 has an example of the changes required, but the changes from this PR to `cmd/vsphere/main.go` will also be required. 