### PR TITLE
OCPBUGS-100056: fix: skip Multisubnet test for single network infra

### DIFF
--- a/test/e2e/nutanix/multi-subnet.go
+++ b/test/e2e/nutanix/multi-subnet.go
@@ -298,6 +298,14 @@ var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:NutanixMultiSubnets][pl
 		machineNetworks = infra.Spec.PlatformSpec.Nutanix.FailureDomains
 		Expect(len(machineNetworks)).ShouldNot(Equal(0))
 
+		// The NutanixMultiSubnets feature gate is enabled by the TechPreviewNoUpgrade
+		// feature set regardless of whether the cluster is actually provisioned with
+		// multi-subnet infrastructure. When no failure domain defines more than one
+		// subnet there is nothing to validate, so skip rather than fail.
+		if !hasMultiSubnetConfiguration(machineNetworks) {
+			Skip("skipping multi-subnet tests - cluster does not have multi-subnet infrastructure configured")
+		}
+
 		nodes, err = c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		machines, err = mc.Machines("openshift-machine-api").List(ctx, metav1.ListOptions{})


### PR DESCRIPTION
Guard in the BeforeEach that reuses the existing hasMultiSubnetConfiguration() helper (which returns true only when some failure domain has more than one subnet). When no multi-subnet infrastructure is present, the suite now skips gracefully:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Multi-subnet conformance checks now skip automatically when the cluster does not use a multi-subnet configuration.
  * Prevents irrelevant validation steps from running in unsupported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->