### PR TITLE
OCPBUGS-44056: Remove unneeded VNet permissions from Azure CredentialsRequest

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -111,9 +111,6 @@ spec:
     - Microsoft.Network/publicIPAddresses/read
     - Microsoft.Network/publicIPAddresses/write
     - Microsoft.Network/routeTables/read
-    - Microsoft.Network/virtualNetworks/delete
-    - Microsoft.Network/virtualNetworks/read
-    - Microsoft.Network/virtualNetworks/join/action
     - Microsoft.Network/virtualNetworks/subnets/join/action
     - Microsoft.Network/virtualNetworks/subnets/read
     - Microsoft.Resources/subscriptions/resourceGroups/read


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-44056

https://github.com/openshift/machine-api-provider-azure/pull/122
Follow up on above PR. The code to managed VNet is being removed from the operator as it is unused, so also removing the matching permissions from the CredentialRequest