### PR TITLE
OCPBUGS-46433: Add cluster-reader to controlplanemachinesets resource

### DIFF
--- a/install/0000_30_machine-api-operator_09_rbac.yaml
+++ b/install/0000_30_machine-api-operator_09_rbac.yaml
@@ -665,6 +665,7 @@ rules:
 - apiGroups:
   - machine.openshift.io
   resources:
+  - controlplanemachinesets
   - machinehealthchecks
   - machines
   - machinesets


### PR DESCRIPTION
Added cluster-reader permissions to controlplanemachinesets resource