### PR TITLE
SPLAT-2854: Fixing issue related to unintended VAP interactions

### DIFF
--- a/pkg/webhooks/vap.go
+++ b/pkg/webhooks/vap.go
@@ -41,6 +41,11 @@ var (
 	vapParamNotFoundAllow = admissionregistrationv1.AllowAction
 )
 
+func matchPolicyEquivalent() *admissionregistrationv1.MatchPolicyType {
+	p := admissionregistrationv1.Equivalent
+	return &p
+}
+
 // NewVSphereFailureDomainMachineVAP returns a ValidatingAdmissionPolicy that prevents
 // an infrastructure/cluster UPDATE from removing a vSphere failure domain that is still
 // referenced by at least one Machine (identified via machine.openshift.io/region and
@@ -64,6 +69,9 @@ func NewVSphereFailureDomainMachineVAP() *admissionregistrationv1.ValidatingAdmi
 			},
 			// Fire on UPDATE of the Infrastructure CR only.
 			MatchConstraints: &admissionregistrationv1.MatchResources{
+				MatchPolicy:       matchPolicyEquivalent(),
+				NamespaceSelector: &metav1.LabelSelector{},
+				ObjectSelector:    &metav1.LabelSelector{},
 				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
 					{
 						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
@@ -172,6 +180,9 @@ func NewVSphereFailureDomainCPMSVAP() *admissionregistrationv1.ValidatingAdmissi
 			},
 			// Fire on UPDATE of the Infrastructure CR only.
 			MatchConstraints: &admissionregistrationv1.MatchResources{
+				MatchPolicy:       matchPolicyEquivalent(),
+				NamespaceSelector: &metav1.LabelSelector{},
+				ObjectSelector:    &metav1.LabelSelector{},
 				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
 					{
 						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
@@ -276,6 +287,9 @@ func NewVSphereFailureDomainMachineSetVAP() *admissionregistrationv1.ValidatingA
 			},
 			// Trigger: UPDATE of the Infrastructure CR only.
 			MatchConstraints: &admissionregistrationv1.MatchResources{
+				MatchPolicy:       matchPolicyEquivalent(),
+				NamespaceSelector: &metav1.LabelSelector{},
+				ObjectSelector:    &metav1.LabelSelector{},
 				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
 					{
 						RuleWithOperations: admissionregistrationv1.RuleWithOperations{

--- a/pkg/webhooks/vap_test.go
+++ b/pkg/webhooks/vap_test.go
@@ -239,6 +239,44 @@ func TestNewVSphereFailureDomainMachineSetVAPBinding(t *testing.T) {
 	g.Expect(spec.ValidationActions).To(ConsistOf(admissionregistrationv1.Deny))
 }
 
+// TestVAPMatchConstraintsServerDefaultedFields ensures that all three VAPs explicitly set
+// MatchPolicy, NamespaceSelector, and ObjectSelector on MatchConstraints. When these fields
+// are nil, the API server defaults them on storage. On the next sync cycle, resourceapply
+// sees a diff between the desired spec (nil) and the stored spec (defaulted), triggering a
+// spurious UPDATE every cycle. See SPLAT-2854.
+func TestVAPMatchConstraintsServerDefaultedFields(t *testing.T) {
+	expectedMatchPolicy := admissionregistrationv1.Equivalent
+	expectedSelector := &metav1.LabelSelector{}
+
+	tests := []struct {
+		name   string
+		policy *admissionregistrationv1.ValidatingAdmissionPolicy
+	}{
+		{"Machine VAP", NewVSphereFailureDomainMachineVAP()},
+		{"CPMS VAP", NewVSphereFailureDomainCPMSVAP()},
+		{"MachineSet VAP", NewVSphereFailureDomainMachineSetVAP()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			mc := tt.policy.Spec.MatchConstraints
+			g.Expect(mc).NotTo(BeNil(), "MatchConstraints must not be nil")
+
+			g.Expect(mc.MatchPolicy).NotTo(BeNil(),
+				"MatchPolicy must be explicitly set to avoid spurious updates from API server defaulting")
+			g.Expect(*mc.MatchPolicy).To(Equal(expectedMatchPolicy))
+
+			g.Expect(mc.NamespaceSelector).To(Equal(expectedSelector),
+				"NamespaceSelector must be explicitly set to avoid spurious updates from API server defaulting")
+
+			g.Expect(mc.ObjectSelector).To(Equal(expectedSelector),
+				"ObjectSelector must be explicitly set to avoid spurious updates from API server defaulting")
+		})
+	}
+}
+
 // TestVAPNamesAreConsistent ensures the binding policy names match the policy names.
 func TestVAPNamesAreConsistent(t *testing.T) {
 	g := NewWithT(t)


### PR DESCRIPTION
[SPLAT-2854](https://redhat.atlassian.net/browse/SPLAT-2854)

### Changes
- Added additional controls to vSphere VAP to reduce unnecessary calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation policy behavior for vSphere failure-domain protections by applying equivalent resource matching.
  * Ensures validation rules consistently cover equivalent API resource versions during updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->