### PR TITLE
SPLAT-2078: Removed VSphereStaticIPs feature gate

### DIFF
--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -112,7 +112,7 @@ func main() {
 
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateVSphereStaticIPs, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
+	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
 	if err != nil {
 		klog.Fatalf("Error setting up feature gates: %v", err)
 	}

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -93,7 +93,7 @@ func main() {
 
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateVSphereStaticIPs, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
+	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
 	if err != nil {
 		klog.Fatalf("Error setting up feature gates: %v", err)
 	}
@@ -151,8 +151,6 @@ func main() {
 
 	klog.Infof("FeatureGateMachineAPIMigration initialised: %t", defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateMachineAPIMigration)))
 
-	staticIPFeatureGateEnabled := defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereStaticIPs))
-	klog.Infof("FeatureGateVSphereStaticIPs initialised: %t", staticIPFeatureGateEnabled)
 	hostVMGroupZonalFeatureGateEnabled := defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereHostVMGroupZonal))
 	klog.Infof("FeatureGateVSphereHostVMGroupZonal initialised %t", hostVMGroupZonalFeatureGateEnabled)
 	multiDiskFeatureGateEnabled := defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereMultiDisk))

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -2755,33 +2755,7 @@ func TestCreate(t *testing.T) {
 			expectedError: errors.New("could not update VM Group membership: *types.InvalidArgument"),
 		},
 		{
-			name:        "Fail to create machine with static IP when tech preview not enabled",
-			machineName: "test-2",
-			providerSpec: machinev1.VSphereMachineProviderSpec{
-				Template: vmName,
-				Workspace: &machinev1.Workspace{
-					Server: host,
-				},
-				CredentialsSecret: &corev1.LocalObjectReference{
-					Name: "test",
-				},
-				DiskGiB: 10,
-				UserDataSecret: &corev1.LocalObjectReference{
-					Name: userDataSecretName,
-				},
-				Network: machinev1.NetworkSpec{
-					Devices: staticIpAddressClaim,
-				},
-			},
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereStaticIPs)] = false
-				return fg
-			}(),
-			expectedError: errors.New("test-2: static IP/IPAM configuration is only available with the VSphereStaticIPs feature gate"),
-		},
-		{
-			name:        "Successfully create machine with static IP address claims when tech preview enabled",
+			name:        "Successfully create machine with static IP address claims",
 			machineName: "test-3",
 			providerSpec: machinev1.VSphereMachineProviderSpec{
 				Template: vmName,
@@ -2803,7 +2777,7 @@ func TestCreate(t *testing.T) {
 			ipAddress:      ipAddress,
 		},
 		{
-			name:        "Successfully create machine with static IP addresses when tech preview enabled",
+			name:        "Successfully create machine with static IP addresses",
 			machineName: "test-4",
 			providerSpec: machinev1.VSphereMachineProviderSpec{
 				Template: vmName,
@@ -2823,7 +2797,7 @@ func TestCreate(t *testing.T) {
 			},
 		},
 		{
-			name:        "Failed to create machine with static IP address claim when tech preview enabled due to waiting for IP",
+			name:        "Failed to create machine with static IP address claim due to waiting for IP",
 			machineName: "test-5",
 			providerSpec: machinev1.VSphereMachineProviderSpec{
 				Template: vmName,

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -475,7 +475,6 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 	// as args)
 	features := map[string]bool{
 		string(apifeatures.FeatureGateMachineAPIMigration):     featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
-		string(apifeatures.FeatureGateVSphereStaticIPs):        featureGates.Enabled(apifeatures.FeatureGateVSphereStaticIPs),
 		string(apifeatures.FeatureGateGCPLabelsTags):           featureGates.Enabled(apifeatures.FeatureGateGCPLabelsTags),
 		string(apifeatures.FeatureGateAzureWorkloadIdentity):   featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
 		string(apifeatures.FeatureGateVSphereMultiDisk):        featureGates.Enabled(apifeatures.FeatureGateVSphereMultiDisk),

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -42,7 +42,6 @@ const (
 var (
 	enabledFeatureGates = []openshiftv1.FeatureGateAttributes{
 		{Name: apifeatures.FeatureGateMachineAPIMigration},
-		{Name: apifeatures.FeatureGateVSphereStaticIPs},
 		{Name: apifeatures.FeatureGateGCPLabelsTags},
 		{Name: apifeatures.FeatureGateAzureWorkloadIdentity},
 		{Name: apifeatures.FeatureGateVSphereMultiDisk},
@@ -53,7 +52,6 @@ var (
 		"MachineAPIMigration":     true,
 		"GCPLabelsTags":           true,
 		"AzureWorkloadIdentity":   true,
-		"VSphereStaticIPs":        true,
 		"VSphereMultiDisk":        true,
 		"VSphereHostVMGroupZonal": true,
 	}

--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -182,7 +182,6 @@ func NewDefaultMutableFeatureGate() (featuregate.MutableFeatureGate, error) {
 	_, err := features.NewFeatureGateOptions(defaultMutableGate,
 		openshiftfeatures.SelfManaged,
 		openshiftfeatures.FeatureGateMachineAPIMigration,
-		openshiftfeatures.FeatureGateVSphereStaticIPs,
 		openshiftfeatures.FeatureGateVSphereHostVMGroupZonal,
 		openshiftfeatures.FeatureGateVSphereMultiDisk)
 	if err != nil {
@@ -191,7 +190,6 @@ func NewDefaultMutableFeatureGate() (featuregate.MutableFeatureGate, error) {
 	if err := defaultMutableGate.SetFromMap(
 		map[string]bool{
 			"MachineAPIMigration": true,
-			"VSphereStaticIPs":    true,
 			"VSphereMultiDisk":    true,
 		},
 	); err != nil {


### PR DESCRIPTION
[SPLAT-2078](https://issues.redhat.com//browse/SPLAT-2078)

### Changes
- Removed VSphereStaticIPs feature gate

### Notes
After a feature gate has been GA in an OCP release, we are supposed to clean up feature gate usage in the next release. VSphere static IP support GA'd in 4.16, so the intention is to remove the feature gate as part of 4.19.