### PR TITLE
OCPBUGS-42388: Ensure deletion annotation takes priority and oldestPolicy can distinguish longer ages

### DIFF
--- a/pkg/controller/machineset/delete_policy_test.go
+++ b/pkg/controller/machineset/delete_policy_test.go
@@ -281,6 +281,9 @@ func TestMachineOldestDelete(t *testing.T) {
 	new := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -5))}}
 	old := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))}}
 	oldest := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))}}
+	old500Day := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -500))}}
+	old1000Day := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -1000))}}
+	old3750Day := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -3750))}}
 	annotatedMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{DeleteNodeAnnotation: "yes"}, CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -1))}}
 	oldAnnotatedMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{oldDeleteNodeAnnotation: "yes"}, CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -1))}}
 	unhealthyMachine := &machinev1.Machine{ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(currentTime.Time.AddDate(0, 0, -10))}, Status: machinev1.MachineStatus{ErrorReason: &statusError}}
@@ -346,6 +349,22 @@ func TestMachineOldestDelete(t *testing.T) {
 				empty, new, oldest, old, newest, unhealthyMachine,
 			},
 			expect: []*machinev1.Machine{unhealthyMachine},
+		},
+		{
+			desc: "func=oldestDeletePriority, diff=1 (old but with annotate priority)",
+			diff: 1,
+			machines: []*machinev1.Machine{
+				new, annotatedMachine, old500Day, old1000Day, old3750Day,
+			},
+			expect: []*machinev1.Machine{annotatedMachine},
+		},
+		{
+			desc: "func=oldestDeletePriority, diff=3 (old machines in order)",
+			diff: 3,
+			machines: []*machinev1.Machine{
+				new, old500Day, old1000Day, old3750Day,
+			},
+			expect: []*machinev1.Machine{old3750Day, old1000Day, old500Day},
 		},
 	}
 


### PR DESCRIPTION
This PR makes two changes to the way that we calculate the deletion priority in the MachineSet oldest delete policy.

The first is to move from `mustDelete` to `betterDelete`. This change ensures that the other `mustDelete` options always have priority (like having an annotation, or already having a deletion timestamp).

The second change expands the range of values for which the age based priority is actually functional.

With the current logic, the value of `(1.0 - math.Exp(-d.Seconds()/secondsPerTenDays)))` tends to `1` as the age of the machine increases. Currently, when the machine is about 375 days old, this expression equals `1` (thank you floating point numbers) and then the priority just becomes the factor (betterDelete now). This means any machines over this age cannot be distinguished and will all be considered the same priority.

It is reasonable to expect that we will have machines over a year old.

By increasing the value of `secondsPerTenDays` to `secondsPerHundredDays` this slows the rate at which the value tends to 1, meaning now it will asymptote at around the 10.3 year mark, which is less likely to be reached by our customers, hopefully meaning we don't see similar bugs again.

Since floating point numbers can compare up to 16 digits, I'm not concerned about slowing the rate of growth of the exponent by 1 order of magnitude (a second is represented at the 7th decimal place when used as an exponent).