### PR TITLE
AUTH-482: Move required-scc annotation from deployment to pod

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -3,6 +3,7 @@ package operator
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -22,6 +23,7 @@ import (
 
 	v1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
+	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehash"
@@ -447,8 +449,7 @@ func newDeployment(config *OperatorConfig, features map[string]bool) *appsv1.Dep
 			Name:      "machine-api-controllers",
 			Namespace: config.TargetNamespace,
 			Annotations: map[string]string{
-				maoOwnedAnnotation:          "",
-				"openshift.io/required-scc": "restricted-v2",
+				maoOwnedAnnotation: "",
 			},
 			Labels: map[string]string{
 				"api":     "clusterapi",
@@ -594,9 +595,15 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 	}
 	volumes = append(volumes, newRBACConfigVolumes()...)
 
+	annotations := map[string]string{
+		securityv1.RequiredSCCAnnotation: "restricted-v2",
+	}
+
+	maps.Insert(annotations, maps.All(commonPodTemplateAnnotations))
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: commonPodTemplateAnnotations,
+			Annotations: annotations,
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "controller",


### PR DESCRIPTION
Move `required-scc` from the deployment annotations to the pod annotations where it is required.

Follow-up - I see a `newTerminationPodTemplateSpec` in here that looks like it does things that require more than `restricted-v2` privileges would grant... Is that function exercised in the nightly CI for any SCC issues to be caught? If not, what would be the appropriate SCC to pin that workload to?