### PR TITLE
OCPBUGS-79373: [release-4.17] Use resource group when generating default Azure image

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -415,7 +415,7 @@ func NewMachineDefaulter() (*admission.Webhook, error) {
 func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *machineDefaulterHandler {
 	return &machineDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, platformStatus: platformStatus},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -857,7 +857,11 @@ func defaultAzure(m *machinev1beta1.Machine, config *admissionConfig) (bool, []s
 	}
 
 	if providerSpec.Image == (machinev1beta1.Image{}) {
-		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID, config.platformStatus.Azure.ResourceGroupName)
+		rg := defaultAzureResourceGroup(config.clusterID)
+		if ps := config.platformStatus; ps != nil && ps.Azure != nil && ps.Azure.ResourceGroupName != "" {
+			rg = ps.Azure.ResourceGroupName
+		}
+		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID, rg)
 	}
 
 	if providerSpec.UserDataSecret == nil {

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -55,7 +55,7 @@ var (
 	defaultAzureNetworkResourceGroup = func(clusterID string) string {
 		return fmt.Sprintf("%s-rg", clusterID)
 	}
-	defaultAzureImageResourceID = func(clusterID string) string {
+	defaultAzureImageResourceID = func(clusterID, rg string) string {
 		// image gallery names cannot have dashes
 		galleryName := strings.Replace(clusterID, "-", "_", -1)
 		imageName := clusterID
@@ -65,7 +65,7 @@ var (
 			// before that change will have a -gen2 image.
 			imageName = fmt.Sprintf("%s-gen2", clusterID)
 		}
-		return fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", clusterID+"-rg", galleryName, imageName, azureRHCOSVersion)
+		return fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", rg, galleryName, imageName, azureRHCOSVersion)
 	}
 	defaultAzureManagedIdentiy = func(clusterID string) string {
 		return fmt.Sprintf("%s-identity", clusterID)
@@ -857,7 +857,7 @@ func defaultAzure(m *machinev1beta1.Machine, config *admissionConfig) (bool, []s
 	}
 
 	if providerSpec.Image == (machinev1beta1.Image{}) {
-		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID)
+		providerSpec.Image.ResourceID = defaultAzureImageResourceID(config.clusterID, config.platformStatus.Azure.ResourceGroupName)
 	}
 
 	if providerSpec.UserDataSecret == nil {

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/gomega"
@@ -3080,6 +3081,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 		testCase         string
 		providerSpec     *machinev1beta1.AzureMachineProviderSpec
 		modifyDefault    func(*machinev1beta1.AzureMachineProviderSpec)
+		platformStatus   *osconfigv1.PlatformStatus
 		expectedError    string
 		expectedOk       bool
 		expectedWarnings []string
@@ -3123,6 +3125,29 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 			modifyDefault: func(p *machinev1beta1.AzureMachineProviderSpec) {
 				p.Image = machinev1beta1.Image{
 					ResourceID: "rid",
+				}
+			},
+			expectedOk:       true,
+			expectedError:    "",
+			expectedWarnings: itWarnings,
+		},
+		{
+			testCase: "it generates azure image ResourceID with custom resource group",
+			providerSpec: &machinev1beta1.AzureMachineProviderSpec{
+				Image: machinev1beta1.Image{},
+			},
+			platformStatus: &osconfigv1.PlatformStatus{
+				Type: osconfigv1.AzurePlatformType,
+				Azure: &osconfigv1.AzurePlatformStatus{
+					ResourceGroupName: "test-rg",
+				},
+			},
+			modifyDefault: func(p *machinev1beta1.AzureMachineProviderSpec) {
+				// Generate expected image ID with custom resource group from infra config
+				galleryName := strings.Replace(clusterID, "-", "_", -1)
+				imageName := clusterID
+				p.Image = machinev1beta1.Image{
+					ResourceID: fmt.Sprintf("/resourceGroups/%s/providers/Microsoft.Compute/galleries/gallery_%s/images/%s/versions/%s", "test-rg", galleryName, imageName, azureRHCOSVersion),
 				}
 			},
 			expectedOk:       true,
@@ -3175,10 +3200,14 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 		},
 	}
 
-	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.AzurePlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	defaultPlatformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.AzurePlatformType}
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
+			platformStatus := defaultPlatformStatus
+			if tc.platformStatus != nil {
+				platformStatus = tc.platformStatus
+			}
+			h := createMachineDefaulter(platformStatus, clusterID)
 			defaultProviderSpec := &machinev1beta1.AzureMachineProviderSpec{
 				VMSize: defaultInstanceType,
 				Vnet:   defaultAzureVnet(clusterID),

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -1252,7 +1252,7 @@ func TestMachineUpdate(t *testing.T) {
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
 		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
+			ResourceID: defaultAzureImageResourceID(azureClusterID, defaultAzureResourceGroup(azureClusterID)),
 		},
 		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),
@@ -3213,7 +3213,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 				Vnet:   defaultAzureVnet(clusterID),
 				Subnet: defaultAzureSubnet(clusterID),
 				Image: machinev1beta1.Image{
-					ResourceID: defaultAzureImageResourceID(clusterID),
+					ResourceID: defaultAzureImageResourceID(clusterID, defaultAzureResourceGroup(clusterID)),
 				},
 				UserDataSecret: &corev1.SecretReference{
 					Name: defaultUserDataSecret,

--- a/pkg/webhooks/machineset_webhook.go
+++ b/pkg/webhooks/machineset_webhook.go
@@ -76,7 +76,7 @@ func NewMachineSetDefaulter() (*admission.Webhook, error) {
 func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *admission.Webhook {
 	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.MachineSet{}, &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, platformStatus: platformStatus},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	})

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -595,7 +595,7 @@ func TestMachineSetUpdate(t *testing.T) {
 		Subnet:               defaultAzureSubnet(azureClusterID),
 		NetworkResourceGroup: defaultAzureNetworkResourceGroup(azureClusterID),
 		Image: machinev1beta1.Image{
-			ResourceID: defaultAzureImageResourceID(azureClusterID),
+			ResourceID: defaultAzureImageResourceID(azureClusterID, defaultAzureResourceGroup(azureClusterID)),
 		},
 		ManagedIdentity: defaultAzureManagedIdentiy(azureClusterID),
 		ResourceGroup:   defaultAzureResourceGroup(azureClusterID),


### PR DESCRIPTION
Manual backport of #1475 