### PR TITLE
OCPBUGS-90560: Resolve GCP boot image from worker machines

### DIFF
--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -210,20 +210,19 @@ func main() {
 	klog.Infof("FeatureGateMachineAPIMigration initialised: %t", defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateMachineAPIMigration)))
 
 	// Enable defaulting and validating webhooks
-	machineDefaulter, err := mapiwebhooks.NewMachineDefaulter()
+	defaulterConfig, err := mapiwebhooks.ResolveDefaulterConfig()
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	machineDefaulter := mapiwebhooks.NewMachineDefaulter(defaulterConfig)
 
 	machineValidator, err := mapiwebhooks.NewMachineValidator(mgr.GetClient(), defaultMutableGate)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	machineSetDefaulter, err := mapiwebhooks.NewMachineSetDefaulter()
-	if err != nil {
-		log.Fatal(err)
-	}
+	machineSetDefaulter := mapiwebhooks.NewMachineSetDefaulter(defaulterConfig)
 
 	machineSetValidator, err := mapiwebhooks.NewMachineSetValidator(mgr.GetClient(), defaultMutableGate)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.3 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
+	github.com/coreos/stream-metadata-go v0.4.10-0.20250806142651-4a7d280a6c7b
 	github.com/curioswitch/go-reassign v0.3.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.6.0 // indirect
 	github.com/daixiang0/gci v0.13.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr
 github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/stream-metadata-go v0.4.10-0.20250806142651-4a7d280a6c7b h1:CT6nMx5Ap/K6MT8zMqByrWz+RZV7O6pBGW5LhB/pwvY=
+github.com/coreos/stream-metadata-go v0.4.10-0.20250806142651-4a7d280a6c7b/go.mod h1:dTE8UEFgyUcrbdUg7vGT3uIP7S8a1IwUlmWLKlOp8G8=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -351,6 +351,44 @@ func getDNS() (*osconfigv1.DNS, error) {
 	return dns, nil
 }
 
+func resolveGCPBootImage(c client.Client) string {
+	archSuffix := "x86-64"
+	if arch == ARM64 {
+		archSuffix = "aarch64"
+	}
+
+	machineList := &machinev1beta1.MachineList{}
+	if err := c.List(context.Background(), machineList,
+		client.InNamespace(defaultSecretNamespace),
+		client.MatchingLabels{machineRoleLabel: "worker"},
+	); err != nil {
+		klog.V(3).Infof("Failed to list worker machines for GCP boot image resolution: %v", err)
+		return ""
+	}
+
+	for _, machine := range machineList.Items {
+		if machine.Spec.ProviderSpec.Value == nil {
+			continue
+		}
+		providerSpec := &machinev1beta1.GCPMachineProviderSpec{}
+		if err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, providerSpec); err != nil {
+			klog.V(4).Infof("Failed to unmarshal providerSpec for machine %s: %v", machine.Name, err)
+			continue
+		}
+		for _, disk := range providerSpec.Disks {
+			if disk == nil {
+				continue
+			}
+			if disk.Boot && disk.Image != "" && strings.Contains(disk.Image, archSuffix) {
+				klog.V(3).Infof("Resolved GCP boot image from worker machine %s: %s", machine.Name, disk.Image)
+				return disk.Image
+			}
+		}
+	}
+
+	return ""
+}
+
 type machineAdmissionFn func(m *machinev1beta1.Machine, config *admissionConfig) (bool, []string, field.ErrorList)
 
 type admissionConfig struct {
@@ -359,6 +397,7 @@ type admissionConfig struct {
 	dnsDisconnected bool
 	client          client.Client
 	featureGates    featuregate.MutableFeatureGate
+	gcpBootImage    string
 }
 
 type admissionHandler struct {
@@ -440,20 +479,50 @@ func getMachineValidatorOperation(platform osconfigv1.PlatformType) machineAdmis
 	}
 }
 
-// NewDefaulter returns a new machineDefaulterHandler.
-func NewMachineDefaulter() (*admission.Webhook, error) {
+// ResolveDefaulterConfig resolves shared configuration needed by both Machine
+// and MachineSet defaulters. Call once at startup and pass the result to both.
+func ResolveDefaulterConfig() (*DefaulterConfig, error) {
 	infra, err := getInfra()
 	if err != nil {
 		return nil, err
 	}
 
-	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(infra.Status.PlatformStatus, infra.Status.InfrastructureName)), nil
+	gcpBootImage := ""
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == osconfigv1.GCPPlatformType {
+		cfg, err := ctrl.GetConfig()
+		if err != nil {
+			return nil, err
+		}
+		cl, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		if err != nil {
+			return nil, err
+		}
+		gcpBootImage = resolveGCPBootImage(cl)
+	}
+
+	return &DefaulterConfig{
+		PlatformStatus: infra.Status.PlatformStatus,
+		ClusterID:      infra.Status.InfrastructureName,
+		GCPBootImage:   gcpBootImage,
+	}, nil
 }
 
-func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *machineDefaulterHandler {
+// DefaulterConfig holds shared state for Machine and MachineSet defaulters.
+type DefaulterConfig struct {
+	PlatformStatus *osconfigv1.PlatformStatus
+	ClusterID      string
+	GCPBootImage   string
+}
+
+// NewDefaulter returns a new machineDefaulterHandler.
+func NewMachineDefaulter(dc *DefaulterConfig) *admission.Webhook {
+	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(dc.PlatformStatus, dc.ClusterID, dc.GCPBootImage))
+}
+
+func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, gcpBootImage string) *machineDefaulterHandler {
 	return &machineDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: gcpBootImage},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -1332,7 +1401,7 @@ func defaultGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []str
 		})
 	}
 
-	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, config.clusterID)
+	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, config.clusterID, config.gcpBootImage)
 
 	if len(providerSpec.GPUs) != 0 {
 		// In case Count was not set it should default to 1, since there is no valid reason for it to be purposely set to 0.
@@ -1366,7 +1435,13 @@ func defaultGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []str
 	return true, warnings, nil
 }
 
-func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string) []*machinev1beta1.GCPDisk {
+func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string, gcpBootImage string) []*machinev1beta1.GCPDisk {
+	image := gcpBootImage
+	if image == "" {
+		image = defaultGCPDiskImage()
+		klog.Infof("No GCP boot image resolved from worker machines, falling back to default: %s", image)
+	}
+
 	if len(disks) == 0 {
 		return []*machinev1beta1.GCPDisk{
 			{
@@ -1374,7 +1449,7 @@ func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string) []*machi
 				Boot:       true,
 				SizeGB:     defaultGCPDiskSizeGb,
 				Type:       defaultGCPDiskType,
-				Image:      defaultGCPDiskImage(),
+				Image:      image,
 			},
 		}
 	}
@@ -1385,7 +1460,7 @@ func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string) []*machi
 		}
 
 		if disk.Boot && disk.Image == "" {
-			disk.Image = defaultGCPDiskImage()
+			disk.Image = image
 		}
 	}
 

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -15,6 +15,8 @@ import (
 
 	"slices"
 
+	archtranslater "github.com/coreos/stream-metadata-go/arch"
+	"github.com/coreos/stream-metadata-go/stream"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -156,6 +158,12 @@ const (
 
 	defaultUserDataSecret  = "worker-user-data"
 	defaultSecretNamespace = "openshift-machine-api"
+
+	bootImagesConfigMapName      = "coreos-bootimages"
+	bootImagesConfigMapNamespace = "openshift-machine-config-operator"
+	bootImagesStreamKey          = "stream"
+	machineArchAnnotationKey     = "capacity.cluster-autoscaler.kubernetes.io/labels"
+	archLabelKey                 = "kubernetes.io/arch="
 
 	// AWS Defaults
 	defaultAWSCredentialsSecret = "aws-cloud-credentials"
@@ -351,44 +359,6 @@ func getDNS() (*osconfigv1.DNS, error) {
 	return dns, nil
 }
 
-func resolveGCPBootImage(c client.Client) string {
-	archSuffix := "x86-64"
-	if arch == ARM64 {
-		archSuffix = "aarch64"
-	}
-
-	machineList := &machinev1beta1.MachineList{}
-	if err := c.List(context.Background(), machineList,
-		client.InNamespace(defaultSecretNamespace),
-		client.MatchingLabels{machineRoleLabel: "worker"},
-	); err != nil {
-		klog.V(3).Infof("Failed to list worker machines for GCP boot image resolution: %v", err)
-		return ""
-	}
-
-	for _, machine := range machineList.Items {
-		if machine.Spec.ProviderSpec.Value == nil {
-			continue
-		}
-		providerSpec := &machinev1beta1.GCPMachineProviderSpec{}
-		if err := json.Unmarshal(machine.Spec.ProviderSpec.Value.Raw, providerSpec); err != nil {
-			klog.V(4).Infof("Failed to unmarshal providerSpec for machine %s: %v", machine.Name, err)
-			continue
-		}
-		for _, disk := range providerSpec.Disks {
-			if disk == nil {
-				continue
-			}
-			if disk.Boot && disk.Image != "" && strings.Contains(disk.Image, archSuffix) {
-				klog.V(3).Infof("Resolved GCP boot image from worker machine %s: %s", machine.Name, disk.Image)
-				return disk.Image
-			}
-		}
-	}
-
-	return ""
-}
-
 type machineAdmissionFn func(m *machinev1beta1.Machine, config *admissionConfig) (bool, []string, field.ErrorList)
 
 type admissionConfig struct {
@@ -397,7 +367,7 @@ type admissionConfig struct {
 	dnsDisconnected bool
 	client          client.Client
 	featureGates    featuregate.MutableFeatureGate
-	gcpBootImage    string
+	streamData      *stream.Stream
 }
 
 type admissionHandler struct {
@@ -487,42 +457,68 @@ func ResolveDefaulterConfig() (*DefaulterConfig, error) {
 		return nil, err
 	}
 
-	gcpBootImage := ""
-	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == osconfigv1.GCPPlatformType {
-		cfg, err := ctrl.GetConfig()
-		if err != nil {
-			return nil, err
-		}
-		cl, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
-		if err != nil {
-			return nil, err
-		}
-		gcpBootImage = resolveGCPBootImage(cl)
-	}
+	streamData := resolveStreamData()
 
 	return &DefaulterConfig{
 		PlatformStatus: infra.Status.PlatformStatus,
 		ClusterID:      infra.Status.InfrastructureName,
-		GCPBootImage:   gcpBootImage,
+		StreamData:     streamData,
 	}, nil
+}
+
+func resolveStreamData() *stream.Stream {
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		klog.Warningf("Failed to get kubeconfig for boot image resolution: %v", err)
+		return nil
+	}
+	cl, err := client.New(cfg, client.Options{})
+	if err != nil {
+		klog.Warningf("Failed to create client for boot image resolution: %v", err)
+		return nil
+	}
+
+	cm := &corev1.ConfigMap{}
+	key := client.ObjectKey{
+		Namespace: bootImagesConfigMapNamespace,
+		Name:      bootImagesConfigMapName,
+	}
+	if err := cl.Get(context.Background(), key, cm); err != nil {
+		klog.Warningf("Failed to read %s/%s ConfigMap: %v", bootImagesConfigMapNamespace, bootImagesConfigMapName, err)
+		return nil
+	}
+
+	rawStream, ok := cm.Data[bootImagesStreamKey]
+	if !ok {
+		klog.Warningf("ConfigMap %s/%s missing %q key", bootImagesConfigMapNamespace, bootImagesConfigMapName, bootImagesStreamKey)
+		return nil
+	}
+
+	sd := &stream.Stream{}
+	if err := json.Unmarshal([]byte(rawStream), sd); err != nil {
+		klog.Warningf("Failed to parse stream data from ConfigMap: %v", err)
+		return nil
+	}
+
+	return sd
 }
 
 // DefaulterConfig holds shared state for Machine and MachineSet defaulters.
 type DefaulterConfig struct {
 	PlatformStatus *osconfigv1.PlatformStatus
 	ClusterID      string
-	GCPBootImage   string
+	StreamData     *stream.Stream
 }
 
 // NewDefaulter returns a new machineDefaulterHandler.
 func NewMachineDefaulter(dc *DefaulterConfig) *admission.Webhook {
-	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(dc.PlatformStatus, dc.ClusterID, dc.GCPBootImage))
+	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(dc.PlatformStatus, dc.ClusterID, dc.StreamData))
 }
 
-func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, gcpBootImage string) *machineDefaulterHandler {
+func createMachineDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, streamData *stream.Stream) *machineDefaulterHandler {
 	return &machineDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: gcpBootImage},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, streamData: streamData},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -1373,6 +1369,36 @@ func validateAzureDiagnostics(diagnosticsSpec machinev1beta1.AzureDiagnostics, p
 	return errs
 }
 
+func getMachineArch(m *machinev1beta1.Machine) string {
+	if m.Annotations != nil {
+		if archLabel, ok := m.Annotations[machineArchAnnotationKey]; ok {
+			for label := range strings.SplitSeq(archLabel, ",") {
+				label = strings.TrimSpace(label)
+				if archValue, found := strings.CutPrefix(label, archLabelKey); found {
+					return archtranslater.RpmArch(archValue)
+				}
+			}
+		}
+	}
+	return archtranslater.CurrentRpmArch()
+}
+
+func getBootImageForGCP(streamData *stream.Stream, arch string) string {
+	if streamData == nil {
+		return ""
+	}
+	archData, ok := streamData.Architectures[arch]
+	if !ok {
+		klog.Warningf("No stream data found for architecture %q", arch)
+		return ""
+	}
+	if archData.Images.Gcp == nil {
+		klog.Warningf("No GCP image found in stream data for architecture %q", arch)
+		return ""
+	}
+	return fmt.Sprintf("projects/%s/global/images/%s", archData.Images.Gcp.Project, archData.Images.Gcp.Name)
+}
+
 func defaultGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []string, field.ErrorList) {
 	klog.V(3).Infof("Defaulting GCP providerSpec")
 
@@ -1401,7 +1427,7 @@ func defaultGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []str
 		})
 	}
 
-	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, config.clusterID, config.gcpBootImage)
+	providerSpec.Disks = defaultGCPDisks(providerSpec.Disks, config.clusterID, config.streamData, m)
 
 	if len(providerSpec.GPUs) != 0 {
 		// In case Count was not set it should default to 1, since there is no valid reason for it to be purposely set to 0.
@@ -1435,11 +1461,12 @@ func defaultGCP(m *machinev1beta1.Machine, config *admissionConfig) (bool, []str
 	return true, warnings, nil
 }
 
-func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string, gcpBootImage string) []*machinev1beta1.GCPDisk {
-	image := gcpBootImage
+func defaultGCPDisks(disks []*machinev1beta1.GCPDisk, clusterID string, streamData *stream.Stream, m *machinev1beta1.Machine) []*machinev1beta1.GCPDisk {
+	arch := getMachineArch(m)
+	image := getBootImageForGCP(streamData, arch)
 	if image == "" {
 		image = defaultGCPDiskImage()
-		klog.Infof("No GCP boot image resolved from worker machines, falling back to default: %s", image)
+		klog.Infof("No GCP boot image resolved from coreos-bootimages ConfigMap for arch %s, falling back to default: %s", arch, image)
 	}
 
 	if len(disks) == 0 {

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -2263,7 +2263,7 @@ func TestMachineCreation(t *testing.T) {
 			if !tc.disconnected {
 				dns.Spec.PublicZone = &osconfigv1.DNSZone{}
 			}
-			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID))
+			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, ""))
 			machineValidator := admission.WithValidator[*machinev1beta1.Machine](scheme.Scheme, createMachineValidator(infra, c, dns, gate))
 			mgr.GetWebhookServer().Register(DefaultMachineMutatingHookPath, &webhook.Admission{Handler: machineDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineValidatingHookPath, &webhook.Admission{Handler: machineValidator})
@@ -3125,7 +3125,7 @@ func TestMachineUpdate(t *testing.T) {
 					PlatformStatus:     platformStatus,
 				},
 			}
-			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID))
+			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, ""))
 			machineValidator := admission.WithValidator[*machinev1beta1.Machine](scheme.Scheme, createMachineValidator(infra, c, plainDNS, gate))
 			mgr.GetWebhookServer().Register(DefaultMachineMutatingHookPath, &webhook.Admission{Handler: machineDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineValidatingHookPath, &webhook.Admission{Handler: machineValidator})
@@ -3684,7 +3684,7 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 			Region: region,
 		},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -4410,7 +4410,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.AzurePlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
 			defaultProviderSpec := &machinev1beta1.AzureMachineProviderSpec{
@@ -5233,7 +5233,7 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 			ProjectID: projectID,
 		},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 
 	for _, tc := range testCases {
 		defaultProviderSpec := &machinev1beta1.GCPMachineProviderSpec{
@@ -5822,7 +5822,7 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.VSpherePlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -5895,7 +5895,7 @@ func TestDefaultNutanixProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.NutanixPlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -6505,7 +6505,7 @@ func TestDefaultPowerVSProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.PowerVSPlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID)
+	h := createMachineDefaulter(platformStatus, clusterID, "")
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -6787,5 +6787,289 @@ func TestValidateAzureCapacityReservationGroupID(t *testing.T) {
 				g.Expect(err).ToNot(HaveOccurred())
 			}
 		})
+	}
+}
+
+func TestResolveGCPBootImage(t *testing.T) {
+	matchingSuffix := "x86-64"
+	mismatchSuffix := "aarch64"
+	if arch == ARM64 {
+		matchingSuffix = "aarch64"
+		mismatchSuffix = "x86-64"
+	}
+
+	testCases := []struct {
+		name          string
+		machines      []machinev1beta1.Machine
+		expectedImage string
+	}{
+		{
+			name:          "no worker machines returns empty string",
+			machines:      nil,
+			expectedImage: "",
+		},
+		{
+			name: "worker machine with matching arch boot disk returns its image",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker-0",
+						Namespace: defaultSecretNamespace,
+						Labels: map[string]string{
+							machineRoleLabel: "worker",
+						},
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: func() []byte {
+									ps := &machinev1beta1.GCPMachineProviderSpec{
+										Disks: []*machinev1beta1.GCPDisk{
+											{
+												Boot:  true,
+												Image: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + matchingSuffix,
+											},
+										},
+									}
+									b, _ := json.Marshal(ps)
+									return b
+								}(),
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + matchingSuffix,
+		},
+		{
+			name: "worker machine with no boot disk image returns empty string",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker-0",
+						Namespace: defaultSecretNamespace,
+						Labels: map[string]string{
+							machineRoleLabel: "worker",
+						},
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: func() []byte {
+									ps := &machinev1beta1.GCPMachineProviderSpec{
+										Disks: []*machinev1beta1.GCPDisk{
+											{Boot: true, Image: ""},
+										},
+									}
+									b, _ := json.Marshal(ps)
+									return b
+								}(),
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "",
+		},
+		{
+			name: "master machine is skipped, worker machine is used",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "master-0",
+						Namespace: defaultSecretNamespace,
+						Labels: map[string]string{
+							machineRoleLabel: "master",
+						},
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: func() []byte {
+									ps := &machinev1beta1.GCPMachineProviderSpec{
+										Disks: []*machinev1beta1.GCPDisk{
+											{Boot: true, Image: "projects/rhcos-cloud/global/images/master-image-" + matchingSuffix},
+										},
+									}
+									b, _ := json.Marshal(ps)
+									return b
+								}(),
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker-0",
+						Namespace: defaultSecretNamespace,
+						Labels: map[string]string{
+							machineRoleLabel: "worker",
+						},
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: func() []byte {
+									ps := &machinev1beta1.GCPMachineProviderSpec{
+										Disks: []*machinev1beta1.GCPDisk{
+											{Boot: true, Image: "projects/rhcos-cloud/global/images/worker-image-" + matchingSuffix},
+										},
+									}
+									b, _ := json.Marshal(ps)
+									return b
+								}(),
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "projects/rhcos-cloud/global/images/worker-image-" + matchingSuffix,
+		},
+		{
+			name: "worker with wrong arch image is skipped",
+			machines: []machinev1beta1.Machine{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "worker-0",
+						Namespace: defaultSecretNamespace,
+						Labels: map[string]string{
+							machineRoleLabel: "worker",
+						},
+					},
+					Spec: machinev1beta1.MachineSpec{
+						ProviderSpec: machinev1beta1.ProviderSpec{
+							Value: &kruntime.RawExtension{
+								Raw: func() []byte {
+									ps := &machinev1beta1.GCPMachineProviderSpec{
+										Disks: []*machinev1beta1.GCPDisk{
+											{Boot: true, Image: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + mismatchSuffix},
+										},
+									}
+									b, _ := json.Marshal(ps)
+									return b
+								}(),
+							},
+						},
+					},
+				},
+			},
+			expectedImage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := make([]client.Object, len(tc.machines))
+			for i := range tc.machines {
+				objs[i] = &tc.machines[i]
+			}
+
+			c := fake.NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(objs...).
+				Build()
+
+			result := resolveGCPBootImage(c)
+			if result != tc.expectedImage {
+				t.Errorf("expected %q, got %q", tc.expectedImage, result)
+			}
+		})
+	}
+}
+
+func TestGCPDefaultsWithResolvedBootImage(t *testing.T) {
+	archSuffix := "x86-64"
+	if arch == ARM64 {
+		archSuffix = "aarch64"
+	}
+	resolvedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
+	clusterID := "gcp-cluster"
+	platformStatus := &osconfigv1.PlatformStatus{
+		Type: osconfigv1.GCPPlatformType,
+		GCP:  &osconfigv1.GCPPlatformStatus{},
+	}
+	h := createMachineDefaulter(platformStatus, clusterID, resolvedImage)
+
+	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
+		Region: "us-central1",
+		Zone:   "us-central1-a",
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultSecretNamespace,
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &kruntime.RawExtension{Raw: rawBytes},
+			},
+		},
+	}
+
+	ok, _, errs := h.webhookOperations(m, h.admissionConfig)
+	if !ok {
+		t.Fatalf("expected ok, got errors: %v", errs)
+	}
+
+	var result machinev1beta1.GCPMachineProviderSpec
+	if err := json.Unmarshal(m.Spec.ProviderSpec.Value.Raw, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Disks) == 0 {
+		t.Fatal("expected disks to be defaulted")
+	}
+	if result.Disks[0].Image != resolvedImage {
+		t.Errorf("expected disk image %q, got %q", resolvedImage, result.Disks[0].Image)
+	}
+}
+
+func TestGCPDefaultsFallbackToHardcodedImage(t *testing.T) {
+	clusterID := "gcp-cluster"
+	platformStatus := &osconfigv1.PlatformStatus{
+		Type: osconfigv1.GCPPlatformType,
+		GCP:  &osconfigv1.GCPPlatformStatus{},
+	}
+	h := createMachineDefaulter(platformStatus, clusterID, "")
+
+	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
+		Region: "us-central1",
+		Zone:   "us-central1-a",
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	m := &machinev1beta1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultSecretNamespace,
+		},
+		Spec: machinev1beta1.MachineSpec{
+			ProviderSpec: machinev1beta1.ProviderSpec{
+				Value: &kruntime.RawExtension{Raw: rawBytes},
+			},
+		},
+	}
+
+	ok, _, errs := h.webhookOperations(m, h.admissionConfig)
+	if !ok {
+		t.Fatalf("expected ok, got errors: %v", errs)
+	}
+
+	var result machinev1beta1.GCPMachineProviderSpec
+	if err := json.Unmarshal(m.Spec.ProviderSpec.Value.Raw, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Disks) == 0 {
+		t.Fatal("expected disks to be defaulted")
+	}
+	if result.Disks[0].Image != defaultGCPDiskImage() {
+		t.Errorf("expected fallback disk image %q, got %q", defaultGCPDiskImage(), result.Disks[0].Image)
 	}
 }

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/openshift/api/features"
 	testutils "github.com/openshift/machine-api-operator/pkg/util/testing"
 
+	archtranslater "github.com/coreos/stream-metadata-go/arch"
+	"github.com/coreos/stream-metadata-go/stream"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -45,6 +47,29 @@ var (
 		},
 	}
 )
+
+func fakeStreamData(project, name string) *stream.Stream {
+	return &stream.Stream{
+		Architectures: map[string]stream.Arch{
+			"x86_64": {
+				Images: stream.Images{
+					Gcp: &stream.GcpImage{
+						Project: project,
+						Name:    name + "-x86-64",
+					},
+				},
+			},
+			"aarch64": {
+				Images: stream.Images{
+					Gcp: &stream.GcpImage{
+						Project: project,
+						Name:    name + "-aarch64",
+					},
+				},
+			},
+		},
+	}
+}
 
 func TestMachineCreation(t *testing.T) {
 	g := NewWithT(t)
@@ -2263,7 +2288,7 @@ func TestMachineCreation(t *testing.T) {
 			if !tc.disconnected {
 				dns.Spec.PublicZone = &osconfigv1.DNSZone{}
 			}
-			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, ""))
+			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, nil))
 			machineValidator := admission.WithValidator[*machinev1beta1.Machine](scheme.Scheme, createMachineValidator(infra, c, dns, gate))
 			mgr.GetWebhookServer().Register(DefaultMachineMutatingHookPath, &webhook.Admission{Handler: machineDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineValidatingHookPath, &webhook.Admission{Handler: machineValidator})
@@ -3125,7 +3150,7 @@ func TestMachineUpdate(t *testing.T) {
 					PlatformStatus:     platformStatus,
 				},
 			}
-			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, ""))
+			machineDefaulter := admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.Machine{}, createMachineDefaulter(platformStatus, tc.clusterID, nil))
 			machineValidator := admission.WithValidator[*machinev1beta1.Machine](scheme.Scheme, createMachineValidator(infra, c, plainDNS, gate))
 			mgr.GetWebhookServer().Register(DefaultMachineMutatingHookPath, &webhook.Admission{Handler: machineDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineValidatingHookPath, &webhook.Admission{Handler: machineValidator})
@@ -3684,7 +3709,7 @@ func TestDefaultAWSProviderSpec(t *testing.T) {
 			Region: region,
 		},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -4410,7 +4435,7 @@ func TestDefaultAzureProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.AzurePlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
 			defaultProviderSpec := &machinev1beta1.AzureMachineProviderSpec{
@@ -5233,7 +5258,7 @@ func TestDefaultGCPProviderSpec(t *testing.T) {
 			ProjectID: projectID,
 		},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	for _, tc := range testCases {
 		defaultProviderSpec := &machinev1beta1.GCPMachineProviderSpec{
@@ -5822,7 +5847,7 @@ func TestDefaultVSphereProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.VSpherePlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -5895,7 +5920,7 @@ func TestDefaultNutanixProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.NutanixPlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -6505,7 +6530,7 @@ func TestDefaultPowerVSProviderSpec(t *testing.T) {
 	}
 
 	platformStatus := &osconfigv1.PlatformStatus{Type: osconfigv1.PowerVSPlatformType}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	for _, tc := range testCases {
 		t.Run(tc.testCase, func(t *testing.T) {
@@ -6790,205 +6815,19 @@ func TestValidateAzureCapacityReservationGroupID(t *testing.T) {
 	}
 }
 
-func TestResolveGCPBootImage(t *testing.T) {
-	matchingSuffix := "x86-64"
-	mismatchSuffix := "aarch64"
-	if arch == ARM64 {
-		matchingSuffix = "aarch64"
-		mismatchSuffix = "x86-64"
-	}
-
-	testCases := []struct {
-		name          string
-		machines      []machinev1beta1.Machine
-		expectedImage string
-	}{
-		{
-			name:          "no worker machines returns empty string",
-			machines:      nil,
-			expectedImage: "",
-		},
-		{
-			name: "worker machine with matching arch boot disk returns its image",
-			machines: []machinev1beta1.Machine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "worker-0",
-						Namespace: defaultSecretNamespace,
-						Labels: map[string]string{
-							machineRoleLabel: "worker",
-						},
-					},
-					Spec: machinev1beta1.MachineSpec{
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &kruntime.RawExtension{
-								Raw: func() []byte {
-									ps := &machinev1beta1.GCPMachineProviderSpec{
-										Disks: []*machinev1beta1.GCPDisk{
-											{
-												Boot:  true,
-												Image: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + matchingSuffix,
-											},
-										},
-									}
-									b, _ := json.Marshal(ps)
-									return b
-								}(),
-							},
-						},
-					},
-				},
-			},
-			expectedImage: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + matchingSuffix,
-		},
-		{
-			name: "worker machine with no boot disk image returns empty string",
-			machines: []machinev1beta1.Machine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "worker-0",
-						Namespace: defaultSecretNamespace,
-						Labels: map[string]string{
-							machineRoleLabel: "worker",
-						},
-					},
-					Spec: machinev1beta1.MachineSpec{
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &kruntime.RawExtension{
-								Raw: func() []byte {
-									ps := &machinev1beta1.GCPMachineProviderSpec{
-										Disks: []*machinev1beta1.GCPDisk{
-											{Boot: true, Image: ""},
-										},
-									}
-									b, _ := json.Marshal(ps)
-									return b
-								}(),
-							},
-						},
-					},
-				},
-			},
-			expectedImage: "",
-		},
-		{
-			name: "master machine is skipped, worker machine is used",
-			machines: []machinev1beta1.Machine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "master-0",
-						Namespace: defaultSecretNamespace,
-						Labels: map[string]string{
-							machineRoleLabel: "master",
-						},
-					},
-					Spec: machinev1beta1.MachineSpec{
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &kruntime.RawExtension{
-								Raw: func() []byte {
-									ps := &machinev1beta1.GCPMachineProviderSpec{
-										Disks: []*machinev1beta1.GCPDisk{
-											{Boot: true, Image: "projects/rhcos-cloud/global/images/master-image-" + matchingSuffix},
-										},
-									}
-									b, _ := json.Marshal(ps)
-									return b
-								}(),
-							},
-						},
-					},
-				},
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "worker-0",
-						Namespace: defaultSecretNamespace,
-						Labels: map[string]string{
-							machineRoleLabel: "worker",
-						},
-					},
-					Spec: machinev1beta1.MachineSpec{
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &kruntime.RawExtension{
-								Raw: func() []byte {
-									ps := &machinev1beta1.GCPMachineProviderSpec{
-										Disks: []*machinev1beta1.GCPDisk{
-											{Boot: true, Image: "projects/rhcos-cloud/global/images/worker-image-" + matchingSuffix},
-										},
-									}
-									b, _ := json.Marshal(ps)
-									return b
-								}(),
-							},
-						},
-					},
-				},
-			},
-			expectedImage: "projects/rhcos-cloud/global/images/worker-image-" + matchingSuffix,
-		},
-		{
-			name: "worker with wrong arch image is skipped",
-			machines: []machinev1beta1.Machine{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "worker-0",
-						Namespace: defaultSecretNamespace,
-						Labels: map[string]string{
-							machineRoleLabel: "worker",
-						},
-					},
-					Spec: machinev1beta1.MachineSpec{
-						ProviderSpec: machinev1beta1.ProviderSpec{
-							Value: &kruntime.RawExtension{
-								Raw: func() []byte {
-									ps := &machinev1beta1.GCPMachineProviderSpec{
-										Disks: []*machinev1beta1.GCPDisk{
-											{Boot: true, Image: "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + mismatchSuffix},
-										},
-									}
-									b, _ := json.Marshal(ps)
-									return b
-								}(),
-							},
-						},
-					},
-				},
-			},
-			expectedImage: "",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			objs := make([]client.Object, len(tc.machines))
-			for i := range tc.machines {
-				objs[i] = &tc.machines[i]
-			}
-
-			c := fake.NewClientBuilder().
-				WithScheme(scheme.Scheme).
-				WithObjects(objs...).
-				Build()
-
-			result := resolveGCPBootImage(c)
-			if result != tc.expectedImage {
-				t.Errorf("expected %q, got %q", tc.expectedImage, result)
-			}
-		})
-	}
-}
-
 func TestGCPDefaultsWithResolvedBootImage(t *testing.T) {
 	archSuffix := "x86-64"
 	if arch == ARM64 {
 		archSuffix = "aarch64"
 	}
-	resolvedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
+	expectedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
+	sd := fakeStreamData("rhcos-cloud", "rhcos-10-2-current-gcp")
 	clusterID := "gcp-cluster"
 	platformStatus := &osconfigv1.PlatformStatus{
 		Type: osconfigv1.GCPPlatformType,
 		GCP:  &osconfigv1.GCPPlatformStatus{},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID, resolvedImage)
+	h := createMachineDefaulter(platformStatus, clusterID, sd)
 
 	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
 		Region: "us-central1",
@@ -7023,8 +6862,8 @@ func TestGCPDefaultsWithResolvedBootImage(t *testing.T) {
 	if len(result.Disks) == 0 {
 		t.Fatal("expected disks to be defaulted")
 	}
-	if result.Disks[0].Image != resolvedImage {
-		t.Errorf("expected disk image %q, got %q", resolvedImage, result.Disks[0].Image)
+	if result.Disks[0].Image != expectedImage {
+		t.Errorf("expected disk image %q, got %q", expectedImage, result.Disks[0].Image)
 	}
 }
 
@@ -7034,7 +6873,7 @@ func TestGCPDefaultsFallbackToHardcodedImage(t *testing.T) {
 		Type: osconfigv1.GCPPlatformType,
 		GCP:  &osconfigv1.GCPPlatformStatus{},
 	}
-	h := createMachineDefaulter(platformStatus, clusterID, "")
+	h := createMachineDefaulter(platformStatus, clusterID, nil)
 
 	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
 		Region: "us-central1",
@@ -7071,5 +6910,106 @@ func TestGCPDefaultsFallbackToHardcodedImage(t *testing.T) {
 	}
 	if result.Disks[0].Image != defaultGCPDiskImage() {
 		t.Errorf("expected fallback disk image %q, got %q", defaultGCPDiskImage(), result.Disks[0].Image)
+	}
+}
+
+func TestGetMachineArch(t *testing.T) {
+	podArch := archtranslater.CurrentRpmArch()
+
+	testCases := []struct {
+		name         string
+		annotations  map[string]string
+		expectedArch string
+	}{
+		{
+			name:         "no annotation returns pod arch",
+			annotations:  nil,
+			expectedArch: podArch,
+		},
+		{
+			name: "annotation with amd64 returns x86_64",
+			annotations: map[string]string{
+				machineArchAnnotationKey: "kubernetes.io/arch=amd64",
+			},
+			expectedArch: "x86_64",
+		},
+		{
+			name: "annotation with arm64 returns aarch64",
+			annotations: map[string]string{
+				machineArchAnnotationKey: "kubernetes.io/arch=arm64",
+			},
+			expectedArch: "aarch64",
+		},
+		{
+			name: "annotation with multiple labels parses arch correctly",
+			annotations: map[string]string{
+				machineArchAnnotationKey: "kubernetes.io/arch=arm64,topology.ebs.csi.aws.com/zone=us-east-1a",
+			},
+			expectedArch: "aarch64",
+		},
+		{
+			name: "annotation without arch label returns pod arch",
+			annotations: map[string]string{
+				machineArchAnnotationKey: "topology.ebs.csi.aws.com/zone=us-east-1a",
+			},
+			expectedArch: podArch,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &machinev1beta1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tc.annotations,
+				},
+			}
+			result := getMachineArch(m)
+			if result != tc.expectedArch {
+				t.Errorf("expected %q, got %q", tc.expectedArch, result)
+			}
+		})
+	}
+}
+
+func TestGetBootImageForGCP(t *testing.T) {
+	testCases := []struct {
+		name          string
+		streamData    *stream.Stream
+		arch          string
+		expectedImage string
+	}{
+		{
+			name:          "nil stream data returns empty",
+			streamData:    nil,
+			arch:          "x86_64",
+			expectedImage: "",
+		},
+		{
+			name:          "valid stream data returns correct image",
+			streamData:    fakeStreamData("rhcos-cloud", "rhcos-420-gcp"),
+			arch:          "x86_64",
+			expectedImage: "projects/rhcos-cloud/global/images/rhcos-420-gcp-x86-64",
+		},
+		{
+			name:          "aarch64 returns correct image",
+			streamData:    fakeStreamData("rhcos-cloud", "rhcos-420-gcp"),
+			arch:          "aarch64",
+			expectedImage: "projects/rhcos-cloud/global/images/rhcos-420-gcp-aarch64",
+		},
+		{
+			name:          "unknown arch returns empty",
+			streamData:    fakeStreamData("rhcos-cloud", "rhcos-420-gcp"),
+			arch:          "ppc64le",
+			expectedImage: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getBootImageForGCP(tc.streamData, tc.arch)
+			if result != tc.expectedImage {
+				t.Errorf("expected %q, got %q", tc.expectedImage, result)
+			}
+		})
 	}
 }

--- a/pkg/webhooks/machineset_webhook.go
+++ b/pkg/webhooks/machineset_webhook.go
@@ -66,19 +66,14 @@ func createMachineSetValidator(infra *osconfigv1.Infrastructure, client client.C
 }
 
 // NewMachineSetDefaulter returns a new machineSetDefaulterHandler.
-func NewMachineSetDefaulter() (*admission.Webhook, error) {
-	infra, err := getInfra()
-	if err != nil {
-		return nil, err
-	}
-
-	return createMachineSetDefaulter(infra.Status.PlatformStatus, infra.Status.InfrastructureName), nil
+func NewMachineSetDefaulter(dc *DefaulterConfig) *admission.Webhook {
+	return createMachineSetDefaulter(dc.PlatformStatus, dc.ClusterID, dc.GCPBootImage)
 }
 
-func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string) *admission.Webhook {
+func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, gcpBootImage string) *admission.Webhook {
 	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.MachineSet{}, &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: gcpBootImage},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	})

--- a/pkg/webhooks/machineset_webhook.go
+++ b/pkg/webhooks/machineset_webhook.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/coreos/stream-metadata-go/stream"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	machinev1beta1 "github.com/openshift/api/machine/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,13 +68,13 @@ func createMachineSetValidator(infra *osconfigv1.Infrastructure, client client.C
 
 // NewMachineSetDefaulter returns a new machineSetDefaulterHandler.
 func NewMachineSetDefaulter(dc *DefaulterConfig) *admission.Webhook {
-	return createMachineSetDefaulter(dc.PlatformStatus, dc.ClusterID, dc.GCPBootImage)
+	return createMachineSetDefaulter(dc.PlatformStatus, dc.ClusterID, dc.StreamData)
 }
 
-func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, gcpBootImage string) *admission.Webhook {
+func createMachineSetDefaulter(platformStatus *osconfigv1.PlatformStatus, clusterID string, streamData *stream.Stream) *admission.Webhook {
 	return admission.WithCustomDefaulter(scheme.Scheme, &machinev1beta1.MachineSet{}, &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: gcpBootImage},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, streamData: streamData},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	})

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -518,7 +518,7 @@ func TestMachineSetCreation(t *testing.T) {
 				t.Errorf("Unexpected error setting up feature gates: %v", err)
 			}
 
-			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, "")
+			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, nil)
 			machineSetValidator := createMachineSetValidator(infra, c, dns, gate)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
@@ -1205,7 +1205,7 @@ func TestMachineSetUpdate(t *testing.T) {
 				t.Errorf("Unexpected error setting up feature gates: %v", err)
 			}
 
-			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, "")
+			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, nil)
 			machineSetValidator := createMachineSetValidator(infra, c, plainDNS, gate)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
@@ -1289,7 +1289,8 @@ func TestMachineSetGCPDefaultsWithResolvedBootImage(t *testing.T) {
 	if arch == ARM64 {
 		archSuffix = "aarch64"
 	}
-	resolvedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
+	sd := fakeStreamData("rhcos-cloud", "rhcos-10-2-current-gcp")
+	expectedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
 	clusterID := "gcp-cluster"
 	platformStatus := &osconfigv1.PlatformStatus{
 		Type: osconfigv1.GCPPlatformType,
@@ -1322,7 +1323,7 @@ func TestMachineSetGCPDefaultsWithResolvedBootImage(t *testing.T) {
 
 	h := &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: resolvedImage},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, streamData: sd},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}
@@ -1340,8 +1341,8 @@ func TestMachineSetGCPDefaultsWithResolvedBootImage(t *testing.T) {
 	if len(result.Disks) == 0 {
 		t.Fatal("expected disks to be defaulted")
 	}
-	if result.Disks[0].Image != resolvedImage {
-		t.Errorf("expected disk image %q, got %q", resolvedImage, result.Disks[0].Image)
+	if result.Disks[0].Image != expectedImage {
+		t.Errorf("expected disk image %q, got %q", expectedImage, result.Disks[0].Image)
 	}
 }
 
@@ -1378,7 +1379,7 @@ func TestMachineSetGCPDefaultsFallbackToHardcodedImage(t *testing.T) {
 
 	h := &machineSetDefaulterHandler{
 		admissionHandler: &admissionHandler{
-			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: ""},
+			admissionConfig:   &admissionConfig{clusterID: clusterID, streamData: nil},
 			webhookOperations: getMachineDefaulterOperation(platformStatus),
 		},
 	}

--- a/pkg/webhooks/machineset_webhook_test.go
+++ b/pkg/webhooks/machineset_webhook_test.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -517,7 +518,7 @@ func TestMachineSetCreation(t *testing.T) {
 				t.Errorf("Unexpected error setting up feature gates: %v", err)
 			}
 
-			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
+			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, "")
 			machineSetValidator := createMachineSetValidator(infra, c, dns, gate)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
@@ -1204,7 +1205,7 @@ func TestMachineSetUpdate(t *testing.T) {
 				t.Errorf("Unexpected error setting up feature gates: %v", err)
 			}
 
-			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID)
+			machineSetDefaulter := createMachineSetDefaulter(platformStatus, tc.clusterID, "")
 			machineSetValidator := createMachineSetValidator(infra, c, plainDNS, gate)
 			mgr.GetWebhookServer().Register(DefaultMachineSetMutatingHookPath, &webhook.Admission{Handler: machineSetDefaulter})
 			mgr.GetWebhookServer().Register(DefaultMachineSetValidatingHookPath, &webhook.Admission{Handler: machineSetValidator})
@@ -1280,5 +1281,122 @@ func TestMachineSetUpdate(t *testing.T) {
 				gs.Expect(err).To(BeNil())
 			}
 		})
+	}
+}
+
+func TestMachineSetGCPDefaultsWithResolvedBootImage(t *testing.T) {
+	archSuffix := "x86-64"
+	if arch == ARM64 {
+		archSuffix = "aarch64"
+	}
+	resolvedImage := "projects/rhcos-cloud/global/images/rhcos-10-2-current-gcp-" + archSuffix
+	clusterID := "gcp-cluster"
+	platformStatus := &osconfigv1.PlatformStatus{
+		Type: osconfigv1.GCPPlatformType,
+		GCP:  &osconfigv1.GCPPlatformStatus{},
+	}
+
+	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
+		Region: "us-central1",
+		Zone:   "us-central1-a",
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ms := &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultSecretNamespace,
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawBytes},
+					},
+				},
+			},
+		},
+	}
+
+	h := &machineSetDefaulterHandler{
+		admissionHandler: &admissionHandler{
+			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: resolvedImage},
+			webhookOperations: getMachineDefaulterOperation(platformStatus),
+		},
+	}
+
+	ok, _, errs := h.defaultMachineSet(ms)
+	if !ok {
+		t.Fatalf("expected ok, got errors: %v", errs)
+	}
+
+	var result machinev1beta1.GCPMachineProviderSpec
+	if err := json.Unmarshal(ms.Spec.Template.Spec.ProviderSpec.Value.Raw, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Disks) == 0 {
+		t.Fatal("expected disks to be defaulted")
+	}
+	if result.Disks[0].Image != resolvedImage {
+		t.Errorf("expected disk image %q, got %q", resolvedImage, result.Disks[0].Image)
+	}
+}
+
+func TestMachineSetGCPDefaultsFallbackToHardcodedImage(t *testing.T) {
+	clusterID := "gcp-cluster"
+	platformStatus := &osconfigv1.PlatformStatus{
+		Type: osconfigv1.GCPPlatformType,
+		GCP:  &osconfigv1.GCPPlatformStatus{},
+	}
+
+	providerSpec := &machinev1beta1.GCPMachineProviderSpec{
+		Region: "us-central1",
+		Zone:   "us-central1-a",
+	}
+	rawBytes, err := json.Marshal(providerSpec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ms := &machinev1beta1.MachineSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: defaultSecretNamespace,
+		},
+		Spec: machinev1beta1.MachineSetSpec{
+			Template: machinev1beta1.MachineTemplateSpec{
+				Spec: machinev1beta1.MachineSpec{
+					ProviderSpec: machinev1beta1.ProviderSpec{
+						Value: &runtime.RawExtension{Raw: rawBytes},
+					},
+				},
+			},
+		},
+	}
+
+	h := &machineSetDefaulterHandler{
+		admissionHandler: &admissionHandler{
+			admissionConfig:   &admissionConfig{clusterID: clusterID, gcpBootImage: ""},
+			webhookOperations: getMachineDefaulterOperation(platformStatus),
+		},
+	}
+
+	ok, _, errs := h.defaultMachineSet(ms)
+	if !ok {
+		t.Fatalf("expected ok, got errors: %v", errs)
+	}
+
+	var result machinev1beta1.GCPMachineProviderSpec
+	if err := json.Unmarshal(ms.Spec.Template.Spec.ProviderSpec.Value.Raw, &result); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(result.Disks) == 0 {
+		t.Fatal("expected disks to be defaulted")
+	}
+	if result.Disks[0].Image != defaultGCPDiskImage() {
+		t.Errorf("expected fallback disk image %q, got %q", defaultGCPDiskImage(), result.Disks[0].Image)
 	}
 }

--- a/vendor/github.com/coreos/stream-metadata-go/LICENSE
+++ b/vendor/github.com/coreos/stream-metadata-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/stream-metadata-go/arch/arch.go
+++ b/vendor/github.com/coreos/stream-metadata-go/arch/arch.go
@@ -1,0 +1,48 @@
+// package arch contains mappings between the Golang architecture and
+// the RPM architecture used by Fedora CoreOS and derivatives.
+package arch
+
+import "runtime"
+
+type mapping struct {
+	rpmArch string
+	goArch  string
+}
+
+// If an architecture isn't defined here, we assume it's
+// pass through.
+var translations = []mapping{
+	{
+		rpmArch: "x86_64",
+		goArch:  "amd64",
+	},
+	{
+		rpmArch: "aarch64",
+		goArch:  "arm64",
+	},
+}
+
+// CurrentRpmArch returns the current architecture in RPM terms.
+func CurrentRpmArch() string {
+	return RpmArch(runtime.GOARCH)
+}
+
+// RpmArch translates a Go architecture to RPM.
+func RpmArch(goarch string) string {
+	for _, m := range translations {
+		if m.goArch == goarch {
+			return m.rpmArch
+		}
+	}
+	return goarch
+}
+
+// GoArch translates an RPM architecture to Go.
+func GoArch(rpmarch string) string {
+	for _, m := range translations {
+		if m.rpmArch == rpmarch {
+			return m.goArch
+		}
+	}
+	return rpmarch
+}

--- a/vendor/github.com/coreos/stream-metadata-go/stream/artifact_utils.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/artifact_utils.go
@@ -1,0 +1,98 @@
+package stream
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"path/filepath"
+)
+
+// Fetch an artifact, validating its checksum.  If applicable,
+// the artifact will not be decompressed.  Does not
+// validate GPG signature.
+func (a *Artifact) Fetch(w io.Writer) error {
+	resp, err := http.Get(a.Location)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(resp.Body.Close())
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s returned status: %s", a.Location, resp.Status)
+	}
+	hasher := sha256.New()
+	reader := io.TeeReader(resp.Body, hasher)
+
+	_, err = io.Copy(w, reader)
+	if err != nil {
+		return err
+	}
+
+	// Validate sha256 checksum
+	foundChecksum := fmt.Sprintf("%x", hasher.Sum(nil))
+	if a.Sha256 != foundChecksum {
+		return fmt.Errorf("checksum mismatch for %s; expected=%s found=%s", a.Location, a.Sha256, foundChecksum)
+	}
+
+	return nil
+}
+
+// Name returns the "basename" of the artifact, i.e. the contents
+// after the last `/`.  This can be useful when downloading to a file.
+func (a *Artifact) Name() (string, error) {
+	loc, err := url.Parse(a.Location)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse artifact url: %w", err)
+	}
+	// Note this one uses `path` since even on Windows URLs have forward slashes.
+	return path.Base(loc.Path), nil
+}
+
+// Download fetches the specified artifact and saves it to the target
+// directory.  The full file path will be returned as a string.
+// If the target file path exists, it will be overwritten.
+// If the download fails, the temporary file will be deleted.
+func (a *Artifact) Download(destdir string) (string, error) {
+	name, err := a.Name()
+	if err != nil {
+		return "", err
+	}
+	destfile := filepath.Join(destdir, name)
+	w, err := os.CreateTemp(destdir, ".coreos-artifact-")
+	if err != nil {
+		return "", err
+	}
+	finalized := false
+	defer func() {
+		if !finalized {
+			// Ignore an error to unlink
+			_ = os.Remove(w.Name())
+		}
+	}()
+
+	if err := a.Fetch(w); err != nil {
+		return "", err
+	}
+	if err := w.Sync(); err != nil {
+		return "", err
+	}
+	if err := w.Chmod(0644); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	if err := os.Rename(w.Name(), destfile); err != nil {
+		return "", err
+	}
+	finalized = true
+
+	return destfile, nil
+}

--- a/vendor/github.com/coreos/stream-metadata-go/stream/rhcos/rhcos.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/rhcos/rhcos.go
@@ -1,0 +1,92 @@
+package rhcos
+
+import "fmt"
+
+// Extensions is data specific to Red Hat Enterprise Linux CoreOS
+type Extensions struct {
+	AwsWinLi    *AwsWinLi    `json:"aws-winli,omitempty"`
+	AzureDisk   *AzureDisk   `json:"azure-disk,omitempty"`
+	Marketplace *Marketplace `json:"marketplace,omitempty"`
+}
+
+// AzureDisk represents an Azure disk image that can be imported
+// into an image gallery or otherwise replicated, and then used
+// as a boot source for virtual machines.
+type AzureDisk struct {
+	// Release is the source release version
+	Release string `json:"release"`
+	// URL to an image already stored in Azure infrastructure
+	// that can be copied into an image gallery.  Avoid creating VMs directly
+	// from this URL as that may lead to performance limitations.
+	URL string `json:"url,omitempty"`
+}
+
+// AwsWinLi represents prebuilt AWS Windows License Included Images.
+type AwsWinLi = ReplicatedImage
+
+// ReplicatedImage represents an image in all regions of an AWS-like cloud
+// This struct was copied from the release package to avoid an import cycle,
+// and is used to describe all AWS WinLI Images in all regions.
+type ReplicatedImage struct {
+	Regions map[string]SingleImage `json:"regions,omitempty"`
+}
+
+// SingleImage represents a globally-accessible image or an image in a
+// single region of an AWS-like cloud
+// This struct was copied from the release package to avoid an import cycle,
+// and is used to describe individual AWS WinLI Images.
+type SingleImage struct {
+	Release string `json:"release"`
+	Image   string `json:"image"`
+}
+
+// Marketplace contains marketplace images for all clouds.
+type Marketplace struct {
+	Azure *AzureMarketplace `json:"azure,omitempty"`
+}
+
+// AzureMarketplaceImages contains both the HyperV- Gen1 & Gen2
+// images for a purchase plan.
+type AzureMarketplaceImages struct {
+	Gen1 *AzureMarketplaceImage `json:"hyperVGen1,omitempty"`
+	Gen2 *AzureMarketplaceImage `json:"hyperVGen2,omitempty"`
+}
+
+// AzureMarketplace lists images, both paid and
+// unpaid, available in the Azure marketplace.
+type AzureMarketplace struct {
+	// NoPurchasePlan is the standard, unpaid RHCOS image.
+	NoPurchasePlan *AzureMarketplaceImages `json:"no-purchase-plan,omitempty"`
+
+	// OCP is the paid marketplace image for OpenShift Container Platform.
+	OCP *AzureMarketplaceImages `json:"ocp,omitempty"`
+
+	// OPP is the paid marketplace image for OpenShift Platform Plus.
+	OPP *AzureMarketplaceImages `json:"opp,omitempty"`
+
+	// OKE is the paid marketplace image for OpenShift Kubernetes Engine.
+	OKE *AzureMarketplaceImages `json:"oke,omitempty"`
+
+	// OCPEMEA is the paid marketplace image for OpenShift Container Platform in EMEA regions.
+	OCPEMEA *AzureMarketplaceImages `json:"ocp-emea,omitempty"`
+
+	// OPPEMEA is the paid marketplace image for OpenShift Platform Plus in EMEA regions.
+	OPPEMEA *AzureMarketplaceImages `json:"opp-emea,omitempty"`
+
+	// OKEEMEA is the paid marketplace image for OpenShift Kubernetes Engine in EMEA regions.
+	OKEEMEA *AzureMarketplaceImages `json:"oke-emea,omitempty"`
+}
+
+// AzureMarketplaceImage defines the attributes for an Azure
+// marketplace image.
+type AzureMarketplaceImage struct {
+	Publisher string `json:"publisher"`
+	Offer     string `json:"offer"`
+	SKU       string `json:"sku"`
+	Version   string `json:"version"`
+}
+
+// URN returns the image URN for the marketplace image.
+func (i *AzureMarketplaceImage) URN() string {
+	return fmt.Sprintf("%s:%s:%s:%s", i.Publisher, i.Offer, i.SKU, i.Version)
+}

--- a/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/stream.go
@@ -1,0 +1,116 @@
+// Package stream models a CoreOS "stream", which is
+// a description of the recommended set of binary images for CoreOS.   Use
+// this API to find cloud images, bare metal disk images, etc.
+package stream
+
+import (
+	"github.com/coreos/stream-metadata-go/stream/rhcos"
+)
+
+// Stream contains artifacts available in a stream
+type Stream struct {
+	Stream        string          `json:"stream"`
+	Metadata      Metadata        `json:"metadata"`
+	Architectures map[string]Arch `json:"architectures"`
+}
+
+// Metadata for a release or stream
+type Metadata struct {
+	LastModified string `json:"last-modified"`
+	Generator    string `json:"generator,omitempty"`
+}
+
+// Arch contains release details for a particular hardware architecture
+type Arch struct {
+	Artifacts map[string]PlatformArtifacts `json:"artifacts"`
+	Images    Images                       `json:"images,omitempty"`
+	// RHELCoreOSExtensions is data specific to Red Hat Enterprise Linux CoreOS
+	RHELCoreOSExtensions *rhcos.Extensions `json:"rhel-coreos-extensions,omitempty"`
+}
+
+// PlatformArtifacts contains images for a platform
+type PlatformArtifacts struct {
+	Release string                 `json:"release"`
+	Formats map[string]ImageFormat `json:"formats"`
+}
+
+// ImageFormat contains all artifacts for a single OS image
+type ImageFormat struct {
+	Disk      *Artifact `json:"disk,omitempty"`
+	Kernel    *Artifact `json:"kernel,omitempty"`
+	Initramfs *Artifact `json:"initramfs,omitempty"`
+	Rootfs    *Artifact `json:"rootfs,omitempty"`
+}
+
+// Artifact represents one image file, plus its metadata
+type Artifact struct {
+	Location           string `json:"location"`
+	Signature          string `json:"signature,omitempty"`
+	Sha256             string `json:"sha256"`
+	UncompressedSha256 string `json:"uncompressed-sha256,omitempty"`
+}
+
+// Images contains images available in cloud providers
+type Images struct {
+	Aliyun   *ReplicatedImage  `json:"aliyun,omitempty"`
+	Aws      *AwsImage         `json:"aws,omitempty"`
+	Gcp      *GcpImage         `json:"gcp,omitempty"`
+	Ibmcloud *ReplicatedObject `json:"ibmcloud,omitempty"`
+	KubeVirt *ContainerImage   `json:"kubevirt,omitempty"`
+	PowerVS  *ReplicatedObject `json:"powervs,omitempty"`
+}
+
+// ReplicatedImage represents an image in all regions of an AWS-like cloud
+type ReplicatedImage struct {
+	Regions map[string]SingleImage `json:"regions,omitempty"`
+}
+
+// SingleImage represents a globally-accessible image or an image in a
+// single region of an AWS-like cloud
+type SingleImage struct {
+	Release string `json:"release"`
+	Image   string `json:"image"`
+}
+
+// ContainerImage represents a tagged container image
+type ContainerImage struct {
+	Release string `json:"release"`
+	// Preferred way to reference the image, which might be by tag or digest
+	Image     string `json:"image"`
+	DigestRef string `json:"digest-ref"`
+}
+
+// AwsImage is a typedef for backwards compatibility.
+type AwsImage = ReplicatedImage
+
+// AwsRegionImage is a typedef for backwards compatibility.
+type AwsRegionImage = SingleImage
+
+// RegionImage is a typedef for backwards compatibility.
+type RegionImage = SingleImage
+
+// GcpImage represents a GCP cloud image
+type GcpImage struct {
+	Release string `json:"release"`
+	Project string `json:"project"`
+	Family  string `json:"family,omitempty"`
+	Name    string `json:"name"`
+}
+
+// ReplicatedObject represents an object in all regions of an IBMCloud-like
+// cloud
+type ReplicatedObject struct {
+	Regions map[string]SingleObject `json:"regions,omitempty"`
+}
+
+// SingleObject represents a globally-accessible cloud storage object, or
+// an object in a single region of an IBMCloud-like cloud
+type SingleObject struct {
+	Release string `json:"release"`
+	Object  string `json:"object"`
+	Bucket  string `json:"bucket"`
+	Url     string `json:"url"`
+}
+
+// RegionObject is a typedef for backwards compatibility.
+type RegionObject = SingleObject

--- a/vendor/github.com/coreos/stream-metadata-go/stream/stream_utils.go
+++ b/vendor/github.com/coreos/stream-metadata-go/stream/stream_utils.go
@@ -1,0 +1,94 @@
+package stream
+
+import "fmt"
+
+// FormatPrefix describes a stream+architecture combination, intended for prepending to error messages
+func (st *Stream) FormatPrefix(archname string) string {
+	return fmt.Sprintf("%s/%s", st.Stream, archname)
+}
+
+// GetArchitecture loads the architecture-specific builds from a stream,
+// with a useful descriptive error message if the architecture is not found.
+func (st *Stream) GetArchitecture(archname string) (*Arch, error) {
+	archdata, ok := st.Architectures[archname]
+	if !ok {
+		return nil, fmt.Errorf("stream:%s does not have architecture '%s'", st.Stream, archname)
+	}
+	return &archdata, nil
+}
+
+// GetAliyunRegionImage returns the release data (Image ID and release ID) for a particular
+// architecture and region.
+func (st *Stream) GetAliyunRegionImage(archname, region string) (*SingleImage, error) {
+	starch, err := st.GetArchitecture(archname)
+	if err != nil {
+		return nil, err
+	}
+	aliyunimages := starch.Images.Aliyun
+	if aliyunimages == nil {
+		return nil, fmt.Errorf("%s: No Aliyun images", st.FormatPrefix(archname))
+	}
+	var regionVal SingleImage
+	var ok bool
+	if regionVal, ok = aliyunimages.Regions[region]; !ok {
+		return nil, fmt.Errorf("%s: No Aliyun images in region %s", st.FormatPrefix(archname), region)
+	}
+
+	return &regionVal, nil
+}
+
+// GetAliyunImage returns the Aliyun image for a particular architecture and region.
+func (st *Stream) GetAliyunImage(archname, region string) (string, error) {
+	regionVal, err := st.GetAliyunRegionImage(archname, region)
+	if err != nil {
+		return "", err
+	}
+	return regionVal.Image, nil
+}
+
+// GetAwsRegionImage returns the release data (AMI and release ID) for a particular
+// architecture and region.
+func (st *Stream) GetAwsRegionImage(archname, region string) (*SingleImage, error) {
+	starch, err := st.GetArchitecture(archname)
+	if err != nil {
+		return nil, err
+	}
+	awsimages := starch.Images.Aws
+	if awsimages == nil {
+		return nil, fmt.Errorf("%s: No AWS images", st.FormatPrefix(archname))
+	}
+	var regionVal SingleImage
+	var ok bool
+	if regionVal, ok = awsimages.Regions[region]; !ok {
+		return nil, fmt.Errorf("%s: No AWS images in region %s", st.FormatPrefix(archname), region)
+	}
+
+	return &regionVal, nil
+}
+
+// GetAMI returns the AWS machine image for a particular architecture and region.
+func (st *Stream) GetAMI(archname, region string) (string, error) {
+	regionVal, err := st.GetAwsRegionImage(archname, region)
+	if err != nil {
+		return "", err
+	}
+	return regionVal.Image, nil
+}
+
+// QueryDisk finds the singleton disk artifact for a given format and architecture.
+func (st *Stream) QueryDisk(architectureName, artifactName, formatName string) (*Artifact, error) {
+	arch, err := st.GetArchitecture(architectureName)
+	if err != nil {
+		return nil, err
+	}
+	artifacts := arch.Artifacts[artifactName]
+	if artifacts.Release == "" {
+		return nil, fmt.Errorf("%s: artifact '%s' not found", st.FormatPrefix(architectureName), artifactName)
+	}
+	format := artifacts.Formats[formatName]
+	if format.Disk == nil {
+		return nil, fmt.Errorf("%s: artifact '%s' format '%s' disk not found", st.FormatPrefix(architectureName), artifactName, formatName)
+	}
+
+	return format.Disk, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -212,6 +212,11 @@ github.com/coreos/go-semver/semver
 github.com/coreos/go-systemd/v22/daemon
 github.com/coreos/go-systemd/v22/dbus
 github.com/coreos/go-systemd/v22/journal
+# github.com/coreos/stream-metadata-go v0.4.10-0.20250806142651-4a7d280a6c7b
+## explicit; go 1.18
+github.com/coreos/stream-metadata-go/arch
+github.com/coreos/stream-metadata-go/stream
+github.com/coreos/stream-metadata-go/stream/rhcos
 # github.com/curioswitch/go-reassign v0.3.0
 ## explicit; go 1.21
 github.com/curioswitch/go-reassign


### PR DESCRIPTION
Instead of hardcoding a stale RHCOS 4.14 boot disk image for GCP defaults, resolve the image dynamically from existing worker machines at webhook startup. Falls back to the hardcoded default when no workers are found. Filters by architecture (x86-64/aarch64) to avoid selecting the wrong image on mixed-arch clusters.

Introduces ResolveDefaulterConfig() so both Machine and MachineSet defaulters share a single client and boot image resolution call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GCP boot disk defaulting for both Machine and MachineSet webhooks by selecting the most appropriate boot image using architecture-aware matching, with automatic fallback to existing defaults when no match is available.
* **Refactor**
  * Updated webhook defaulting to use a shared, configuration-driven setup so Machine and MachineSet behave consistently.
* **Tests**
  * Expanded unit test coverage for GCP boot image resolution (including architecture selection), resolved-image defaulting, and fallback behavior across both webhooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->