### PR TITLE
Oape 232

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -475,7 +475,6 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 	// as args)
 	features := map[string]bool{
 		string(apifeatures.FeatureGateMachineAPIMigration):     featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
-		string(apifeatures.FeatureGateGCPLabelsTags):           featureGates.Enabled(apifeatures.FeatureGateGCPLabelsTags),
 		string(apifeatures.FeatureGateAzureWorkloadIdentity):   featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
 		string(apifeatures.FeatureGateVSphereMultiDisk):        featureGates.Enabled(apifeatures.FeatureGateVSphereMultiDisk),
 		string(apifeatures.FeatureGateVSphereHostVMGroupZonal): featureGates.Enabled(apifeatures.FeatureGateVSphereHostVMGroupZonal),

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -42,7 +42,6 @@ const (
 var (
 	enabledFeatureGates = []openshiftv1.FeatureGateAttributes{
 		{Name: apifeatures.FeatureGateMachineAPIMigration},
-		{Name: apifeatures.FeatureGateGCPLabelsTags},
 		{Name: apifeatures.FeatureGateAzureWorkloadIdentity},
 		{Name: apifeatures.FeatureGateVSphereMultiDisk},
 		{Name: apifeatures.FeatureGateVSphereHostVMGroupZonal},
@@ -50,7 +49,6 @@ var (
 
 	enabledFeatureMap = map[string]bool{
 		"MachineAPIMigration":     true,
-		"GCPLabelsTags":           true,
 		"AzureWorkloadIdentity":   true,
 		"VSphereMultiDisk":        true,
 		"VSphereHostVMGroupZonal": true,

--- a/test/e2e/vsphere/multi-nic.go
+++ b/test/e2e/vsphere/multi-nic.go
@@ -212,7 +212,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiNetworks][p
 			}
 		}
 
-		for k, _ := range portGroups {
+		for k := range portGroups {
 			machinePortgroups = append(machinePortgroups, k)
 		}
 	})
@@ -264,7 +264,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiNetworks][p
 			}
 		}
 
-		for k, _ := range portGroups {
+		for k := range portGroups {
 			machinePortgroups = append(machinePortgroups, k)
 		}
 


### PR DESCRIPTION
PR contains below commits
- Removes feature gates checks for configuring GCP labels and tags, as the feature is GA.
- Changes suggested by fmt tool.

Required for https://github.com/openshift/api/pull/2372