### PR TITLE
OCPBUGS-49413: add image/read permissions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -94,6 +94,10 @@ spec:
     - Microsoft.Compute/virtualMachines/read
     - Microsoft.Compute/virtualMachines/write
     - Microsoft.Compute/capacityReservationGroups/deploy/action
+    - Microsoft.Compute/galleries/read
+    - Microsoft.Compute/galleries/images/read
+    - Microsoft.Compute/galleries/images/versions/read
+    - Microsoft.Compute/images/read
     - Microsoft.ManagedIdentity/userAssignedIdentities/assign/action
     - Microsoft.Network/applicationSecurityGroups/joinNetworkSecurityRule/action
     - Microsoft.Network/applicationSecurityGroups/read


### PR DESCRIPTION
This is to resolve the permission issue when upgraded from 4.11 -> 4.14 .

more context on it [here](https://redhat-internal.slack.com/archives/C04TMSTHUHK/p1738750794938799) 

PTAL when time permits.