### PR TITLE
OCPBUGS-55461: Changed machineset tests to be serial

### DIFF
--- a/test/e2e/util.go
+++ b/test/e2e/util.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/api/machine/v1beta1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned"
 	machinesetclient "github.com/openshift/client-go/machine/clientset/versioned/typed/machine/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,6 +177,13 @@ func CreateMachine(ctx context.Context, cfg *rest.Config, mc *machinesetclient.M
 			ProviderSpec: v1beta1.ProviderSpec{
 				Value: provider,
 			},
+			Taints: []v1.Taint{
+				{
+					Effect: v1.TaintEffectNoSchedule,
+					Key:    "mapi-e2e",
+					Value:  "yes",
+				},
+			},
 		},
 	}
 
@@ -222,6 +230,13 @@ func CreateMachineSet(ctx context.Context, cfg *rest.Config, mc *machinesetclien
 					ObjectMeta:     v1beta1.ObjectMeta{},
 					ProviderSpec: v1beta1.ProviderSpec{
 						Value: provider,
+					},
+					Taints: []v1.Taint{
+						{
+							Effect: v1.TaintEffectNoSchedule,
+							Key:    "mapi-e2e",
+							Value:  "yes",
+						},
 					},
 				},
 			},

--- a/test/e2e/vsphere/machines.go
+++ b/test/e2e/vsphere/machines.go
@@ -19,11 +19,11 @@ import (
 )
 
 const (
-	machineRole         = "e2e-test"
+	machineRole         = "feature-gate-test"
 	machineReadyTimeout = time.Minute * 6
 )
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platform:vsphere] Managed cluster should", func() {
+var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platform:vsphere][Disruptive] Managed cluster should", Label("Conformance"), Label("Serial"), func() {
 	defer GinkgoRecover()
 	ctx := context.Background()
 
@@ -46,7 +46,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platf
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("create machines with data disks [apigroup:machine.openshift.io]", func() {
+	It("create machines with data disks [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", func() {
 		machineName := "machine-multi-test"
 		dataDisks := []v1beta1.VSphereDisk{
 			{
@@ -151,33 +151,43 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platf
 		err = util.ScaleMachineSet(cfg, ddMachineSet.Name, 0)
 		Expect(err).NotTo(HaveOccurred())
 
+		// Verify / wait for machine is removed
+		By("verifying machine is destroyed")
+		Eventually(func() (int32, error) {
+			ms, err := mc.MachineSets(util.MachineAPINamespace).Get(ctx, ddMachineSet.Name, metav1.GetOptions{})
+			if err != nil {
+				return -1, err
+			}
+			return ms.Status.ReadyReplicas, nil
+		}, machineReadyTimeout).Should(BeEquivalentTo(0))
+
 		// Delete machineset
 		By("deleting the machineset")
 		err = mc.MachineSets(util.MachineAPINamespace).Delete(ctx, ddMachineSet.Name, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	},
-		Entry("with thin data disk [apigroup:machine.openshift.io]", "ms-thin-test", []v1beta1.VSphereDisk{
+		Entry("with thin data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", "ms-thin-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thickDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeThick,
 			},
 		}),
-		Entry("with thick data disk [apigroup:machine.openshift.io]", "ms-thick-test", []v1beta1.VSphereDisk{
+		Entry("with thick data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", "ms-thick-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thickDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeThick,
 			},
 		}),
-		Entry("with eagerly zeroed data disk [apigroup:machine.openshift.io]", "ms-zeroed-test", []v1beta1.VSphereDisk{
+		Entry("with eagerly zeroed data disk [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", "ms-zeroed-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "zeroedDataDisk",
 				SizeGiB:          1,
 				ProvisioningMode: v1beta1.ProvisioningModeEagerlyZeroed,
 			},
 		}),
-		Entry("with a data disk using each provisioning mode [apigroup:machine.openshift.io]", "ms-multi-test", []v1beta1.VSphereDisk{
+		Entry("with a data disk using each provisioning mode [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", "ms-multi-test", []v1beta1.VSphereDisk{
 			{
 				Name:             "thinDataDisk",
 				SizeGiB:          1,

--- a/test/e2e/vsphere/multi-nic.go
+++ b/test/e2e/vsphere/multi-nic.go
@@ -215,7 +215,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiNetworks][p
 		failIfIncorrectPortgroupsAttachedToVMs(ctx, infra.Spec.PlatformSpec, nodes, vsphereCreds)
 	})
 
-	It("new machines should pass multi network tests [apigroup:machine.openshift.io][Suite:openshift/conformance/parallel]", func() {
+	It("new machines should pass multi network tests [apigroup:machine.openshift.io][Suite:openshift/conformance/serial]", Label("Serial"), func() {
 		machineSets, err := e2eutil.GetMachineSets(cfg)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
[OCPBUGS-55461](https://issues.redhat.com/browse/OCPBUGS-55461)

### Changes
- Changed machineset tests to run in serial suite instead of parallel (both data disk and nic tests)
- Added taints to machinesets to prevent unnecessary pod scheduling
- Modified NIC machineset test to not look at all VMs in the failure domain, but rather focus on ones with the cluster's tag on them.
- Included following changes from past reverts:
  - Added check for multi network config before running test
  - Updated multi network tests to have apigroup label
  - Added [Suite:openshift/conformance/parallel] to e2e tests for legacy (current) technique
  - Added Conformance label to e2e tests (for future way)

### Notes
This PR is fixing issues found via this bug.  There were several issues found.
- Panic when interacting with migration TP feature gate
- NIC tests were failing due to changes made in installer by different feature / bug
- Machineset e2e tests are causing cluster instability