### PR TITLE
OCPBUGS-55720: fix: use patch for machine/machineset status

### DIFF
--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -756,6 +756,7 @@ func TestUpdateStatus(t *testing.T) {
 					t.Fatalf("error deleting machine: %v", err)
 				}
 			}()
+			machineCopy := machine.DeepCopy()
 
 			if tc.existingProviderStatus != "" {
 				machine.Status.ProviderStatus = &runtime.RawExtension{
@@ -763,7 +764,7 @@ func TestUpdateStatus(t *testing.T) {
 				}
 			}
 
-			gs.Expect(k8sClient.Status().Update(ctx, machine)).To(Succeed())
+			gs.Expect(k8sClient.Status().Patch(ctx, machine, client.MergeFrom(machineCopy))).To(Succeed())
 
 			namespacedName := types.NamespacedName{
 				Namespace: machine.Namespace,


### PR DESCRIPTION
In a similar vein of https://github.com/openshift/machine-api-operator/pull/1352

Use patch to apply machine's status, to retain the .status.synchronizedGeneration field previously set by the migration/sync controllers.

