### PR TITLE
OCPBUGS-105407: Remove VSphereMultiNetworks feature gate from e2e test

### DIFF
--- a/test/e2e/vsphere/multi-nic.go
+++ b/test/e2e/vsphere/multi-nic.go
@@ -149,7 +149,7 @@ func failIfMachineDoesNotHaveAllPortgroups(machine machinev1beta1.Machine, failu
 	Expect(slices.Equal(expectedPortgroups, portgroups)).To(BeTrue())
 }
 
-var _ = Describe("[sig-cluster-lifecycle][OCPFeatureGate:VSphereMultiNetworks][platform:vsphere] Managed cluster should", Label("Conformance"), func() {
+var _ = Describe("[sig-cluster-lifecycle][platform:vsphere] Managed cluster should", Label("Conformance"), func() {
 	defer GinkgoRecover()
 	ctx := context.Background()
 


### PR DESCRIPTION
OCPBUGS-105407

### Changes
- Removed VSphereMultiNetworks feature gate from e2e test

### Notes
The VSphereMultiNetworks feature has been GA for several releases. Remove the OCPFeatureGate tag so the multi-NIC e2e test runs unconditionally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the vSphere multi-network end-to-end test classification to use the standard managed-cluster description.
  * Existing vSphere platform and conformance coverage remains unchanged.
  * No user-facing functionality or product behavior changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->