### PR TITLE
Revert "OCPCLOUD-2986,OCPBUGS-56849: fix: controllers: guard on empty .status.authoritativeAPI"

### DIFF
--- a/pkg/controller/machine/machine_controller_test.go
+++ b/pkg/controller/machine/machine_controller_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Machine Reconciler", func() {
 
 		It("Should set the Paused condition appropriately", func() {
 
-			By("Creating the Machine (empty status.authoritativeAPI)")
+			By("Creating the Machine")
 			Expect(k8sClient.Create(ctx, instance)).To(Succeed())
 
 			By("Setting the AuthoritativeAPI to ClusterAPI")
@@ -143,12 +143,11 @@ var _ = Describe("Machine Reconciler", func() {
 				instance.Status.AuthoritativeAPI = machinev1.MachineAuthorityClusterAPI
 			})).Should(Succeed())
 
-			By("Verifying the paused condition is appropriately set to true")
+			By("Verifying the paused condition is approproately set to true")
 			Eventually(k.Object(instance), timeout).Should(SatisfyAll(
 				HaveField("Status.Conditions", ContainElement(SatisfyAll(
 					HaveField("Type", Equal(PausedCondition)),
 					HaveField("Status", Equal(corev1.ConditionTrue)),
-					HaveField("Message", Equal("The AuthoritativeAPI status is set to 'ClusterAPI'")),
 				))),
 				HaveField("Status.AuthoritativeAPI", Equal(machinev1.MachineAuthorityClusterAPI)),
 			))
@@ -190,50 +189,36 @@ var _ = Describe("Machine Reconciler", func() {
 					})
 			}()
 
-			By("Changing status.authoritativeAPI from ClusterAPI to Migrating")
+			By("Transitioning the AuthoritativeAPI though 'Migrating' to MachineAPI")
 			Eventually(k.UpdateStatus(instance, func() {
 				instance.Status.AuthoritativeAPI = machinev1.MachineAuthorityMigrating
 			})).Should(Succeed())
 
-			By("Verifying the paused condition is appropriately set to true")
-			Eventually(k.Object(instance), timeout).Should(SatisfyAll(
-				HaveField("Status.Conditions", ContainElement(SatisfyAll(
-					HaveField("Type", Equal(PausedCondition)),
-					HaveField("Status", Equal(corev1.ConditionTrue)),
-					HaveField("Message", Equal("The AuthoritativeAPI status is set to 'Migrating'")),
-				))),
-				HaveField("Status.AuthoritativeAPI", Equal(machinev1.MachineAuthorityMigrating)),
-			))
-
-			By("Changing status.authoritativeAPI from Migrating to MachineAPI")
+			By("Updating the AuthoritativeAPI from Migrating to MachineAPI")
 			Eventually(k.UpdateStatus(instance, func() {
 				instance.Status.AuthoritativeAPI = machinev1.MachineAuthorityMachineAPI
 			})).Should(Succeed())
 
-			By("Verifying the paused condition is appropriately set to false")
+			By("Verifying the paused condition is approproately set to false")
 			Eventually(k.Object(instance), timeout).Should(SatisfyAll(
 				HaveField("Status.Conditions", ContainElement(SatisfyAll(
 					HaveField("Type", Equal(PausedCondition)),
 					HaveField("Status", Equal(corev1.ConditionFalse)),
-					HaveField("Message", Equal("The AuthoritativeAPI status is set to 'MachineAPI'")),
 				))),
 				HaveField("Status.AuthoritativeAPI", Equal(machinev1.MachineAuthorityMachineAPI)),
 			))
 
-			By("Changing status.authoritativeAPI from MachineAPI to empty")
+			By("Unsetting the AuthoritativeAPI field in the status")
 			Eventually(k.UpdateStatus(instance, func() {
 				instance.Status.AuthoritativeAPI = ""
 			})).Should(Succeed())
 
-			By("Verifying the paused condition is still appropriately set to true when empty status.authoritativeAPI")
-			Eventually(k.Object(instance), timeout).Should(SatisfyAll(
-				HaveField("Status.Conditions", ContainElement(SatisfyAll(
-					HaveField("Type", Equal(PausedCondition)),
-					HaveField("Status", Equal(corev1.ConditionTrue)),
-					HaveField("Message", Equal("The AuthoritativeAPI status is not yet set")),
-				))),
-				HaveField("Status.AuthoritativeAPI", BeEquivalentTo("")),
-			))
+			By("Verifying the paused condition is still approproately set to false")
+			Eventually(k.Object(instance), timeout).Should(HaveField("Status.Conditions", ContainElement(SatisfyAll(
+				HaveField("Type", Equal(PausedCondition)),
+				HaveField("Status", Equal(corev1.ConditionFalse)),
+				HaveField("Message", Equal("The AuthoritativeAPI is not set")),
+			))))
 		})
 	})
 })

--- a/pkg/util/conditions/gettersetter.go
+++ b/pkg/util/conditions/gettersetter.go
@@ -151,20 +151,6 @@ func IsFalse(from interface{}, t machinev1.ConditionType) bool {
 	return false
 }
 
-// IsEquivalentTo returns true if condition a is equivalent to condition b,
-// by checking for equality of the following fields: Type, Status, Reason, Severity and Message (it excludes LastTransitionTime).
-func IsEquivalentTo(a, b *machinev1.Condition) bool {
-	if a == nil && b == nil {
-		return true
-	} else if a == nil {
-		return false
-	} else if b == nil {
-		return false
-	}
-
-	return hasSameState(a, b)
-}
-
 // lexicographicLess returns true if a condition is less than another with regards to the
 // to order of conditions designed for convenience of the consumer, i.e. kubectl.
 func lexicographicLess(i, j *machinev1.Condition) bool {


### PR DESCRIPTION
Reverts openshift/machine-api-operator#1380