### PR TITLE
SPLAT-2180: Added conformance label

### DIFF
--- a/test/e2e/vsphere/machines.go
+++ b/test/e2e/vsphere/machines.go
@@ -23,7 +23,7 @@ const (
 	machineReadyTimeout = time.Minute * 6
 )
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platform:vsphere] Managed cluster should", func() {
+var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platform:vsphere] Managed cluster should", Label("Conformance"), func() {
 	defer GinkgoRecover()
 	ctx := context.Background()
 
@@ -46,7 +46,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platf
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("create machines with data disks [apigroup:machine.openshift.io]", func() {
+	It("create machines with data disks [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", func() {
 		machineName := "machine-multi-test"
 		dataDisks := []v1beta1.VSphereDisk{
 			{
@@ -156,28 +156,28 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platf
 		err = mc.MachineSets(util.MachineAPINamespace).Delete(ctx, ddMachineSet.Name, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	},
-		Entry("with thin data disk [apigroup:machine.openshift.io]", "ms-thin-test", []v1beta1.VSphereDisk{
+		Entry("with thin data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", "ms-thin-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thickDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeThick,
 			},
 		}),
-		Entry("with thick data disk [apigroup:machine.openshift.io]", "ms-thick-test", []v1beta1.VSphereDisk{
+		Entry("with thick data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", "ms-thick-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thickDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeThick,
 			},
 		}),
-		Entry("with eagerly zeroed data disk [apigroup:machine.openshift.io]", "ms-zeroed-test", []v1beta1.VSphereDisk{
+		Entry("with eagerly zeroed data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", "ms-zeroed-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "zeroedDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeEagerlyZeroed,
 			},
 		}),
-		Entry("with a data disk using each provisioning mode [apigroup:machine.openshift.io]", "ms-multi-test", []v1beta1.VSphereDisk{
+		Entry("with a data disk using each provisioning mode [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", "ms-multi-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thinDataDisk",
 				SizeGiB:          1,

--- a/test/e2e/vsphere/multi-nic.go
+++ b/test/e2e/vsphere/multi-nic.go
@@ -190,24 +190,24 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiNetworks][p
 		}
 	})
 
-	It("node addresses should be correlated with the machine network", func() {
+	It("node addresses should be correlated with the machine network [Suite:openshift/conformance/parallel]", func() {
 		By("checking for correlation between node internal/external IPs and the machine network")
 		failIfNodeNotInMachineNetwork(*nodes, machineNetworks)
 	})
 
-	It("machine network should be correlated with node networking", func() {
+	It("machine network should be correlated with node networking [Suite:openshift/conformance/parallel]", func() {
 		failIfNodeNetworkingInconsistentWithMachineNetwork(infra.Spec.PlatformSpec, machineNetworks)
 	})
 
-	It("machines should have all specified portgroup associated with their failure domain", func() {
+	It("machines should have all specified portgroup associated with their failure domain [Suite:openshift/conformance/parallel]", func() {
 		failIfMachinesDoNotHaveAllPortgroups(infra.Spec.PlatformSpec, machines)
 	})
 
-	It("node VMs should have all specified portgroups attached which are associated with their failure domain", func() {
+	It("node VMs should have all specified portgroups attached which are associated with their failure domain [Suite:openshift/conformance/parallel]", func() {
 		failIfIncorrectPortgroupsAttachedToVMs(ctx, infra.Spec.PlatformSpec, nodes, vsphereCreds)
 	})
 
-	It("new machines should pass multi network tests", func() {
+	It("new machines should pass multi network tests [Suite:openshift/conformance/parallel]", func() {
 		machineSets, err := e2eutil.GetMachineSets(cfg)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
[SPLAT-2180](https://issues.redhat.com//browse/SPLAT-2180)

### Changes
- Added `Conformance` label to e2e tests (for future way)
- Added `[Suite:openshift/conformance/parallel]` to e2e tests for legacy (current) technique

### Notes
Currently when nightlies run, the new openshift test extensions are being seen, but not ran.  Adding the `Conformance` label to the tests so they are included in the parallel suite.

openshift-tests-ext has a way for adding your files to parent suites; however, this is not functional at this time.  

This PR will need to be backported to 4.19