### PR TITLE
SPLAT-1800: vSphere host zonal missing operator feature

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -474,11 +474,12 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 	// flags, we selectively populate the map (and therefore passed
 	// as args)
 	features := map[string]bool{
-		string(apifeatures.FeatureGateMachineAPIMigration):   featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
-		string(apifeatures.FeatureGateVSphereStaticIPs):      featureGates.Enabled(apifeatures.FeatureGateVSphereStaticIPs),
-		string(apifeatures.FeatureGateGCPLabelsTags):         featureGates.Enabled(apifeatures.FeatureGateGCPLabelsTags),
-		string(apifeatures.FeatureGateAzureWorkloadIdentity): featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
-		string(apifeatures.FeatureGateVSphereMultiDisk):      featureGates.Enabled(apifeatures.FeatureGateVSphereMultiDisk),
+		string(apifeatures.FeatureGateMachineAPIMigration):     featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
+		string(apifeatures.FeatureGateVSphereStaticIPs):        featureGates.Enabled(apifeatures.FeatureGateVSphereStaticIPs),
+		string(apifeatures.FeatureGateGCPLabelsTags):           featureGates.Enabled(apifeatures.FeatureGateGCPLabelsTags),
+		string(apifeatures.FeatureGateAzureWorkloadIdentity):   featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
+		string(apifeatures.FeatureGateVSphereMultiDisk):        featureGates.Enabled(apifeatures.FeatureGateVSphereMultiDisk),
+		string(apifeatures.FeatureGateVSphereHostVMGroupZonal): featureGates.Enabled(apifeatures.FeatureGateVSphereHostVMGroupZonal),
 	}
 	if features[string(apifeatures.FeatureGateMachineAPIMigration)] {
 		klog.V(2).Info("Enabling MachineAPIMigration for provider controller and machinesets")

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -46,14 +46,16 @@ var (
 		{Name: apifeatures.FeatureGateGCPLabelsTags},
 		{Name: apifeatures.FeatureGateAzureWorkloadIdentity},
 		{Name: apifeatures.FeatureGateVSphereMultiDisk},
+		{Name: apifeatures.FeatureGateVSphereHostVMGroupZonal},
 	}
 
 	enabledFeatureMap = map[string]bool{
-		"MachineAPIMigration":   true,
-		"GCPLabelsTags":         true,
-		"AzureWorkloadIdentity": true,
-		"VSphereStaticIPs":      true,
-		"VSphereMultiDisk":      true,
+		"MachineAPIMigration":     true,
+		"GCPLabelsTags":           true,
+		"AzureWorkloadIdentity":   true,
+		"VSphereStaticIPs":        true,
+		"VSphereMultiDisk":        true,
+		"VSphereHostVMGroupZonal": true,
 	}
 )
 


### PR DESCRIPTION
Follow up to #1285.
This PR adds `FeatureGateVSphereHostVMGroupZonal` to the map of features so the command line of the controller pods is set correctly.