### PR TITLE
OCPBUGS-88561: Increase machineset-controller startup probe failure threshold

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -730,7 +730,7 @@ func newContainers(config *OperatorConfig, features map[string]bool, tlsArgs []s
 			StartupProbe: &corev1.Probe{
 				PeriodSeconds:       10,
 				TimeoutSeconds:      10,
-				FailureThreshold:    30,
+				FailureThreshold:    60,
 				SuccessThreshold:    1,
 				InitialDelaySeconds: 0,
 				ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
## Problem

During 4.22→5.0 major upgrades on **Single Node OpenShift (SNO)**, the `machineset-controller` container repeatedly fails its startup probe and enters CrashLoopBackOff. On SNO, all pods restart simultaneously on a single node (~1052 containers in a 38-minute window), overloading the kube-apiserver. The `machineset-controller` needs API server round-trips for cache sync and leader election, which exceed the current 5-minute startup probe window (30 failures × 10s period).

Each CrashLoopBackOff restart resets the cache sync, making convergence harder. The probe failure events repeat 21-22 times pathologically, triggering the monitor test regression.

## Fix

Increase `FailureThreshold` from 30 to 60, extending the startup probe tolerance from **5 to 10 minutes**. This gives the `machineset-controller` enough time to complete cache sync under heavy API server load without entering CrashLoopBackOff.

The startup probe only runs once during container initialization — once passed, the readiness and liveness probes (unchanged) take over. Increasing the startup threshold has no impact on steady-state behavior.

## Evidence

Journal analysis from a failing run ([2066200127957110784](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-main-nightly-5.0-upgrade-from-stable-4.22-e2e-aws-upgrade-ovn-single-node/2066200127957110784)):

- **17:03:46** — CRI-O creates the pod sandbox
- **17:09:56** — First probe failures: `connection refused` (process not listening yet)
- **17:13:26** — Probes switch to `context deadline exceeded` (`/readyz` too slow under API server load)
- **17:14:19** — CrashLoopBackOff begins after exhausting 30-failure threshold
- **17:14→17:51** — Repeated CrashLoopBackOff cycles with exponential backoff
- During this window: **1052 containers** being created/started on the single node

Pass rates: Base (4.22) 87/87 (100%) → Sample (5.0) 19/23 (82.6%) on the SNO upgrade job.

## Bug

https://redhat.atlassian.net/browse/OCPBUGS-88561

---
🤖 *This PR was generated by AI on behalf of @mkowalski, who has reviewed it.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved startup stability of the operator component by increasing failure tolerance during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->