### PR TITLE
Fixes https://redhat.atlassian.net/browse/OCPBUGS-82584

### DIFF
--- a/install/0000_30_machine-api-operator_03_machineset.CustomNoUpgrade.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.CustomNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/install/0000_30_machine-api-operator_03_machineset.Default.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.Default.crd.yaml
@@ -615,6 +615,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -635,7 +641,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/install/0000_30_machine-api-operator_03_machineset.DevPreviewNoUpgrade.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.DevPreviewNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/install/0000_30_machine-api-operator_03_machineset.OKD.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.OKD.crd.yaml
@@ -615,6 +615,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -635,7 +641,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/install/0000_30_machine-api-operator_03_machineset.TechPreviewNoUpgrade.crd.yaml
+++ b/install/0000_30_machine-api-operator_03_machineset.TechPreviewNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/pkg/controller/machineset/status.go
+++ b/pkg/controller/machineset/status.go
@@ -67,6 +67,7 @@ func (c *ReconcileMachineSet) calculateStatus(ms *machinev1.MachineSet, filtered
 	newStatus.FullyLabeledReplicas = int32(fullyLabeledReplicasCount)
 	newStatus.ReadyReplicas = int32(readyReplicasCount)
 	newStatus.AvailableReplicas = int32(availableReplicasCount)
+	newStatus.Selector = metav1.FormatLabelSelector(&ms.Spec.Selector)
 	return newStatus
 }
 
@@ -80,6 +81,7 @@ func updateMachineSetStatus(c client.Client, ms *machinev1.MachineSet, newStatus
 		ms.Status.FullyLabeledReplicas == newStatus.FullyLabeledReplicas &&
 		ms.Status.ReadyReplicas == newStatus.ReadyReplicas &&
 		ms.Status.AvailableReplicas == newStatus.AvailableReplicas &&
+		ms.Status.Selector == newStatus.Selector &&
 		reflect.DeepEqual(ms.Status.Conditions, newStatus.Conditions) &&
 		ms.Generation == ms.Status.ObservedGeneration {
 		return ms, nil

--- a/pkg/controller/machineset/status_test.go
+++ b/pkg/controller/machineset/status_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machineset
+
+import (
+	"testing"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestMachineSetStatusSelectorMatchesScaleSubresource verifies that status.selector is the
+// serialized label selector string expected by the CRD scale subresource (labelSelectorPath
+// -> .status.selector), which the apiserver maps to autoscaling/v1 Scale status.selector.
+func TestMachineSetStatusSelectorMatchesScaleSubresource(t *testing.T) {
+	tests := []struct {
+		name string
+		spec metav1.LabelSelector
+	}{
+		{
+			name: "matchLabels",
+			spec: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"machine.openshift.io/cluster-api-cluster":    "cluster-id",
+					"machine.openshift.io/cluster-api-machineset": "workers",
+				},
+			},
+		},
+		{
+			name: "matchExpressions",
+			spec: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "role", Operator: metav1.LabelSelectorOpIn, Values: []string{"worker", "infra"}},
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ms := &machinev1.MachineSet{
+				Spec: machinev1.MachineSetSpec{
+					Selector: tc.spec,
+				},
+			}
+			r := &ReconcileMachineSet{}
+			got := r.calculateStatus(ms, nil).Selector
+			want := metav1.FormatLabelSelector(&ms.Spec.Selector)
+			if got != want {
+				t.Fatalf("status.selector = %q, want %q (must match Scale status.selector for HPA)", got, want)
+			}
+		})
+	}
+}

--- a/vendor/github.com/openshift/api/machine/v1beta1/types_machineset.go
+++ b/vendor/github.com/openshift/api/machine/v1beta1/types_machineset.go
@@ -17,7 +17,7 @@ import (
 // +openshift:capability=MachineAPI
 // +kubebuilder:metadata:annotations="exclude.release.openshift.io/internal-openshift-hosted=true"
 // +kubebuilder:metadata:annotations="include.release.openshift.io/self-managed-high-availability=true"
-// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.labelSelector
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="Desired",type="integer",JSONPath=".spec.replicas",description="Desired Replicas"
 // +kubebuilder:printcolumn:name="Current",type="integer",JSONPath=".status.replicas",description="Current Replicas"
 // +kubebuilder:printcolumn:name="Ready",type="integer",JSONPath=".status.readyReplicas",description="Ready Replicas"
@@ -120,6 +120,11 @@ type MachineSetStatus struct {
 	// The number of replicas that have labels matching the labels of the machine template of the MachineSet.
 	// +optional
 	FullyLabeledReplicas int32 `json:"fullyLabeledReplicas,omitempty"`
+	// selector is the string form of the label selector in spec.selector, in the same format as
+	// autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+	// machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+	// +optional
+	Selector string `json:"selector,omitempty"`
 	// The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-CustomNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-Default.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-Default.crd.yaml
@@ -615,6 +615,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -635,7 +641,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-DevPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-DevPreviewNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-OKD.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-OKD.crd.yaml
@@ -615,6 +615,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -635,7 +641,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.crd-manifests/0000_10_machine-api_01_machinesets-TechPreviewNoUpgrade.crd.yaml
@@ -660,6 +660,12 @@ spec:
                   labels of the machine template of the MachineSet.
                 format: int32
                 type: integer
+              selector:
+                description: |-
+                  selector is the string form of the label selector in spec.selector, in the same format as
+                  autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+                  machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+                type: string
               observedGeneration:
                 description: observedGeneration reflects the generation of the most
                   recently observed MachineSet.
@@ -708,7 +714,7 @@ spec:
     storage: true
     subresources:
       scale:
-        labelSelectorPath: .status.labelSelector
+        labelSelectorPath: .status.selector
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}

--- a/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.swagger_doc_generated.go
+++ b/vendor/github.com/openshift/api/machine/v1beta1/zz_generated.swagger_doc_generated.go
@@ -745,6 +745,7 @@ var map_MachineSetStatus = map[string]string{
 	"":                       "MachineSetStatus defines the observed state of MachineSet",
 	"replicas":               "replicas is the most recently observed number of replicas.",
 	"fullyLabeledReplicas":   "The number of replicas that have labels matching the labels of the machine template of the MachineSet.",
+	"selector":               "selector is the string form of the label selector in spec.selector, in the same format as autoscaling/v1 Scale status.selector (for example \"app=myapp,role=worker\"). It is written by the machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.",
 	"readyReplicas":          "The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is \"Ready\".",
 	"availableReplicas":      "The number of available replicas (ready for at least minReadySeconds) for this MachineSet.",
 	"observedGeneration":     "observedGeneration reflects the generation of the most recently observed MachineSet.",

--- a/vendor/github.com/openshift/client-go/machine/applyconfigurations/internal/internal.go
+++ b/vendor/github.com/openshift/client-go/machine/applyconfigurations/internal/internal.go
@@ -791,6 +791,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: fullyLabeledReplicas
       type:
         scalar: numeric
+    - name: selector
+      type:
+        scalar: string
     - name: observedGeneration
       type:
         scalar: numeric

--- a/vendor/github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1/machinesetstatus.go
+++ b/vendor/github.com/openshift/client-go/machine/applyconfigurations/machine/v1beta1/machinesetstatus.go
@@ -15,6 +15,10 @@ type MachineSetStatusApplyConfiguration struct {
 	Replicas *int32 `json:"replicas,omitempty"`
 	// The number of replicas that have labels matching the labels of the machine template of the MachineSet.
 	FullyLabeledReplicas *int32 `json:"fullyLabeledReplicas,omitempty"`
+	// selector is the string form of the label selector in spec.selector, in the same format as
+	// autoscaling/v1 Scale status.selector (for example "app=myapp,role=worker"). It is written by the
+	// machineset controller so the scale subresource's labelSelectorPath resolves for HPAs and other autoscalers.
+	Selector *string `json:"selector,omitempty"`
 	// The number of ready replicas for this MachineSet. A machine is considered ready when the node has been created and is "Ready".
 	ReadyReplicas *int32 `json:"readyReplicas,omitempty"`
 	// The number of available replicas (ready for at least minReadySeconds) for this MachineSet.
@@ -78,6 +82,14 @@ func (b *MachineSetStatusApplyConfiguration) WithReplicas(value int32) *MachineS
 // If called multiple times, the FullyLabeledReplicas field is set to the value of the last call.
 func (b *MachineSetStatusApplyConfiguration) WithFullyLabeledReplicas(value int32) *MachineSetStatusApplyConfiguration {
 	b.FullyLabeledReplicas = &value
+	return b
+}
+
+// WithSelector sets the selector field (status string for scale subresource) in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Selector field is set to the value of the last call.
+func (b *MachineSetStatusApplyConfiguration) WithSelector(value string) *MachineSetStatusApplyConfiguration {
+	b.Selector = &value
 	return b
 }
 


### PR DESCRIPTION
It adds a new status field called selector, with the same logic as other scale subresources (an joined string of spec.selector fields comma separated), and fix the scale subresource definition to point to that field. With that, the HPA and other scaling mechanisms would not raise exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `status.selector` field to MachineSet status that exposes the label selector in string format, enabling proper autoscaler and HPA integration through the scale subresource.

* **Tests**
  * Added test coverage to validate the status selector field correctly matches the spec selector configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->