### PR TITLE
DNM/aws/creds: fix typo on permission name

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -48,7 +48,7 @@ spec:
       - kms:Decrypt
       - kms:Encrypt
       - kms:GenerateDataKey
-      - kms:GenerateDataKeyWithoutPlainText
+      - kms:GenerateDataKeyWithoutPlaintext
       - kms:DescribeKey
       resource: '*'
     - effect: Allow


### PR DESCRIPTION
TODO: validate and open a bug

According to the AWS, and audit events collected by AWS CloudTrail[1] the correct permission/API name is `kms:GenerateDataKeyWithoutPlaintext`: https://docs.aws.amazon.com/kms/latest/APIReference/API_GenerateDataKeyWithoutPlaintext.html

I am tracking real issues of a CI step which is under development[0] to check required permissions versus requested permissions (CredentialsRequests) by OCP components. Here[1] is a preview of a user created to the controller.

[0] https://github.com/openshift/release/pull/58651
[1] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_release/58651/rehearse-58651-periodic-ci-openshift-release-master-nightly-4.18-e2e-aws-ovn-audit-perms/1874577125499998208/artifacts/e2e-aws-ovn-audit-perms/gather-cloud-iam-access-aws/artifacts/compiled_users.json 