### PR TITLE
OCPBUGS-105398: refactor: remove AzureWorkloadIdentity feature gate

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -477,7 +477,6 @@ func (optr *Operator) maoConfigFromInfrastructure() (*OperatorConfig, error) {
 	features := map[string]bool{
 		string(apifeatures.FeatureGateAWSDedicatedHosts):       featureGates.Enabled(apifeatures.FeatureGateAWSDedicatedHosts),
 		string(apifeatures.FeatureGateMachineAPIMigration):     featureGates.Enabled(apifeatures.FeatureGateMachineAPIMigration),
-		string(apifeatures.FeatureGateAzureWorkloadIdentity):   featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity),
 		string(apifeatures.FeatureGateVSphereHostVMGroupZonal): featureGates.Enabled(apifeatures.FeatureGateVSphereHostVMGroupZonal),
 	}
 	if features[string(apifeatures.FeatureGateMachineAPIMigration)] {

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -42,7 +42,6 @@ const (
 var (
 	enabledFeatureGates = []openshiftv1.FeatureGateAttributes{
 		{Name: apifeatures.FeatureGateMachineAPIMigration},
-		{Name: apifeatures.FeatureGateAzureWorkloadIdentity},
 		{Name: apifeatures.FeatureGateVSphereHostVMGroupZonal},
 		{Name: apifeatures.FeatureGateAWSDedicatedHosts},
 	}
@@ -54,7 +53,6 @@ var (
 
 	enabledFeatureMap = map[string]bool{
 		"MachineAPIMigration":     true,
-		"AzureWorkloadIdentity":   true,
 		"VSphereHostVMGroupZonal": true,
 		"AWSDedicatedHosts":       true,
 	}


### PR DESCRIPTION
## Summary
- Remove the `AzureWorkloadIdentity` map entry from the featuregates passed to the machine controllers in `pkg/operator/operator.go` — the gate is GA and enabled by default upstream (openshift/api), so this was always evaluating to `true`
- Update test fixtures accordingly

## Why
Once `AzureWorkloadIdentity` is deregistered from `openshift/api` (openshift/api#3018), the unconditional `featureGates.Enabled(apifeatures.FeatureGateAzureWorkloadIdentity)` call here panics, because library-go's `FeatureGate.Enabled()` panics when asked about a name that isn't part of the FeatureGate CR's known set. That panic crashes machine-api-operator, which cascades into control-plane machines never becoming ready (verified in a failing e2e-aws-ovn run on openshift/api#3018 — CI logs showed `machine-api-operator` panicking with `feature "AzureWorkloadIdentity" is not registered in FeatureGates [...]`).

Companion PR: openshift/machine-api-provider-azure#207 (already open, removes the same gate's plumbing from the Azure actuators).

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./pkg/operator/...` passes
- [x] No remaining references to `AzureWorkloadIdentity` outside vendor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the Azure Workload Identity feature gate from provider controller and MachineSet configuration.
  * Updated operator test configuration to reflect the feature gate’s removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->