### PR TITLE
OCPBUGS-74510: Removed VSphereMultiDisk feature gate 

### DIFF
--- a/cmd/machineset/main.go
+++ b/cmd/machineset/main.go
@@ -137,7 +137,7 @@ func main() {
 
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, majorVersion, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
+	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, majorVersion, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal)
 	if err != nil {
 		klog.Fatalf("Error setting up feature gates: %v", err)
 	}

--- a/cmd/vsphere/main.go
+++ b/cmd/vsphere/main.go
@@ -107,7 +107,7 @@ func main() {
 
 	// Sets up feature gates
 	defaultMutableGate := feature.DefaultMutableFeatureGate
-	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, majorVersion, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal, apifeatures.FeatureGateVSphereMultiDisk)
+	gateOpts, err := features.NewFeatureGateOptions(defaultMutableGate, majorVersion, apifeatures.SelfManaged, apifeatures.FeatureGateMachineAPIMigration, apifeatures.FeatureGateVSphereHostVMGroupZonal)
 	if err != nil {
 		klog.Fatalf("Error setting up feature gates: %v", err)
 	}
@@ -167,9 +167,6 @@ func main() {
 
 	hostVMGroupZonalFeatureGateEnabled := defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereHostVMGroupZonal))
 	klog.Infof("FeatureGateVSphereHostVMGroupZonal initialised %t", hostVMGroupZonalFeatureGateEnabled)
-	multiDiskFeatureGateEnabled := defaultMutableGate.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereMultiDisk))
-	klog.Infof("FeatureGateVSphereMultiDisk initialised: %t", multiDiskFeatureGateEnabled)
-
 	// Setup a Manager
 	mgr, err := manager.New(cfg, opts)
 	if err != nil {

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -1203,12 +1203,6 @@ func getDiskSpec(s *machineScope, devices object.VirtualDeviceList) (types.BaseV
 func createDataDisks(s *machineScope, devices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
 	var diskSpecs []types.BaseVirtualDeviceConfigSpec
 
-	// Only add additional disks if the feature gate is enabled.
-	if len(s.providerSpec.DataDisks) > 0 && !s.featureGates.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereMultiDisk)) {
-		return nil, machinecontroller.InvalidMachineConfiguration(
-			"machines cannot contain additional disks due to VSphereMultiDisk feature gate being disabled")
-	}
-
 	// Get primary disk
 	disks := devices.SelectByType((*types.VirtualDisk)(nil))
 	if len(disks) == 0 {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -478,7 +478,6 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 		string(apifeatures.FeatureGateAWSDedicatedHosts):       featureGates.Enabled(apifeatures.FeatureGateAWSDedicatedHosts),
 		string(apifeatures.FeatureGateMachineAPIMigration):     featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
 		string(apifeatures.FeatureGateAzureWorkloadIdentity):   featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
-		string(apifeatures.FeatureGateVSphereMultiDisk):        featureGates.Enabled(apifeatures.FeatureGateVSphereMultiDisk),
 		string(apifeatures.FeatureGateVSphereHostVMGroupZonal): featureGates.Enabled(apifeatures.FeatureGateVSphereHostVMGroupZonal),
 	}
 	if features[string(apifeatures.FeatureGateMachineAPIMigration)] {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -43,7 +43,6 @@ var (
 	enabledFeatureGates = []openshiftv1.FeatureGateAttributes{
 		{Name: apifeatures.FeatureGateMachineAPIMigration},
 		{Name: apifeatures.FeatureGateAzureWorkloadIdentity},
-		{Name: apifeatures.FeatureGateVSphereMultiDisk},
 		{Name: apifeatures.FeatureGateVSphereHostVMGroupZonal},
 		{Name: apifeatures.FeatureGateAWSDedicatedHosts},
 	}
@@ -56,7 +55,6 @@ var (
 	enabledFeatureMap = map[string]bool{
 		"MachineAPIMigration":     true,
 		"AzureWorkloadIdentity":   true,
-		"VSphereMultiDisk":        true,
 		"VSphereHostVMGroupZonal": true,
 		"AWSDedicatedHosts":       true,
 	}

--- a/pkg/util/testing/testing.go
+++ b/pkg/util/testing/testing.go
@@ -172,15 +172,13 @@ func NewDefaultMutableFeatureGate() (featuregate.MutableFeatureGate, error) {
 	_, err := features.NewFeatureGateOptions(defaultMutableGate, version.Version.Major,
 		openshiftfeatures.SelfManaged,
 		openshiftfeatures.FeatureGateMachineAPIMigration,
-		openshiftfeatures.FeatureGateVSphereHostVMGroupZonal,
-		openshiftfeatures.FeatureGateVSphereMultiDisk)
+		openshiftfeatures.FeatureGateVSphereHostVMGroupZonal)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up default feature gate: %w", err)
 	}
 	if err := defaultMutableGate.SetFromMap(
 		map[string]bool{
 			"MachineAPIMigration": true,
-			"VSphereMultiDisk":    true,
 		},
 	); err != nil {
 		return nil, fmt.Errorf("failed to set features from map: %w", err)

--- a/pkg/webhooks/machine_webhook.go
+++ b/pkg/webhooks/machine_webhook.go
@@ -1763,11 +1763,7 @@ func validateVSphere(m *machinev1beta1.Machine, config *admissionConfig) (bool, 
 	}
 
 	if len(providerSpec.DataDisks) > 0 {
-		if !config.featureGates.Enabled(featuregate.Feature(apifeatures.FeatureGateVSphereMultiDisk)) {
-			errs = append(errs, field.Forbidden(field.NewPath("providerSpec", "disks"), "this field is protected by the VSphereMultiDisk feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set"))
-		} else {
-			errs = append(errs, validateVSphereDataDisks(providerSpec.DataDisks)...)
-		}
+		errs = append(errs, validateVSphereDataDisks(providerSpec.DataDisks)...)
 	}
 
 	if len(errs) > 0 {

--- a/pkg/webhooks/machine_webhook_test.go
+++ b/pkg/webhooks/machine_webhook_test.go
@@ -5553,25 +5553,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 			}(),
 		},
 		{
-			testCase: "with data disk configured without feature gate enabled",
-			modifySpec: func(p *machinev1beta1.VSphereMachineProviderSpec) {
-				p.DataDisks = []machinev1beta1.VSphereDisk{
-					{
-						Name:    "Disk1",
-						SizeGiB: 10,
-					},
-				}
-			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = false
-				return fg
-			}(),
-			expectedError: "providerSpec.disks: Forbidden: this field is protected by the VSphereMultiDisk feature gate which must be enabled through either the TechPreviewNoUpgrade or CustomNoUpgrade feature set",
-		},
-		{
-			testCase: "with data disk configured with feature gate enabled",
+			testCase: "with data disk configured",
 			modifySpec: func(p *machinev1beta1.VSphereMachineProviderSpec) {
 				p.DataDisks = []machinev1beta1.VSphereDisk{
 					{
@@ -5581,11 +5563,6 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk: true,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
 		},
 		{
 			testCase: "with data disk configured with max size",
@@ -5598,11 +5575,6 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk: true,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
 		},
 		{
 			testCase: "with data disk configured with size above max",
@@ -5614,12 +5586,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
+			expectedOk:    false,
 			expectedError: "providerSpec.disks[0].sizeGiB: Invalid value: 17000: data disk size (GiB) must not exceed 16384",
 		},
 		{
@@ -5631,12 +5598,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
+			expectedOk:    false,
 			expectedError: "providerSpec.disks[0].sizeGiB: Required value: data disk size must be set",
 		},
 		{
@@ -5648,12 +5610,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
+			expectedOk:    false,
 			expectedError: "providerSpec.disks[0].name: Required value: data disk name must be set",
 		},
 		{
@@ -5666,12 +5623,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
+			expectedOk:    false,
 			expectedError: "providerSpec.disks[0].name: Invalid value: \"Bad #Name\": data disk name must consist only of alphanumeric characters, hyphens and underscores, and must start and end with an alphanumeric character.",
 		},
 		{
@@ -5686,11 +5638,6 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 				}
 			},
 			expectedOk: true,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
 		},
 		{
 			testCase: "with data disk configured with invalid provisioning mode",
@@ -5703,12 +5650,7 @@ func TestValidateVSphereProviderSpec(t *testing.T) {
 					},
 				}
 			},
-			expectedOk: false,
-			featureGatesEnabled: func() map[string]bool {
-				fg := make(map[string]bool)
-				fg[string(features.FeatureGateVSphereMultiDisk)] = true
-				return fg
-			}(),
+			expectedOk:    false,
 			expectedError: "providerSpec.disks[0]: Unsupported value: \"Fat\": supported values: \"EagerlyZeroed\", \"Thick\", \"Thin\"",
 		},
 	}

--- a/test/e2e/vsphere/machines.go
+++ b/test/e2e/vsphere/machines.go
@@ -24,7 +24,7 @@ const (
 	machineReadyTimeout = time.Minute * 6
 )
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiDisk][platform:vsphere][Disruptive] Managed cluster should", Label("Conformance"), Label("Serial"), func() {
+var _ = Describe("[sig-cluster-lifecycle][platform:vsphere][Disruptive] Managed cluster should", Label("Conformance"), Label("Serial"), func() {
 	defer GinkgoRecover()
 	ctx := context.Background()
 


### PR DESCRIPTION
OCPBUGS-74510

### Changes
- Removed usages of VSphereMultiDisk feature gate
- Updated tests to assume GA of feature gate

### Notes
Removed VSphereMultiDisk feature gate now that it has been GA for several releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - vSphere machines now support multiple data disks by default, without requiring a separate feature toggle.
  - Data disk validation is consistently applied, including size, naming, and provisioning constraints.

- **Bug Fixes**
  - Removed the previous configuration restriction that blocked additional disks when the feature toggle was disabled.
  - Updated validation and end-to-end coverage to reflect the default multi-disk behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->