### PR TITLE
OCPBUGS-56159: correct aws kms permissions

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -45,6 +45,7 @@ spec:
       resource: "*"
     - effect: Allow
       action:
+      - 'kms:ReEncrypt*'
       - kms:Decrypt
       - kms:Encrypt
       - kms:GenerateDataKey


### PR DESCRIPTION
- In **[AWS official doc](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption-requirements.html)** the ebs volume kms encryption needs the follow permissions ->
```console
- kms:CreateGrant
- kms:Decrypt
- kms:DescribeKey
- kms:GenerateDataKeyWithoutPlainText
- kms:ReEncrypt
```
Using customer kms key create machine in the local zone failed caused by missed `kms:ReEncrypt` permission.
![image](https://github.com/user-attachments/assets/f796caf1-ac31-4487-9986-39b52c5d060d)