### PR TITLE
NO-ISSUE: Add memory limit to machine-controller container

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -684,6 +684,15 @@ func newContainers(config *OperatorConfig, features map[string]bool, tlsArgs []s
 			corev1.ResourceCPU:    resource.MustParse("10m"),
 		},
 	}
+	machineControllerResources := corev1.ResourceRequirements{
+		Requests: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("20Mi"),
+			corev1.ResourceCPU:    resource.MustParse("10m"),
+		},
+		Limits: map[corev1.ResourceName]resource.Quantity{
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
 	args := []string{
 		"--logtostderr=true",
 		"--v=3",
@@ -780,7 +789,7 @@ func newContainers(config *OperatorConfig, features map[string]bool, tlsArgs []s
 			Image:     config.Controllers.Provider,
 			Command:   []string{"/machine-controller-manager"},
 			Args:      machineControllerArgs,
-			Resources: resources,
+			Resources: machineControllerResources,
 			Env: append(proxyEnvArgs, corev1.EnvVar{
 				Name: "NODE_NAME",
 				ValueFrom: &corev1.EnvVarSource{

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -707,6 +707,36 @@ func TestNewKubeProxyContainers(t *testing.T) {
 	}
 }
 
+func TestNewContainersMemoryLimit(t *testing.T) {
+	g := NewWithT(t)
+
+	config := &OperatorConfig{
+		TargetNamespace: targetNamespace,
+		PlatformType:    configv1.AWSPlatformType,
+		Controllers: Controllers{
+			Provider:           "provider-image:latest",
+			MachineSet:         "machineset-image:latest",
+			NodeLink:           "nodelink-image:latest",
+			MachineHealthCheck: "mhc-image:latest",
+		},
+	}
+
+	containers := newContainers(config, nil, nil)
+
+	for _, container := range containers {
+		g.Expect(container.Resources.Requests.Memory().String()).To(Equal("20Mi"),
+			"memory request for %s", container.Name)
+
+		if container.Name == "machine-controller" {
+			g.Expect(container.Resources.Limits.Memory().String()).To(Equal("512Mi"),
+				"memory limit for %s", container.Name)
+		} else {
+			g.Expect(container.Resources.Limits.Memory().IsZero()).To(BeTrue(),
+				"unexpected memory limit on %s", container.Name)
+		}
+	}
+}
+
 func TestNewPodTemplateSpecTLSArgs(t *testing.T) {
 	testCases := []struct {
 		name                                  string


### PR DESCRIPTION
## Summary

- Add a 512Mi memory limit to the `machine-controller` container as a safety net against unbounded memory growth from leaked AWS session HTTP transports
- Only the `machine-controller` container is affected — other controllers (machineset, healthcheck, nodelink) keep the existing resource spec without a limit
- Companion fix in machine-api-provider-aws: [openshift/machine-api-provider-aws#190](https://github.com/openshift/machine-api-provider-aws/pull/190)

## Test Plan

- [x] `make unit` passes with race detector (13 suites)
- [x] `make vet` and `gofmt` clean
- [x] Unit test: machine-controller has 512Mi memory limit
- [x] Unit test: machine-controller has 20Mi memory request (unchanged)
- [x] Unit test: other controllers have no memory limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced resource management for the machine-controller component by implementing a dedicated memory limit to improve stability and prevent resource exhaustion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->