### PR TITLE
OCPBUGS-51373,OCPBUGS-44671: Updates GCP credentials request

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -174,6 +174,8 @@ spec:
     - "compute.globalOperations.get"
     - "compute.globalOperations.list"
     - "compute.healthChecks.useReadOnly"
+    - "compute.images.get"
+    - "compute.images.getFromFamily"
     - "compute.instanceGroups.create"
     - "compute.instanceGroups.delete"
     - "compute.instanceGroups.get"


### PR DESCRIPTION
This change adds the compute.images.get and getFromFamily to the credentials request for GCP. It is required by MAPG for checking if a disk is UEFI compatible.

See https://github.com/openshift/machine-api-provider-gcp/pull/108