### PR TITLE
GCP - Add exception for onHostMaintenance Migrate on confidential compute n2d instances

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1353,6 +1353,12 @@ func validateGCPConfidentialComputing(providerSpec *machinev1beta1.GCPMachinePro
 					fmt.Sprintf("ConfidentialCompute %s requires a machine type in the following series: %s", providerSpec.ConfidentialCompute, strings.Join(gcpConfidentialTypeMachineSeriesSupportingSEVSNP, `,`))),
 				)
 			}
+			// Check on host maintenance for ConfidentialComputePolicySEVSNP
+			if providerSpec.OnHostMaintenance != machinev1beta1.TerminateHostMaintenanceType {
+				errs = append(errs, field.Invalid(field.NewPath("providerSpec", "onHostMaintenance"),
+					providerSpec.OnHostMaintenance,
+					fmt.Sprintf("ConfidentialCompute %s requires OnHostMaintenance to be set to %s, the current value is: %s", providerSpec.ConfidentialCompute, machinev1beta1.TerminateHostMaintenanceType, providerSpec.OnHostMaintenance)))
+			}
 		case machinev1beta1.ConfidentialComputePolicyTDX:
 			if !slices.Contains(gcpConfidentialTypeMachineSeriesSupportingTDX, machineSeries) {
 				errs = append(errs, field.Invalid(field.NewPath("providerSpec", "machineType"),

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -4023,7 +4023,8 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 				p.MachineType = "n2d-standard-4"
 				p.GPUs = []machinev1beta1.GCPGPUConfig{}
 			},
-			expectedOk: true,
+			expectedOk:    false,
+			expectedError: "providerSpec.onHostMaintenance: Invalid value: \"Migrate\": ConfidentialCompute AMDEncryptedVirtualizationNestedPaging requires OnHostMaintenance to be set to Terminate, the current value is: Migrate",
 		},
 		{
 			testCase: "with ConfidentialCompute IntelTrustedDomainExtensions and an unsupported machine",

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -3934,11 +3934,21 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			expectedError: "providerSpec.confidentialCompute: Invalid value: \"invalid-value\": ConfidentialCompute must be Enabled, Disabled, AMDEncryptedVirtualization, AMDEncryptedVirtualizationNestedPaging, or IntelTrustedDomainExtensions",
 		},
 		{
-			testCase: "with ConfidentialCompute enabled while onHostMaintenance is set to Migrate",
+			testCase: "with ConfidentialCompute enabled while onHostMaintenance is set to Migrate on n2d instances",
 			modifySpec: func(p *machinev1beta1.GCPMachineProviderSpec) {
 				p.ConfidentialCompute = machinev1beta1.ConfidentialComputePolicyEnabled
 				p.OnHostMaintenance = machinev1beta1.MigrateHostMaintenanceType
 				p.MachineType = "n2d-standard-4"
+				p.GPUs = []machinev1beta1.GCPGPUConfig{}
+			},
+			expectedOk: true,
+		},
+		{
+			testCase: "with ConfidentialCompute enabled while onHostMaintenance is set to Migrate on non n2d instances (c2d)",
+			modifySpec: func(p *machinev1beta1.GCPMachineProviderSpec) {
+				p.ConfidentialCompute = machinev1beta1.ConfidentialComputePolicyEnabled
+				p.OnHostMaintenance = machinev1beta1.MigrateHostMaintenanceType
+				p.MachineType = "c2d-standard-4"
 				p.GPUs = []machinev1beta1.GCPGPUConfig{}
 			},
 			expectedOk:    false,
@@ -4006,15 +4016,14 @@ func TestValidateGCPProviderSpec(t *testing.T) {
 			expectedError: "",
 		},
 		{
-			testCase: "with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and onHostMaintenance set to Migrate",
+			testCase: "with ConfidentialCompute AMDEncryptedVirtualizationNestedPaging and onHostMaintenance set to Migrate on n2d instances",
 			modifySpec: func(p *machinev1beta1.GCPMachineProviderSpec) {
 				p.ConfidentialCompute = machinev1beta1.ConfidentialComputePolicySEVSNP
 				p.OnHostMaintenance = machinev1beta1.MigrateHostMaintenanceType
 				p.MachineType = "n2d-standard-4"
 				p.GPUs = []machinev1beta1.GCPGPUConfig{}
 			},
-			expectedOk:    false,
-			expectedError: "providerSpec.onHostMaintenance: Invalid value: \"Migrate\": ConfidentialCompute AMDEncryptedVirtualizationNestedPaging requires OnHostMaintenance to be set to Terminate, the current value is: Migrate",
+			expectedOk: true,
 		},
 		{
 			testCase: "with ConfidentialCompute IntelTrustedDomainExtensions and an unsupported machine",


### PR DESCRIPTION
This PR closes #1405 

# Context

Provisionning Machines on GCP Provider
With confidential compute enabled
Try to set onHostMaintenance to Migrate

# Current Issue

Today the webhook refused this case, as it is forbidden by default on GCP.

But an exception exists on n2d series
See this doc for information : https://cloud.google.com/confidential-computing/confidential-vm/docs/troubleshoot-live-migration

# Resolution

Add an exception on the webhhook for the n2d series VM, and accept the Migrate onHostMaintenance

# Environment

This issue is present on Openshift 4.16, 4.18 and 4.19 for sure
