### PR TITLE
OCPBUGS-55461: Fix updateMachineSetStatus nil pointer

### DIFF
--- a/pkg/controller/machineset/controller.go
+++ b/pkg/controller/machineset/controller.go
@@ -190,7 +190,7 @@ func (r *ReconcileMachineSet) Reconcile(ctx context.Context, request reconcile.R
 
 			machineSet, err := updateMachineSetStatus(r.Client, machineSet, machineSetCopy.Status)
 			if err != nil {
-				klog.Errorf("%v: error updating status: %v", machineSet.Name, err)
+				klog.Errorf("%v: error updating status: %v", machineSetCopy.Name, err)
 			}
 
 			klog.Infof("%v: machine set is paused, taking no further action", machineSet.Name)
@@ -214,7 +214,7 @@ func (r *ReconcileMachineSet) Reconcile(ctx context.Context, request reconcile.R
 		))
 		machineSet, err := updateMachineSetStatus(r.Client, machineSet, machineSetCopy.Status)
 		if err != nil {
-			klog.Errorf("%v: error updating status: %v", machineSet.Name, err)
+			klog.Errorf("%v: error updating status: %v", machineSetCopy.Name, err)
 		}
 		klog.Infof("%v: setting paused to false and continuing reconcile", machineSet.Name)
 	}


### PR DESCRIPTION
This change updates the error log to rely on the machineSetCopy, rather than the machineSet passed to be updated.

This is because the machineSet may be nil if the update fails, due to the get at the end of updateMachineSetStatus.