### PR TITLE
OCPBUGS-51042: Drop oVirt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Have a question? See our [Frequently Asked Questions](FAQ.md) for common inquiri
   - [cluster-api-provider-openstack](https://github.com/openshift/cluster-api-provider-openstack)
 
   - [cluster-api-provider-baremetal](https://github.com/openshift/cluster-api-provider-baremetal)
-
-  - [cluster-api-provider-ovirt](https://github.com/openshift/cluster-api-provider-ovirt)
   
   - [cluster-api-provider-ibmcloud](https://github.com/openshift/cluster-api-provider-ibmcloud)
 

--- a/docs/dev/hacking-guide.md
+++ b/docs/dev/hacking-guide.md
@@ -41,7 +41,6 @@ Machine API consists of a number different components:
   - https://github.com/openshift/machine-api-operator/tree/master/pkg/controller/vsphere
   - https://github.com/openshift/cluster-api-provider-openstack
   - https://github.com/openshift/cluster-api-provider-baremetal
-  - https://github.com/openshift/cluster-api-provider-ovirt
 
 ### How to start contributing
 
@@ -154,7 +153,6 @@ data:
         "clusterAPIControllerBareMetal": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
         "clusterAPIControllerAzure": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
         "clusterAPIControllerGCP": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
-        "clusterAPIControllerOvirt": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
         "clusterAPIControllerVSphere": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
         "baremetalOperator": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",
         "baremetalIronic": "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:...",

--- a/docs/user/machine-api-operator-overview.md
+++ b/docs/user/machine-api-operator-overview.md
@@ -53,7 +53,6 @@ Providers which currently works with MAO, are:
 - [vSphere](https://github.com/openshift/machine-api-operator/tree/master/pkg/controller/vsphere)
 - [Azure](https://github.com/openshift/cluster-api-provider-azure)
 - [BareMetal](https://github.com/openshift/cluster-api-provider-baremetal/)
-- [OVirt](https://github.com/openshift/cluster-api-provider-ovirt)
 
 ## Works closely, but not directly responsible for
 

--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -216,24 +216,6 @@ kind: CredentialsRequest
 metadata:
   labels:
     controller-tools.k8s.io: "1.0"
-  name: openshift-machine-api-ovirt
-  namespace: openshift-cloud-credential-operator
-  annotations:
-    capability.openshift.io/name: MachineAPI+CloudCredential
-    include.release.openshift.io/self-managed-high-availability: "true"
-spec:
-  secretRef:
-    name: ovirt-credentials
-    namespace: openshift-machine-api
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: OvirtProviderSpec
----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
   name: openshift-machine-api-vsphere
   namespace: openshift-cloud-credential-operator
   annotations:

--- a/install/0000_30_machine-api-operator_01_images.configmap.yaml
+++ b/install/0000_30_machine-api-operator_01_images.configmap.yaml
@@ -22,7 +22,6 @@ data:
       "clusterAPIControllerGCP": "quay.io/openshift/origin-gcp-machine-controllers",
       "clusterAPIControllerIBMCloud": "quay.io/openshift/origin-ibmcloud-machine-controllers",
       "clusterAPIControllerNutanix": "quay.io/openshift/origin-nutanix-machine-controllers",
-      "clusterAPIControllerOvirt": "quay.io/openshift/origin-ovirt-machine-controllers",
       "clusterAPIControllerPowerVS": "quay.io/openshift/origin-powervs-machine-controllers",
       "clusterAPIControllerVSphere": "quay.io/openshift/origin-machine-api-operator"
     }

--- a/install/image-references
+++ b/install/image-references
@@ -46,10 +46,6 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy
-  - name: ovirt-machine-controllers
-    from:
-      kind: DockerImage
-      name: quay.io/openshift/origin-ovirt-machine-controllers
   - name: nutanix-machine-controllers
     from:
       kind: DockerImage

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -45,7 +45,6 @@ type Images struct {
 	ClusterAPIControllerBareMetal string `json:"clusterAPIControllerBareMetal"`
 	ClusterAPIControllerAzure     string `json:"clusterAPIControllerAzure"`
 	ClusterAPIControllerGCP       string `json:"clusterAPIControllerGCP"`
-	ClusterAPIControllerOvirt     string `json:"clusterAPIControllerOvirt"`
 	ClusterAPIControllerVSphere   string `json:"clusterAPIControllerVSphere"`
 	ClusterAPIControllerIBMCloud  string `json:"clusterAPIControllerIBMCloud"`
 	ClusterAPIControllerPowerVS   string `json:"clusterAPIControllerPowerVS"`
@@ -89,8 +88,6 @@ func getProviderControllerFromImages(platform configv1.PlatformType, images Imag
 		return images.ClusterAPIControllerGCP, nil
 	case configv1.BareMetalPlatformType:
 		return images.ClusterAPIControllerBareMetal, nil
-	case configv1.OvirtPlatformType:
-		return images.ClusterAPIControllerOvirt, nil
 	case configv1.VSpherePlatformType:
 		return images.ClusterAPIControllerVSphere, nil
 	case configv1.IBMCloudPlatformType:

--- a/pkg/operator/config_test.go
+++ b/pkg/operator/config_test.go
@@ -21,7 +21,6 @@ const (
 	expectedGCPImage       = "quay.io/openshift/origin-gcp-machine-controllers"
 	expectedLibvirtImage   = "quay.io/openshift/origin-libvirt-machine-controllers"
 	expectedOpenstackImage = "quay.io/openshift/origin-openstack-machine-api-provider"
-	expectedOvirtImage     = "quay.io/openshift/origin-ovirt-machine-controllers"
 	expectedPowerVSImage   = "quay.io/openshift/origin-powervs-machine-controllers"
 	expectedVSphereImage   = "quay.io/openshift/origin-machine-api-operator"
 	expectedNutanixImage   = "quay.io/openshift/origin-nutanix-machine-controllers"
@@ -169,22 +168,6 @@ func TestGetProviderFromInfrastructure(t *testing.T) {
 		infra: &configv1.Infrastructure{
 			Status: configv1.InfrastructureStatus{
 				PlatformStatus: &configv1.PlatformStatus{
-					Type: configv1.OvirtPlatformType,
-				},
-			},
-		},
-		expected: configv1.OvirtPlatformType,
-	}, {
-		infra: &configv1.Infrastructure{
-			Status: configv1.InfrastructureStatus{
-				Platform: configv1.OvirtPlatformType,
-			},
-		},
-		expected: "",
-	}, {
-		infra: &configv1.Infrastructure{
-			Status: configv1.InfrastructureStatus{
-				PlatformStatus: &configv1.PlatformStatus{
 					Type: configv1.PowerVSPlatformType,
 				},
 			},
@@ -246,9 +229,6 @@ func TestGetImagesFromJSONFile(t *testing.T) {
 	if img.ClusterAPIControllerGCP != expectedGCPImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedGCPImage, img.ClusterAPIControllerGCP)
 	}
-	if img.ClusterAPIControllerOvirt != expectedOvirtImage {
-		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedOvirtImage, img.ClusterAPIControllerOvirt)
-	}
 	if img.ClusterAPIControllerVSphere != expectedVSphereImage {
 		t.Errorf("failed getImagesFromJSONFile. Expected: %s, got: %s", expectedVSphereImage, img.ClusterAPIControllerVSphere)
 	}
@@ -302,10 +282,6 @@ func TestGetProviderControllerFromImages(t *testing.T) {
 		{
 			provider:      configv1.NonePlatformType,
 			expectedImage: clusterAPIControllerNoOp,
-		},
-		{
-			provider:      configv1.OvirtPlatformType,
-			expectedImage: expectedOvirtImage,
 		},
 		{
 			provider:      configv1.PowerVSPlatformType,
@@ -386,10 +362,6 @@ func TestGetTerminationHandlerFromImages(t *testing.T) {
 		},
 		{
 			provider:      configv1.NonePlatformType,
-			expectedImage: clusterAPIControllerNoOp,
-		},
-		{
-			provider:      configv1.OvirtPlatformType,
 			expectedImage: clusterAPIControllerNoOp,
 		},
 		{

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -175,10 +175,6 @@ func TestOperatorSync_NoOp(t *testing.T) {
 			expectedNoop: false,
 		},
 		{
-			platform:     openshiftv1.OvirtPlatformType,
-			expectedNoop: false,
-		},
-		{
 			platform:     openshiftv1.PowerVSPlatformType,
 			expectedNoop: false,
 		},
@@ -639,40 +635,6 @@ func TestMAOConfigFromInfrastructure(t *testing.T) {
 					KubeRBACProxy:      images.KubeRBACProxy,
 				},
 				PlatformType: openshiftv1.VSpherePlatformType,
-				Features:     enabledFeatureMap,
-			},
-		},
-		{
-			name:     string(openshiftv1.OvirtPlatformType),
-			platform: openshiftv1.OvirtPlatformType,
-			infra:    infra,
-			featureGate: &openshiftv1.FeatureGate{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Status: openshiftv1.FeatureGateStatus{
-					FeatureGates: []openshiftv1.FeatureGateDetails{
-						{
-							Version:  "",
-							Enabled:  enabledFeatureGates,
-							Disabled: []openshiftv1.FeatureGateAttributes{{Name: apifeatures.FeatureGateMachineAPIOperatorDisableMachineHealthCheckController}},
-						},
-					},
-				},
-			},
-			proxy: proxy,
-			expectedConfig: &OperatorConfig{
-				TargetNamespace: targetNamespace,
-				Proxy:           proxy,
-				Controllers: Controllers{
-					Provider:           images.ClusterAPIControllerOvirt,
-					MachineSet:         images.MachineAPIOperator,
-					NodeLink:           images.MachineAPIOperator,
-					MachineHealthCheck: images.MachineAPIOperator,
-					TerminationHandler: clusterAPIControllerNoOp,
-					KubeRBACProxy:      images.KubeRBACProxy,
-				},
-				PlatformType: openshiftv1.OvirtPlatformType,
 				Features:     enabledFeatureMap,
 			},
 		},


### PR DESCRIPTION
Per thread in [slack](https://redhat-internal.slack.com/archives/CE4UC6AVB/p1738699843095579), oVirt support ended in 4.14 and we no longer wish to reference or be able to install oVirt through MAO.

CC @sdodson 