### PR TITLE
SPLAT-2680: Changed DHA to require hostAffinity=host

### DIFF
--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -953,6 +953,14 @@ func processAWSPlacementTenancy(m *machinev1beta1.Machine, placement machinev1be
 				case machinev1beta1.HostAffinityAnyAvailable:
 					// DedicatedHost is optional.  If it is set, make sure it follows conventions
 					if placement.Host.DedicatedHost != nil {
+						// Dynamic Host Allocation (DHA) requires DedicatedHost affinity
+						strategy := machinev1beta1.AllocationStrategyUserProvided
+						if placement.Host.DedicatedHost.AllocationStrategy != nil {
+							strategy = *placement.Host.DedicatedHost.AllocationStrategy
+						}
+						if strategy == machinev1beta1.AllocationStrategyDynamic {
+							errs = append(errs, field.Forbidden(field.NewPath("spec.placement.host.affinity"), "hostAffinity must be DedicatedHost when using dynamic host allocation"))
+						}
 						errs = append(errs, validateDedicatedHost(placement.Host.DedicatedHost)...)
 					}
 				case machinev1beta1.HostAffinityDedicatedHost:

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -1008,7 +1008,7 @@ func TestMachineCreation(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "",
+			expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host.affinity: Forbidden: hostAffinity must be DedicatedHost when using dynamic host allocation",
 		},
 		{
 			name:         "configure Affinity AnyAvailable with AllocationStrategy Dynamic and DynamicHostAllocation",
@@ -1032,7 +1032,7 @@ func TestMachineCreation(t *testing.T) {
 					},
 				},
 			},
-			expectedError: "",
+			expectedError: "admission webhook \"validation.machine.machine.openshift.io\" denied the request: spec.placement.host.affinity: Forbidden: hostAffinity must be DedicatedHost when using dynamic host allocation",
 		},
 		{
 			name:            "control plane machine with dedicated host should fail",


### PR DESCRIPTION
[SPLAT-2680](https://redhat.atlassian.net/browse/SPLAT-2680)

### Changes
- Changed DHA logic to require hostAffinity=host so instances do not drift off of the allocated host when restarted