### PR TITLE
OCPBUGS-66940: fix default image for confidential VMs

### DIFF
--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -1712,7 +1712,7 @@ func TestMachineUpdate(t *testing.T) {
 		Vnet:                 defaultAzureVnet(azureClusterID),
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
-		Image:                defaultAzureImage(),
+		Image:                defaultAzureImage(nil, azureClusterID),
 		ManagedIdentity:      defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:        defaultAzureResourceGroup(azureClusterID),
 		UserDataSecret: &corev1.SecretReference{
@@ -3765,7 +3765,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 				VMSize: defaultInstanceType,
 				Vnet:   defaultAzureVnet(clusterID),
 				Subnet: defaultAzureSubnet(clusterID),
-				Image:  defaultAzureImage(),
+				Image:  defaultAzureImage(nil, clusterID),
 				UserDataSecret: &corev1.SecretReference{
 					Name: defaultUserDataSecret,
 				},

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -602,7 +602,7 @@ func TestMachineSetUpdate(t *testing.T) {
 		Vnet:                 defaultAzureVnet(azureClusterID),
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
-		Image:                defaultAzureImage(),
+		Image:                defaultAzureImage(nil, azureClusterID),
 		ManagedIdentity:      defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:        defaultAzureResourceGroup(azureClusterID),
 		UserDataSecret: &corev1.SecretReference{


### PR DESCRIPTION
The installer still creates an image gallery for confidfential VMs, and we can tell its a confidential VM from the machine provider spec, so this updates the default to point to an installer-created gallery rather than the marketplace image.