### PR TITLE
NO-JIRA: machine-api-termination-handler: add scc annotation, terminationMessage: FallbackToLogsOnError

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -1067,11 +1067,12 @@ func newTerminationContainers(config *OperatorConfig) []corev1.Container {
 
 	return []corev1.Container{
 		{
-			Name:      "termination-handler",
-			Image:     config.Controllers.TerminationHandler,
-			Command:   []string{"/termination-handler"},
-			Args:      terminationArgs,
-			Resources: resources,
+			Name:                    "termination-handler",
+			Image:                   config.Controllers.TerminationHandler,
+			Command:                 []string{"/termination-handler"},
+			Args:                    terminationArgs,
+			Resources:               resources,
+			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			Env: append(proxyEnvArgs, corev1.EnvVar{
 				Name:  "KUBECONFIG",
 				Value: hostKubeConfigPath,

--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"maps"
 	"os"
 	"slices"
 	"strings"
@@ -1002,9 +1003,12 @@ func newTerminationDaemonSet(config *OperatorConfig) *appsv1.DaemonSet {
 func newTerminationPodTemplateSpec(config *OperatorConfig) *corev1.PodTemplateSpec {
 	containers := newTerminationContainers(config)
 
+	annotations := maps.Clone(commonPodTemplateAnnotations)
+	annotations["openshift.io/required-scc"] = "machine-api-termination-handler"
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: commonPodTemplateAnnotations,
+			Annotations: annotations,
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "termination-handler",
@@ -1067,11 +1071,11 @@ func newTerminationContainers(config *OperatorConfig) []corev1.Container {
 
 	return []corev1.Container{
 		{
-			Name:                    "termination-handler",
-			Image:                   config.Controllers.TerminationHandler,
-			Command:                 []string{"/termination-handler"},
-			Args:                    terminationArgs,
-			Resources:               resources,
+			Name:                     "termination-handler",
+			Image:                    config.Controllers.TerminationHandler,
+			Command:                  []string{"/termination-handler"},
+			Args:                     terminationArgs,
+			Resources:                resources,
 			TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 			Env: append(proxyEnvArgs, corev1.EnvVar{
 				Name:  "KUBECONFIG",


### PR DESCRIPTION
- [set terminationMessagePolicy on termination-handler container](https://github.com/openshift/machine-api-operator/commit/6af8c5ae4ced936e9609e7fa5de6d12a056d7771) 
The termination-handler container was missing terminationMessagePolicy=FallbackToLogsOnError

- [require machine-api-termination-handler SCC via annotation](https://github.com/openshift/machine-api-operator/commit/e527fdd99cb8ecdf53b8eb437c96d9262bbd35e8) 
pin the termination-handler DaemonSet pods to the dedicated
machine-api-termination-handler SCC using the openshift.io/required-scc annotation.
This makes the SCC binding explicit and prevents silent fallback to a different
SCC if admission ordering changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Applied required OpenShift security constraint to the termination-handler pod so it meets platform security requirements.
  * Updated termination behavior to prefer logs on errors for the termination-handler container, improving post-termination diagnostics and error visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->