### PR TITLE
OCPBUGS-85110: Move required-scc annotation to pod template for machine-api-controllers

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -470,8 +470,7 @@ func newDeployment(config *OperatorConfig, features map[string]bool) *appsv1.Dep
 			Name:      "machine-api-controllers",
 			Namespace: config.TargetNamespace,
 			Annotations: map[string]string{
-				maoOwnedAnnotation:          "",
-				"openshift.io/required-scc": "restricted-v2",
+				maoOwnedAnnotation: "",
 			},
 			Labels: map[string]string{
 				"api":     "clusterapi",
@@ -619,9 +618,12 @@ func newPodTemplateSpec(config *OperatorConfig, features map[string]bool) *corev
 	}
 	volumes = append(volumes, newRBACConfigVolumes()...)
 
+	podAnnotations := maps.Clone(commonPodTemplateAnnotations)
+	podAnnotations["openshift.io/required-scc"] = "restricted-v2"
+
 	return &corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Annotations: commonPodTemplateAnnotations,
+			Annotations: podAnnotations,
 			Labels: map[string]string{
 				"api":     "clusterapi",
 				"k8s-app": "controller",


### PR DESCRIPTION
This PR fixes the location of the required-scc annotation to the pod template instead of the deployment.

Failing sippy tests: https://sippy.dptools.openshift.org/sippy-ng/tests/5.0/analysis?test=%5Bsig-auth%5D%20all%20workloads%20in%20ns%2Fopenshift-machine-api%20must%20set%20the%20%27openshift.io%2Frequired-scc%27%20annotation

Fixing this will allow us to drop the [exception](https://github.com/openshift/origin/blob/main/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L46) from the required-scc-annotation-checker monitor test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted OpenShift security context constraint configuration for the machine-api-controllers component, relocating the annotation to a more appropriate level within the deployment structure for improved security policy enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->