### PR TITLE
OCPBUGS-43481: fix: health probes paths and updated timing

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -694,18 +694,41 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 					ContainerPort: defaultMachineSetHealthPort,
 				},
 			},
-			ReadinessProbe: &corev1.Probe{
+			StartupProbe: &corev1.Probe{
+				PeriodSeconds:       10,
+				TimeoutSeconds:      10,
+				FailureThreshold:    30,
+				SuccessThreshold:    1,
+				InitialDelaySeconds: 0,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/healthz",
+						Path: "/readyz",
+						Port: intstr.Parse("healthz"),
+					},
+				},
+			},
+			ReadinessProbe: &corev1.Probe{
+				PeriodSeconds:       10,
+				TimeoutSeconds:      5,
+				FailureThreshold:    3,
+				SuccessThreshold:    1,
+				InitialDelaySeconds: 0,
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/readyz",
 						Port: intstr.Parse("healthz"),
 					},
 				},
 			},
 			LivenessProbe: &corev1.Probe{
+				PeriodSeconds:       10,
+				TimeoutSeconds:      5,
+				FailureThreshold:    3,
+				SuccessThreshold:    1,
+				InitialDelaySeconds: 0,
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
-						Path: "/readyz",
+						Path: "/healthz",
 						Port: intstr.Parse("healthz"),
 					},
 				},


### PR DESCRIPTION
aligned readiness probe to /readyz and liveness to /healthz added explicit timing values for health probes to handle slower response environments like sno during upgrades