### PR TITLE
OCPBUGS-55025: fix: nodelink use patch to apply machine's nodeRef

### DIFF
--- a/pkg/controller/nodelink/nodelink_controller.go
+++ b/pkg/controller/nodelink/nodelink_controller.go
@@ -259,6 +259,7 @@ func (r *ReconcileNodeLink) Reconcile(ctx context.Context, request reconcile.Req
 // updateNodeRef set the given node as nodeRef in the machine status
 func (r *ReconcileNodeLink) updateNodeRef(machine *machinev1.Machine, node *corev1.Node) error {
 	now := metav1.Now()
+	machineCopy := machine.DeepCopy()
 	machine.Status.LastUpdated = &now
 
 	if !node.DeletionTimestamp.IsZero() {
@@ -280,7 +281,7 @@ func (r *ReconcileNodeLink) updateNodeRef(machine *machinev1.Machine, node *core
 		Name: node.GetName(),
 		UID:  node.GetUID(),
 	}
-	if err := r.client.Status().Update(context.Background(), machine); err != nil {
+	if err := r.client.Status().Patch(context.Background(), machine, client.MergeFrom(machineCopy)); err != nil {
 		return fmt.Errorf("error updating machine %q: %v", machine.GetName(), err)
 	}
 	r.nodeReadinessCache[node.GetName()] = nodeReady


### PR DESCRIPTION
### Fix
Use patch to apply machine's nodeRef, to retain the `.status.synchronizedGeneration` field previously set by the migration/sync controllers. 

---

### Context
I found an conflicting issue between the migration/sync controllers, the nodelink controller and the CPMSO.
A cluster with MachineAPIMigration=true is installed
- The installer creates control plane machines, which gets registered with the cluster
- The installer applies/creates control plane machines objects in the cluster
- The migration controller gets notified about a machine event, and reconciles, finds the .status.authoritativeAPI is empty and propagates the value from .spec.authoritativeAPI to it [a] (logs here)
In the meanwhile the CPMSO hasn't started up yet (see logs here) so no owner reference of the CPMSO is set on the control plane machines
- The sync controller can now reconcile the machine as it has .status.authoritativeAPI, goes into reconcileMAPIMachinetoCAPIMachine() , hits the if len(mapiMachine.OwnerReferences) == 0 { case here, and carries on to r.convertMAPIToCAPIMachine(mapiMachine), here it errors because control plane machines have the loadbalancers set (we are unable to covert it at this point), so it applies the synchronized=false and synchronizedGeneration=0 (this is crucial) [b]
- The nodelink controller finally wakes up, and tries to set the nodeRef on the control plane machines to the corresponding nodes. But it fails [c] because it attempts an update to the control plane machine's status (to set the noderef) without specifying the synchronizedGeneration , which was previously and erroneously set, and goes against the openAPI validation we have for the authoritativeAPI <> synchronizedGeneration status fields.
This yields prevents the control plane nodes to go into Running state and renders them un-adoptable by the CPMSO, which goes into Available=False making the entire Cluster initialization to fail, and the installation with it.

[a]
```
I0414 17:22:31.708923       1 machine_migration_controller.go:355] "Setting AuthoritativeAPI status to \"MachineAPI\" for resource" controller="MachineMigrationController" controllerGroup="machine.openshift.io" controllerKind="Machine" Machine="openshift-machine-api/ci-op-zd4rxsg5-c9e33-kjczc-master-0" namespace="openshift-machine-api" name="ci-op-zd4rxsg5-c9e33-kjczc-master-0" reconcileID="ad911656-fecc-408b-b472-267f9d0c2a82" namespace="openshift-machine-api" name="ci-op-zd4rxsg5-c9e33-kjczc-master-0"
```

[b]
```
E0414 17:22:41.795328       1 controller.go:316] "Reconciler error" err="failed to convert Machine API machine to Cluster API machine: spec.providerSpec.value.loadBalancers: Invalid value: []v1beta1.LoadBalancerReference{v1beta1.LoadBalancerReference{Name:\"ci-op-zd4rxsg5-c9e33-kjczc-int\", Type:\"network\"}, v1beta1.LoadBalancerReference{Name:\"ci-op-zd4rxsg5-c9e33-kjczc-ext\", Type:\"network\"}}: loadBalancers are not supported" controller="MachineSyncController" controllerGroup="machine.openshift.io" controllerKind="Machine" Machine="openshift-machine-api/ci-op-zd4rxsg5-c9e33-kjczc-master-0" namespace="openshift-machine-api" name="ci-op-zd4rxsg5-c9e33-kjczc-master-0" reconcileID="2c4e9bb8-0947-44ab-9137-04e08d5b9473" 
```

[c]
```
E0414 17:26:25.242119       1 controller.go:341] "Reconciler error" err="error updating nodeRef for machine \"ci-op-zd4rxsg5-c9e33-kjczc-master-1\" and node \"ip-10-0-32-19.ec2.internal\": error updating machine \"ci-op-zd4rxsg5-c9e33-kjczc-master-1\": Machine.machine.openshift.io \"ci-op-zd4rxsg5-c9e33-kjczc-master-1\" is invalid: status.synchronizedGeneration: Invalid value: \"object\": synchronizedGeneration must not decrease unless authoritativeAPI is transitioning from Migrating to another value" controller="nodelink-controller" object="ip-10-0-32-19.ec2.internal" namespace="" name="ip-10-0-32-19.ec2.internal" reconcileID="e3427d0e-a70b-4aa1-8799-89639410f484"
```