### PR TITLE
[release-4.18] OCPBUGS-59387: Enabled 10 concurrent reconciles on GCP

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -670,7 +670,7 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 
 	machineControllerArgs := append([]string{}, featureGateArgs...)
 	switch config.PlatformType {
-	case v1.AzurePlatformType:
+	case v1.AzurePlatformType, v1.GCPPlatformType:
 		machineControllerArgs = append(machineControllerArgs, "--max-concurrent-reconciles=10")
 	}
 


### PR DESCRIPTION
Depends on https://github.com/openshift/machine-api-provider-gcp/pull/126

Enables the new max-concurrent-reconciles flag on GCP to speed up processing of deep reconcile queues