### PR TITLE
[release-4.19] OCPBUGS-55706: fix: use patch for machine/machineset status

### DIFF
--- a/pkg/controller/machine/controller_test.go
+++ b/pkg/controller/machine/controller_test.go
@@ -756,6 +756,7 @@ func TestUpdateStatus(t *testing.T) {
 					t.Fatalf("error deleting machine: %v", err)
 				}
 			}()
+			machineCopy := machine.DeepCopy()
 
 			if tc.existingProviderStatus != "" {
 				machine.Status.ProviderStatus = &runtime.RawExtension{
@@ -763,7 +764,7 @@ func TestUpdateStatus(t *testing.T) {
 				}
 			}
 
-			gs.Expect(k8sClient.Status().Update(ctx, machine)).To(Succeed())
+			gs.Expect(k8sClient.Status().Patch(ctx, machine, client.MergeFrom(machineCopy))).To(Succeed())
 
 			namespacedName := types.NamespacedName{
 				Namespace: machine.Namespace,


### PR DESCRIPTION
Manual backport of https://github.com/openshift/machine-api-operator/pull/1362

Superseeds https://github.com/openshift/machine-api-operator/pull/1364