### PR TITLE
OCPBUGS-100067: Deduplicate unchanged status upgrade events

### DIFF
--- a/pkg/operator/status.go
+++ b/pkg/operator/status.go
@@ -70,7 +70,6 @@ func (optr *Operator) statusProgressing() error {
 	if !reflect.DeepEqual(desiredVersions, currentVersions) {
 		klog.V(2).Info("Syncing status: progressing")
 		message = fmt.Sprintf("Progressing towards %s", optr.printOperandVersions())
-		optr.eventRecorder.Eventf(co, v1.EventTypeNormal, "Status upgrade", "%s", message)
 		isProgressing = osconfigv1.ConditionTrue
 		reason = string(ReasonSyncing)
 	} else {
@@ -79,8 +78,18 @@ func (optr *Operator) statusProgressing() error {
 		isProgressing = osconfigv1.ConditionFalse
 	}
 
+	progressingCondition := newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, isProgressing, reason, message)
+	currentProgressingCondition := v1helpers.FindStatusCondition(co.Status.Conditions, osconfigv1.OperatorProgressing)
+	if isProgressing == osconfigv1.ConditionTrue &&
+		(currentProgressingCondition == nil ||
+			currentProgressingCondition.Status != progressingCondition.Status ||
+			currentProgressingCondition.Reason != progressingCondition.Reason ||
+			currentProgressingCondition.Message != progressingCondition.Message) {
+		optr.eventRecorder.Eventf(co, v1.EventTypeNormal, "Status upgrade", "%s", message)
+	}
+
 	conds := []osconfigv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(osconfigv1.OperatorProgressing, isProgressing, reason, message),
+		progressingCondition,
 		operatorUpgradeable,
 	}
 

--- a/pkg/operator/status_test.go
+++ b/pkg/operator/status_test.go
@@ -153,6 +153,49 @@ func TestOperatorStatusProgressing(t *testing.T) {
 	}
 }
 
+func TestOperatorStatusProgressingEvents(t *testing.T) {
+	eventRecorder := record.NewFakeRecorder(5)
+	assertEvent := func(expected string) {
+		t.Helper()
+		select {
+		case event := <-eventRecorder.Events:
+			assert.Equal(t, expected, event)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for event %q", expected)
+		}
+	}
+	optr := Operator{
+		eventRecorder: eventRecorder,
+		operandVersions: []osconfigv1.OperandVersion{
+			{Name: "operator", Version: "2.0"},
+		},
+	}
+	co := optr.defaultClusterOperator()
+	co.Status.Versions = []osconfigv1.OperandVersion{
+		{Name: "operator", Version: "1.0"},
+	}
+	optr.osClient = fakeconfigclientset.NewClientset(co)
+
+	assert.NoError(t, optr.statusProgressing())
+	assertEvent("Normal Status upgrade Progressing towards operator: 2.0")
+
+	assert.NoError(t, optr.statusProgressing())
+	select {
+	case event := <-eventRecorder.Events:
+		t.Fatalf("expected no event for an unchanged Progressing condition, got %q", event)
+	default:
+	}
+
+	optr.operandVersions[0].Version = "3.0"
+	assert.NoError(t, optr.statusProgressing())
+	assertEvent("Normal Status upgrade Progressing towards operator: 3.0")
+
+	assert.NoError(t, optr.statusAvailable(""))
+	optr.operandVersions[0].Version = "4.0"
+	assert.NoError(t, optr.statusProgressing())
+	assertEvent("Normal Status upgrade Progressing towards operator: 4.0")
+}
+
 func TestGetOrCreateClusterOperator(t *testing.T) {
 	var namespace = "some-namespace"
 


### PR DESCRIPTION
## What

- Emit `Status upgrade` only when the `Progressing` status, reason, or message changes.
- Continue syncing the `ClusterOperator` conditions on every reconciliation.
- Cover initial upgrade entry, an identical repeated sync, a changed target, and re-entry after becoming available.

## Why

During a slow SNO upgrade rollout, MAO reconciles approximately every five seconds and currently emits the same `Status upgrade` Kubernetes Event each time. Nine of ten jobs for `5.0.0-0.nightly-2026-07-28-003649` recorded the identical event 25 times and failed the pathological-event invariant, although the upgrades completed successfully.

The `ClusterOperator` condition is the durable representation of an ongoing upgrade. Repeated reconciliations of that unchanged condition should not create new occurrence Events.

Bug: https://issues.redhat.com/browse/OCPBUGS-100067

## Validation

- `go test ./pkg/operator`
- `make lint`
- `make test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced duplicate “Status upgrade” notifications when the operator’s progressing status has not changed.
  * Progress updates now generate notifications only when relevant status details change, making upgrade activity clearer.
  * Notifications continue to appear when the desired version changes or the operator transitions to a new progressing state.

* **Tests**
  * Added coverage to verify notification behavior across repeated updates and version changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->