### PR TITLE
SPLAT-2745: Changed vSphere cloud config to be read from openshift-config-managed

### DIFF
--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -179,7 +179,7 @@ func main() {
 		EventRecorder:            mgr.GetEventRecorder("vspherecontroller"),
 		TaskIDCache:              taskIDCache,
 		FeatureGates:             defaultMutableGate,
-		OpenshiftConfigNamespace: vsphere.OpenshiftConfigNamespace,
+		OpenshiftConfigNamespace: vsphere.OpenshiftConfigManagedNamespace,
 	})
 
 	if err := configv1.Install(mgr.GetScheme()); err != nil {

--- a/pkg/controller/vsphere/actuator_test.go
+++ b/pkg/controller/vsphere/actuator_test.go
@@ -137,33 +137,17 @@ func TestMachineEvents(t *testing.T) {
 	testConfig := fmt.Sprintf(testConfigFmt, port, credentialsSecretName, testNamespaceName)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname",
+			Name:      OpenshiftConfigManagedConfigMap,
 			Namespace: openshiftConfigNamespaceForTest,
 		},
 		Data: map[string]string{
-			"testkey": testConfig,
+			OpenshiftConfigManagedCloudConfigKey: testConfig,
 		},
 	}
 
 	g.Expect(k8sClient.Create(context.Background(), configMap)).To(Succeed())
 	defer func() {
 		g.Expect(k8sClient.Delete(context.Background(), configMap)).To(Succeed())
-	}()
-
-	infra := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: globalInfrastuctureName,
-		},
-		Spec: configv1.InfrastructureSpec{
-			CloudConfig: configv1.ConfigMapFileReference{
-				Name: "testname",
-				Key:  "testkey",
-			},
-		},
-	}
-	g.Expect(k8sClient.Create(context.Background(), infra)).To(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(context.Background(), infra)).To(Succeed())
 	}()
 
 	userDataSecretName := "vsphere-ignition"

--- a/pkg/controller/vsphere/machine_scope_test.go
+++ b/pkg/controller/vsphere/machine_scope_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	. "github.com/onsi/gomega"
-	configv1 "github.com/openshift/api/config/v1"
 	machinev1 "github.com/openshift/api/machine/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -355,32 +354,16 @@ func TestPatchMachine(t *testing.T) {
 	testConfig := fmt.Sprintf(testConfigFmt, port, credentialsSecretName, testNamespaceName)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testname",
+			Name:      OpenshiftConfigManagedConfigMap,
 			Namespace: openshiftConfigNamespaceForTest,
 		},
 		Data: map[string]string{
-			"testkey": testConfig,
+			OpenshiftConfigManagedCloudConfigKey: testConfig,
 		},
 	}
 	g.Expect(k8sClient.Create(ctx, configMap)).To(Succeed())
 	defer func() {
 		g.Expect(k8sClient.Delete(ctx, configMap)).To(Succeed())
-	}()
-
-	infra := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: globalInfrastuctureName,
-		},
-		Spec: configv1.InfrastructureSpec{
-			CloudConfig: configv1.ConfigMapFileReference{
-				Name: "testname",
-				Key:  "testkey",
-			},
-		},
-	}
-	g.Expect(k8sClient.Create(ctx, infra)).To(Succeed())
-	defer func() {
-		g.Expect(k8sClient.Delete(ctx, infra)).To(Succeed())
 	}()
 
 	failedPhase := "Failed"

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1930,7 +1930,6 @@ func TestConvertUUIDToProviderID(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	type vCenterSimConfig struct {
-		infra       *configv1.Infrastructure
 		secret      *corev1.Secret
 		configMap   *corev1.ConfigMap
 		featureGate *configv1.FeatureGate
@@ -1982,23 +1981,11 @@ func TestDelete(t *testing.T) {
 		testConfig := fmt.Sprintf(testConfigFmt, port, credentialsSecretName, ns)
 		configMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "testName",
+				Name:      OpenshiftConfigManagedConfigMap,
 				Namespace: openshiftConfigNamespaceForTest,
 			},
 			Data: map[string]string{
-				"testKey": testConfig,
-			},
-		}
-
-		infra := &configv1.Infrastructure{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: globalInfrastuctureName,
-			},
-			Spec: configv1.InfrastructureSpec{
-				CloudConfig: configv1.ConfigMapFileReference{
-					Name: "testName",
-					Key:  "testKey",
-				},
+				OpenshiftConfigManagedCloudConfigKey: testConfig,
 			},
 		}
 
@@ -2009,7 +1996,6 @@ func TestDelete(t *testing.T) {
 		}
 
 		return &vCenterSimConfig{
-			infra:       infra,
 			secret:      secret,
 			configMap:   configMap,
 			host:        host,
@@ -2161,7 +2147,6 @@ func TestDelete(t *testing.T) {
 				simParams.secret,
 				tc.machine(t, simParams.host),
 				simParams.configMap,
-				simParams.infra,
 				tc.node(t)).Build()
 			machineScope, err := newMachineScope(machineScopeParams{
 				client:                   client,
@@ -2441,7 +2426,6 @@ func TestDelete(t *testing.T) {
 				simParams.secret,
 				tc.machine(t, simParams.host),
 				simParams.configMap,
-				simParams.infra,
 				tc.node(t),
 			).Build()
 			mScope, err := newMachineScope(machineScopeParams{
@@ -2511,23 +2495,11 @@ func TestCreate(t *testing.T) {
 	testConfig := fmt.Sprintf(testConfigFmt, port, credentialsSecretName, namespace)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testName",
+			Name:      OpenshiftConfigManagedConfigMap,
 			Namespace: openshiftConfigNamespaceForTest,
 		},
 		Data: map[string]string{
-			"testKey": testConfig,
-		},
-	}
-
-	infra := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: globalInfrastuctureName,
-		},
-		Spec: configv1.InfrastructureSpec{
-			CloudConfig: configv1.ConfigMapFileReference{
-				Name: "testName",
-				Key:  "testKey",
-			},
+			OpenshiftConfigManagedCloudConfigKey: testConfig,
 		},
 	}
 
@@ -2870,7 +2842,6 @@ func TestCreate(t *testing.T) {
 			builder := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(
 				credentialsSecret,
 				configMap,
-				infra,
 				userDataSecret,
 				machine)
 			if tc.ipAddressClaim != nil {
@@ -3007,23 +2978,11 @@ func TestUpdate(t *testing.T) {
 	testConfig := fmt.Sprintf(testConfigFmt, port, credentialsSecretName, namespace)
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testName",
+			Name:      OpenshiftConfigManagedConfigMap,
 			Namespace: openshiftConfigNamespaceForTest,
 		},
 		Data: map[string]string{
-			"testKey": testConfig,
-		},
-	}
-
-	infra := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: globalInfrastuctureName,
-		},
-		Spec: configv1.InfrastructureSpec{
-			CloudConfig: configv1.ConfigMapFileReference{
-				Name: "testName",
-				Key:  "testKey",
-			},
+			OpenshiftConfigManagedCloudConfigKey: testConfig,
 		},
 	}
 
@@ -3093,8 +3052,7 @@ func TestUpdate(t *testing.T) {
 
 			client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(
 				credentialsSecret,
-				configMap,
-				infra).Build()
+				configMap).Build()
 
 			rawProviderSpec, err := RawExtensionFromProviderSpec(&tc.providerSpec)
 			if err != nil {

--- a/pkg/controller/vsphere/util.go
+++ b/pkg/controller/vsphere/util.go
@@ -20,8 +20,10 @@ import (
 )
 
 const (
-	globalInfrastuctureName  = "cluster"
-	OpenshiftConfigNamespace = "openshift-config"
+	globalInfrastuctureName              = "cluster"
+	OpenshiftConfigManagedNamespace      = "openshift-config-managed"
+	OpenshiftConfigManagedConfigMap      = "kube-cloud-config"
+	OpenshiftConfigManagedCloudConfigKey = "cloud.conf"
 )
 
 // GetInfrastructure retrieves the Infrastructure object from the provided API reader.
@@ -46,22 +48,13 @@ func getVSphereConfig(c runtimeclient.Reader, configNamespace string) (*vsphere.
 		return nil, errors.New("no API reader -- will not fetch vSphere config")
 	}
 
-	infra, err := GetInfrastructure(c)
-	if err != nil {
-		return nil, err
-	}
-
-	if infra.Spec.CloudConfig.Name == "" {
-		return nil, fmt.Errorf("cluster infrastructure CloudConfig has empty name")
-	}
-
-	if infra.Spec.CloudConfig.Key == "" {
-		return nil, fmt.Errorf("cluster infrastructure CloudConfig has empty key")
+	if configNamespace == "" {
+		configNamespace = OpenshiftConfigManagedNamespace
 	}
 
 	cm := &corev1.ConfigMap{}
 	cmName := runtimeclient.ObjectKey{
-		Name:      infra.Spec.CloudConfig.Name,
+		Name:      OpenshiftConfigManagedConfigMap,
 		Namespace: configNamespace,
 	}
 
@@ -69,10 +62,10 @@ func getVSphereConfig(c runtimeclient.Reader, configNamespace string) (*vsphere.
 		return nil, err
 	}
 
-	cloudConfig, found := cm.Data[infra.Spec.CloudConfig.Key]
+	cloudConfig, found := cm.Data[OpenshiftConfigManagedCloudConfigKey]
 	if !found {
 		return nil, fmt.Errorf("cloud-config ConfigMap has no %q key",
-			infra.Spec.CloudConfig.Key,
+			OpenshiftConfigManagedCloudConfigKey,
 		)
 	}
 

--- a/pkg/controller/vsphere/util_test.go
+++ b/pkg/controller/vsphere/util_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -34,27 +33,15 @@ func TestGetVSphereConfig(t *testing.T) {
 	testConfig := fmt.Sprintf(testConfigFmt, "443", "test", "test-namespace")
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testName",
+			Name:      OpenshiftConfigManagedConfigMap,
 			Namespace: openshiftConfigNamespaceForTest,
 		},
 		Data: map[string]string{
-			"testKey": testConfig,
+			OpenshiftConfigManagedCloudConfigKey: testConfig,
 		},
 	}
 
-	infra := &configv1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: globalInfrastuctureName,
-		},
-		Spec: configv1.InfrastructureSpec{
-			CloudConfig: configv1.ConfigMapFileReference{
-				Name: "testName",
-				Key:  "testKey",
-			},
-		},
-	}
-
-	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(infra, configMap).Build()
+	client := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithRuntimeObjects(configMap).Build()
 
 	vSphereConfig, err := getVSphereConfig(client, openshiftConfigNamespaceForTest)
 	if err != nil {


### PR DESCRIPTION
[SPLAT-2745](https://redhat.atlassian.net/browse/SPLAT-2745)

#### Goal
Update the Machine API Operator (MAO) to use the new version of cloud config located in the openshift-config-managed namespace, and ensure the operator picks up the latest changes after any updates to the cluster Infrastructure spec.

#### Background / Problem
MAO currently consumes a cloud-config source that is being superseded by a new version published in openshift-config-managed. In addition, changes to Infrastructure.spec should trigger MAO to refresh/reconcile its effective cloud-config so it stays aligned with cluster-level infra settings.

### Changes
- Changed vSphere cloud config to be read from openshift-config-managed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vSphere configuration loading to use a managed namespace approach, improving how OpenShift configuration is accessed and managed in vSphere environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->