### PR TITLE
CNF-26431: Allow ironic-networking JSON-RPC port in NetworkPolicy

### DIFF
--- a/install/0000_90_machine-api-operator_05_networkpolicy-allow-ingress-metal.yaml
+++ b/install/0000_90_machine-api-operator_05_networkpolicy-allow-ingress-metal.yaml
@@ -30,6 +30,8 @@ spec:
     - protocol: TCP
       port: 9608 # prometheus exporter for ironic
     - protocol: TCP
+      port: 6190 # ironic networking JSON-RPC
+    - protocol: TCP
       port: 9447 # bare metal webhook service
   podSelector: {}
   policyTypes:


### PR DESCRIPTION
Add port 6190 to the allow-ingress-metal NetworkPolicy to permit ingress traffic to the ironic-networking service's JSON-RPC endpoint. Without this, the default-deny policy blocks the ironic container from reaching the networking service when switch management is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled TCP access on port 6190 for the Ironic networking service through the metal network policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->