### PR TITLE
[release-4.19] NO-ISSUE: Declare pprof containerPort for machine-controller

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -41,6 +41,7 @@ const (
 	machineExposeMetricsPort            = 8441
 	machineSetExposeMetricsPort         = 8442
 	machineHealthCheckExposeMetricsPort = 8444
+	pprofPort                           = 6060
 	defaultMachineHealthPort            = 9440
 	defaultMachineSetHealthPort         = 9441
 	defaultMachineHealthCheckHealthPort = 9442
@@ -770,6 +771,10 @@ func newContainers(config *OperatorConfig, features map[string]bool) []corev1.Co
 				{
 					Name:          "healthz",
 					ContainerPort: defaultMachineHealthPort,
+				},
+				{
+					Name:          "pprof",
+					ContainerPort: pprofPort,
 				},
 			},
 			ReadinessProbe: &corev1.Probe{


### PR DESCRIPTION
Cherry-pick of #1502 to release-4.19.

## Summary

- Add an informational containerPort (6060, named "pprof") to the machine-controller container spec so that the pprof endpoint added in machine-api-provider-aws is discoverable
- Companion PR: [openshift/machine-api-provider-aws#189](https://github.com/openshift/machine-api-provider-aws/pull/189)

## Test Plan

- [x] `make unit` passes with race detector
- [x] `make vet` and `gofmt` clean