### PR TITLE
NO-JIRA: fix: importing nutanix test to in the binary

### DIFF
--- a/cmd/machine-api-tests-ext/main.go
+++ b/cmd/machine-api-tests-ext/main.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/component-base/logs"
 
 	// If using ginkgo, import your tests here
+	_ "github.com/openshift/machine-api-operator/test/e2e/nutanix"
 	_ "github.com/openshift/machine-api-operator/test/e2e/vsphere"
 )
 

--- a/test/e2e/nutanix/multi-subnet.go
+++ b/test/e2e/nutanix/multi-subnet.go
@@ -295,7 +295,7 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:NutanixMultiSubnets][pl
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(infra.Spec.PlatformSpec.Nutanix.FailureDomains)).ShouldNot(Equal(0))
 
-		machineNetworks = append(machineNetworks, infra.Spec.PlatformSpec.Nutanix.FailureDomains...)
+		machineNetworks = infra.Spec.PlatformSpec.Nutanix.FailureDomains
 		Expect(len(machineNetworks)).ShouldNot(Equal(0))
 
 		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
Summary
This PR fixes the integration of Nutanix multi-subnet E2E tests into the machine-api-tests-ext binary and resolves a variable assignment issue in the test logic.

Changes Made
1. Fixed Missing Test Import (cmd/machine-api-tests-ext/main.go)
Added missing import for Nutanix E2E tests: _ "github.com/openshift/machine-api-operator/test/e2e/nutanix"
This ensures that the comprehensive Nutanix multi-subnet test suite is properly included in the extended test binary
Without this import, the tests would not be discoverable or executable via the test extension framework
2. Corrected Variable Assignment (test/e2e/nutanix/multi-subnet.go)
Fixed incorrect use of append() when assigning failure domains to machineNetworks
Changed from: machineNetworks = append(machineNetworks, infra.Spec.PlatformSpec.Nutanix.FailureDomains...)
Changed to: machineNetworks = infra.Spec.PlatformSpec.Nutanix.FailureDomains
This prevents potential duplication of failure domains if the variable was previously initialized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end test support for Nutanix platform deployments
  * Fixed Nutanix multi-subnet test setup to correctly initialize network failure domain configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->