### PR TITLE
OCPBUGS-55083: Updates GCP CredentialsRequest

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -176,6 +176,7 @@ spec:
     - "compute.healthChecks.useReadOnly"
     - "compute.images.get"
     - "compute.images.getFromFamily"
+    - "compute.images.useReadOnly"
     - "compute.instanceGroups.create"
     - "compute.instanceGroups.delete"
     - "compute.instanceGroups.get"


### PR DESCRIPTION
- Adds compute.images.useReadOnly, which is required for provisioning additional disks.