### PR TITLE
SPLAT-2612: Changed AWS dedicated host webhook to allow host info with other tenancies

### DIFF
--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -656,7 +656,9 @@ func TestMachineCreation(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host: Forbidden: host may only be specified when tenancy is 'host'",
+			// We used to error on the following, but due to CAPI allowing it even though AWS will ignore the host info
+			// and just honor the tenancy, we are changing our logic to behave the same
+			//expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host: Forbidden: host may only be specified when tenancy is 'host'",
 		},
 		{
 			name:         "configure default tenancy with host placement",
@@ -677,7 +679,9 @@ func TestMachineCreation(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host: Forbidden: host may only be specified when tenancy is 'host'",
+			// We used to error on the following, but due to CAPI allowing it even though AWS will ignore the host info
+			// and just honor the tenancy, we are changing our logic to behave the same
+			//expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host: Forbidden: host may only be specified when tenancy is 'host'",
 		},
 		{
 			name:         "with VolumeType set to gp3 and Throughput set under minium value",


### PR DESCRIPTION
[SPLAT-2612](https://issues.redhat.com//browse/SPLAT-2612)

### Changes
- Changed AWS dedicated host webhook to allow host info with other tenancies

### Notes
This change is being done due to difference in behavior with CAPA vs MAPI.  CAPA seems to allow host affinity and ID even when tenancy is default or dedicated.  We found this behavior during our CCAPIO testing: https://github.com/openshift/cluster-capi-operator/pull/374

Documentation on tenancy behavior/usage:
- https://docs.aws.amazon.com/license-manager/latest/userguide/conversion-tenancy.html