### PR TITLE
OCPBUGS-47508: Set --max-concurrent-reconciles=10 for AWS machine controller

### DIFF
--- a/pkg/operator/sync.go
+++ b/pkg/operator/sync.go
@@ -750,7 +750,7 @@ func newContainers(config *OperatorConfig, features map[string]bool, tlsArgs []s
 
 	machineControllerArgs := append([]string{}, featureGateArgs...)
 	switch config.PlatformType {
-	case configv1.AzurePlatformType, configv1.GCPPlatformType:
+	case configv1.AWSPlatformType, configv1.AzurePlatformType, configv1.GCPPlatformType:
 		machineControllerArgs = append(machineControllerArgs, "--max-concurrent-reconciles=10")
 	case configv1.BareMetalPlatformType:
 		machineControllerArgs = append(machineControllerArgs, tlsArgs...)

--- a/pkg/operator/sync_test.go
+++ b/pkg/operator/sync_test.go
@@ -800,6 +800,77 @@ func TestNewKubeProxyContainers(t *testing.T) {
 	}
 }
 
+func TestNewContainersMaxConcurrentReconciles(t *testing.T) {
+	const maxConcurrentReconcilesArg = "--max-concurrent-reconciles=10"
+
+	baseControllers := Controllers{
+		Provider:           "provider-image:latest",
+		MachineSet:         "machineset-image:latest",
+		NodeLink:           "nodelink-image:latest",
+		MachineHealthCheck: "mhc-image:latest",
+		KubeRBACProxy:      "kube-rbac-proxy-image:latest",
+	}
+
+	testCases := []struct {
+		name                          string
+		platformType                  configv1.PlatformType
+		expectMaxConcurrentReconciles bool
+	}{
+		{
+			name:                          "AWS enables max concurrent reconciles",
+			platformType:                  configv1.AWSPlatformType,
+			expectMaxConcurrentReconciles: true,
+		},
+		{
+			name:                          "Azure enables max concurrent reconciles",
+			platformType:                  configv1.AzurePlatformType,
+			expectMaxConcurrentReconciles: true,
+		},
+		{
+			name:                          "GCP enables max concurrent reconciles",
+			platformType:                  configv1.GCPPlatformType,
+			expectMaxConcurrentReconciles: true,
+		},
+		{
+			name:                          "BareMetal does not enable max concurrent reconciles",
+			platformType:                  configv1.BareMetalPlatformType,
+			expectMaxConcurrentReconciles: false,
+		},
+		{
+			name:                          "vSphere does not enable max concurrent reconciles",
+			platformType:                  configv1.VSpherePlatformType,
+			expectMaxConcurrentReconciles: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			config := &OperatorConfig{
+				TargetNamespace: targetNamespace,
+				PlatformType:    tc.platformType,
+				Controllers:     baseControllers,
+			}
+
+			var machineControllerArgs []string
+			for _, container := range newContainers(config, map[string]bool{}, nil) {
+				if container.Name == "machine-controller" {
+					machineControllerArgs = container.Args
+					break
+				}
+			}
+			g.Expect(machineControllerArgs).ToNot(BeEmpty(), "machine-controller container should exist")
+
+			if tc.expectMaxConcurrentReconciles {
+				g.Expect(machineControllerArgs).To(ContainElement(maxConcurrentReconcilesArg))
+			} else {
+				g.Expect(machineControllerArgs).ToNot(ContainElement(maxConcurrentReconcilesArg))
+			}
+		})
+	}
+}
+
 func TestNewPodTemplateSpecTLSArgs(t *testing.T) {
 	testCases := []struct {
 		name                                  string


### PR DESCRIPTION
Depends on https://github.com/openshift/machine-api-provider-aws/pull/195

/hold until above is merged

## Summary
Add `AWSPlatformType` to the existing platform switch that passes `--max-concurrent-reconciles=10` to the machine-controller (already used for Azure and GCP).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS deployments to apply the intended machine-controller concurrency argument, aligning AWS behavior with Azure and GCP.

* **Tests**
  * Added a new test that verifies the max-concurrent-reconciles argument is present for AWS/Azure/GCP and omitted for BareMetal and vSphere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->