### PR TITLE
AUTH-482: set required-scc for openshift workloads 

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -445,7 +445,8 @@ func newDeployment(config *OperatorConfig, features map[string]bool) *appsv1.Dep
 			Name:      "machine-api-controllers",
 			Namespace: config.TargetNamespace,
 			Annotations: map[string]string{
-				maoOwnedAnnotation: "",
+				maoOwnedAnnotation:          "",
+				"openshift.io/required-scc": "restricted-v2",
 			},
 			Labels: map[string]string{
 				"api":     "clusterapi",


### PR DESCRIPTION
completion for [AUTH-482: set required-scc for openshift workloads #1308](https://github.com/openshift/machine-api-operator/pull/1308)
