### PR TITLE
OCPBUGS-115162: CORS-4521: GCP: Add regional permission

### DIFF
--- a/install/0000_30_machine-api-operator_00_credentials-request.yaml
+++ b/install/0000_30_machine-api-operator_00_credentials-request.yaml
@@ -202,6 +202,7 @@ spec:
     - "compute.regionBackendServices.get"
     - "compute.regionBackendServices.create"
     - "compute.regionBackendServices.update"
+    - "compute.regionHealthChecks.useReadOnly"
     - "compute.regions.get"
     - "compute.regions.list"
     - "compute.subnetworks.use"


### PR DESCRIPTION
Adds a permission necessary for deploying in Google Dedicated Cloud environments, which are regional--not global.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added the required read-only permission for accessing regional compute health checks during credential requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->