### PR TITLE
OCPBUGS-52464: webhook to validate marketType field

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -788,6 +788,10 @@ func validateAWS(m *machinev1beta1.Machine, config *admissionConfig) (bool, []st
 		}
 	}
 
+	if providerSpec.MarketType == "" && providerSpec.SpotMarketOptions != nil && providerSpec.CapacityReservationID != "" {
+		errs = append(errs, field.Invalid(field.NewPath("providerSpec", "capacityReservationId"), providerSpec.CapacityReservationID, "spotMarketOptions and capacityReservationID may not be used together"))
+	}
+
 	// TODO(alberto): Validate providerSpec.BlockDevices.
 	// https://github.com/openshift/cluster-api-provider-aws/pull/299#discussion_r433920532
 
@@ -2428,6 +2432,14 @@ func validateAWSInstanceMarketType(providerSpec *machinev1beta1.AWSMachineProvid
 	}
 	if providerSpec.MarketType == machinev1beta1.MarketTypeCapacityBlock && len(providerSpec.CapacityReservationID) == 0 {
 		return errors.New("capacityReservationID is required when CapacityBlock is provided")
+	}
+	if providerSpec.MarketType == machinev1beta1.MarketTypeSpot && providerSpec.CapacityReservationID != "" {
+		return errors.New("invalid marketType: marketType set to Spot and capacityReservationID may not be used together")
+	}
+	switch providerSpec.MarketType {
+	case "", machinev1beta1.MarketTypeOnDemand, machinev1beta1.MarketTypeSpot, machinev1beta1.MarketTypeCapacityBlock:
+	default:
+		return fmt.Errorf("invalid marketType: %s valid values are: %s, %s, %s and omitted", providerSpec.MarketType, machinev1beta1.MarketTypeOnDemand, machinev1beta1.MarketTypeSpot, machinev1beta1.MarketTypeCapacityBlock)
 	}
 	return nil
 }

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -199,6 +199,64 @@ func TestMachineCreation(t *testing.T) {
 			expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: providerSpec.capacityReservationId: Invalid value: \"cr-123\": invalid value for capacityReservationId: \"cr-123\", it must start with 'cr-' and be exactly 20 characters long with 17 hexadecimal characters",
 		},
 		{
+			name:         "with invalid MarketType provided",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    "aws-cluster",
+			providerSpecValue: &kruntime.RawExtension{
+				Object: &machinev1beta1.AWSMachineProviderConfig{
+					AMI: machinev1beta1.AWSResourceReference{
+						ID: ptr.To[string]("ami"),
+					},
+					MarketType: "invalid",
+				},
+			},
+			expectedError: fmt.Sprintf("invalid marketType: invalid valid values are: %s, %s, %s and omitted", machinev1beta1.MarketTypeOnDemand, machinev1beta1.MarketTypeSpot, machinev1beta1.MarketTypeCapacityBlock),
+		},
+		{
+			name:         "with MarketType empty value provided",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    "aws-cluster",
+			providerSpecValue: &kruntime.RawExtension{
+				Object: &machinev1beta1.AWSMachineProviderConfig{
+					AMI: machinev1beta1.AWSResourceReference{
+						ID: ptr.To[string]("ami"),
+					},
+					MarketType: "",
+				},
+			},
+			expectedError: "",
+		},
+		{
+			name:         "with MarketType Spot and  CapacityReservationID value provided",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    "aws-cluster",
+			providerSpecValue: &kruntime.RawExtension{
+				Object: &machinev1beta1.AWSMachineProviderConfig{
+					AMI: machinev1beta1.AWSResourceReference{
+						ID: ptr.To[string]("ami"),
+					},
+					MarketType:            machinev1beta1.MarketTypeSpot,
+					CapacityReservationID: "cr-12345678901234567",
+				},
+			},
+			expectedError: "invalid marketType: marketType set to Spot and capacityReservationID may not be used together",
+		},
+		{
+			name:         "with CapacityReservationID and SpotMarketOptions are provided",
+			platformType: osconfigv1.AWSPlatformType,
+			clusterID:    "aws-cluster",
+			providerSpecValue: &kruntime.RawExtension{
+				Object: &machinev1beta1.AWSMachineProviderConfig{
+					AMI: machinev1beta1.AWSResourceReference{
+						ID: ptr.To[string]("ami"),
+					},
+					SpotMarketOptions:     &machinev1beta1.SpotMarketOptions{},
+					CapacityReservationID: "cr-12345678901234567",
+				},
+			},
+			expectedError: "spotMarketOptions and capacityReservationID may not be used together",
+		},
+		{
 			name:         "with MarketType set to MarketTypeCapacityBlock and spotMarketOptions are specified",
 			platformType: osconfigv1.AWSPlatformType,
 			clusterID:    "aws-cluster",


### PR DESCRIPTION
[OCPBUGS-52464](https://issues.redhat.com/browse/OCPBUGS-52464)

### Changes
- Validate the marketType field value in webhook. 
- Added the unittest 

