### PR TITLE
OCPBUGS-66244: default Azure to marketplace image

### DIFF
--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -1712,11 +1712,9 @@ func TestMachineUpdate(t *testing.T) {
 		Vnet:                 defaultAzureVnet(azureClusterID),
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
-		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
-		},
-		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
-		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),
+		Image:                defaultAzureImage(),
+		ManagedIdentity:      defaultAzureManagedIdentiy(azureClusterID),
+		ResourceGroup:        defaultAzureResourceGroup(azureClusterID),
 		UserDataSecret: &corev1.SecretReference{
 			Name:      defaultUserDataSecret,
 			Namespace: defaultSecretNamespace,
@@ -3767,9 +3765,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 				VMSize: defaultInstanceType,
 				Vnet:   defaultAzureVnet(clusterID),
 				Subnet: defaultAzureSubnet(clusterID),
-				Image: machinev1beta1.Image{
-					ResourceID: defaultAzureImageResourceID(clusterID),
-				},
+				Image:  defaultAzureImage(),
 				UserDataSecret: &corev1.SecretReference{
 					Name: defaultUserDataSecret,
 				},

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -602,11 +602,9 @@ func TestMachineSetUpdate(t *testing.T) {
 		Vnet:                 defaultAzureVnet(azureClusterID),
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
-		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
-		},
-		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
-		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),
+		Image:                defaultAzureImage(),
+		ManagedIdentity:      defaultAzureManagedIdentiy(azureClusterID),
+		ResourceGroup:        defaultAzureResourceGroup(azureClusterID),
 		UserDataSecret: &corev1.SecretReference{
 			Name:      defaultUserDataSecret,
 			Namespace: defaultSecretNamespace,


### PR DESCRIPTION
Rather than use the AWS approach proposed in #1440, this proposes to use a similar approach to GCP of hardcoding a 
marketplace image default value. 

In 4.21, the installer stopped creating a cluster-specific image gallery and moved to marketplace images. This PR updates the default for a minimal provider spec to use a hard-coded marketplace image, similar to the approach used for GCP.