### PR TITLE
OCPBUGS-66244: azure: remove image defaulting

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -65,18 +65,6 @@ var (
 	defaultAzureNetworkResourceGroup = func(clusterID string) string {
 		return fmt.Sprintf("%s-rg", clusterID)
 	}
-	defaultAzureImageResourceID = func(clusterID string) string {
-		// image gallery names cannot have dashes
-		galleryName := strings.Replace(clusterID, "-", "_", -1)
-		imageName := clusterID
-		if arch == ARM64 {
-			// append gen2 to the image name for ARM64.
-			// Although the installer creates a gen2 image for AMD64, we cannot guarantee that clusters created
-			// before that change will have a -gen2 image.
-			imageName = fmt.Sprintf("%s-gen2", clusterID)
-		}
-		return fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", clusterID+"-rg", galleryName, imageName, azureRHCOSVersion)
-	}
 	defaultAzureManagedIdentiy = func(clusterID string) string {
 		return fmt.Sprintf("%s-identity", clusterID)
 	}
@@ -1009,10 +997,6 @@ func defaultAzure(m *machinev1beta1.Machine, config *admissionConfig) (bool, []s
 	if providerSpec.Vnet == "" && providerSpec.Subnet == "" {
 		providerSpec.Vnet = defaultAzureVnet(config.clusterID)
 		providerSpec.Subnet = defaultAzureSubnet(config.clusterID)
-	}
-
-	if providerSpec.Image == (machinev1beta1.Image{}) {
-		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID)
 	}
 
 	if providerSpec.UserDataSecret == nil {

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -557,6 +557,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -570,6 +571,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB:  128,
 						CachingType: "ReadOnly",
@@ -587,6 +589,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 						DiskSettings: machinev1beta1.DiskSettings{
@@ -603,6 +606,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB:  128,
 						CachingType: "ReadOnly",
@@ -617,6 +621,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB:  128,
 						CachingType: "INVALID",
@@ -631,6 +636,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB:  128,
 						CachingType: "ReadWrite",
@@ -648,6 +654,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -663,6 +670,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -676,6 +684,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -697,6 +706,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -721,6 +731,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -735,6 +746,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -749,6 +761,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -763,6 +776,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -787,6 +801,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -814,6 +829,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -837,6 +853,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -860,6 +877,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -883,6 +901,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -911,6 +930,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -932,6 +952,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -959,6 +980,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -980,6 +1002,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1001,6 +1024,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1028,6 +1052,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1041,6 +1066,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1054,6 +1080,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1066,6 +1093,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1081,6 +1109,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1108,6 +1137,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1134,6 +1164,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1159,6 +1190,7 @@ func TestMachineCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &kruntime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -1713,7 +1745,10 @@ func TestMachineUpdate(t *testing.T) {
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
 		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
+			Publisher: "test-publisher",
+			Offer:     "test-offer",
+			SKU:       "test-sku",
+			Version:   "test-version",
 		},
 		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),
@@ -3768,7 +3803,10 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 				Vnet:   defaultAzureVnet(clusterID),
 				Subnet: defaultAzureSubnet(clusterID),
 				Image: machinev1beta1.Image{
-					ResourceID: defaultAzureImageResourceID(clusterID),
+					Publisher: "test-publisher",
+					Offer:     "test-offer",
+					SKU:       "test-sku",
+					Version:   "test-version",
 				},
 				UserDataSecret: &corev1.SecretReference{
 					Name: defaultUserDataSecret,

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -150,6 +150,7 @@ func TestMachineSetCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					Location: "location",
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
@@ -164,6 +165,7 @@ func TestMachineSetCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -179,6 +181,7 @@ func TestMachineSetCreation(t *testing.T) {
 			clusterID:    "azure-cluster",
 			providerSpecValue: &runtime.RawExtension{
 				Object: &machinev1beta1.AzureMachineProviderSpec{
+					Image: machinev1beta1.Image{ResourceID: "test-image-id"},
 					OSDisk: machinev1beta1.OSDisk{
 						DiskSizeGB: 128,
 					},
@@ -603,7 +606,10 @@ func TestMachineSetUpdate(t *testing.T) {
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
 		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
+			Publisher: "test-publisher",
+			Offer:     "test-offer",
+			SKU:       "test-sku",
+			Version:   "test-version",
 		},
 		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),


### PR DESCRIPTION
Note: For now we went for an alternative approach here: https://github.com/openshift/machine-api-operator/pull/1441

--

Removes the default image value populated by the webhook. Uses existing validation to ensure the image id is populated.

The installer switched to defaulting to marketplace images, and no longer creates a cluster-specific image gallery (or managed image). So the default value populated by the webhook is no longer correct. The behavior now is similar to AWS, which requires an image be specified. 

We will also need to fix the tests to provide the image value.

/hold

I ran out of time, and still need to fix up a few unit tests, but wanted to get this open for feedback.

I realize this is not ideal to remove the defaulting behavior, but the existing defaulting behavior is quite buggy as well.